### PR TITLE
fix: add warnings

### DIFF
--- a/packages/runtime-core/__tests__/apiOptions.spec.ts
+++ b/packages/runtime-core/__tests__/apiOptions.spec.ts
@@ -8,7 +8,8 @@ import {
   nextTick,
   renderToString,
   ref,
-  createComponent
+  createComponent,
+  mockWarn
 } from '@vue/runtime-test'
 
 describe('api: options', () => {
@@ -504,5 +505,38 @@ describe('api: options', () => {
     triggerEvent(root.children[0] as TestElement, 'click')
     await nextTick()
     expect(serializeInner(root)).toBe(`<div>1,1,3</div>`)
+  })
+
+  describe('warnings', () => {
+    mockWarn()
+
+    test('Expected a function as watch handler', () => {
+      const Comp = {
+        watch: {
+          foo: 'notExistingMethod'
+        },
+        render() {}
+      }
+
+      const root = nodeOps.createElement('div')
+      render(h(Comp), root)
+
+      expect(
+        'Expected a function as watch handler "notExistingMethod"'
+      ).toHaveBeenWarned()
+    })
+
+    test('Invalid watch options', () => {
+      const Comp = {
+        watch: { foo: true },
+        render() {}
+      }
+
+      const root = nodeOps.createElement('div')
+      // @ts-ignore
+      render(h(Comp), root)
+
+      expect('Invalid watch options "foo"').toHaveBeenWarned()
+    })
   })
 })

--- a/packages/runtime-core/__tests__/apiOptions.spec.ts
+++ b/packages/runtime-core/__tests__/apiOptions.spec.ts
@@ -522,11 +522,11 @@ describe('api: options', () => {
       render(h(Comp), root)
 
       expect(
-        'Expected a function as watch handler "notExistingMethod"'
+        'Invalid watch handler specified by key "notExistingMethod"'
       ).toHaveBeenWarned()
     })
 
-    test('Invalid watch options', () => {
+    test('Invalid watch option', () => {
       const Comp = {
         watch: { foo: true },
         render() {}
@@ -536,7 +536,7 @@ describe('api: options', () => {
       // @ts-ignore
       render(h(Comp), root)
 
-      expect('Invalid watch options "foo"').toHaveBeenWarned()
+      expect('Invalid watch option: "foo"').toHaveBeenWarned()
     })
   })
 })

--- a/packages/runtime-core/__tests__/componentProxy.spec.ts
+++ b/packages/runtime-core/__tests__/componentProxy.spec.ts
@@ -1,4 +1,4 @@
-import { mockWarn } from '@vue/runtime-test'
+import { createApp, nodeOps, mockWarn } from '@vue/runtime-test'
 
 describe('component proxy', () => {
   /**
@@ -12,25 +12,38 @@ describe('component proxy', () => {
    */
   describe('warnings', () => {
     mockWarn()
+    let app: any, appProps: any
+
+    beforeEach(() => {
+      const component = {
+        render() {}
+      }
+      const root = nodeOps.createElement('div')
+      app = createApp().mount(component, root, appProps)
+    })
 
     test('Attempting to mutate public property', () => {
-      console.warn(
-        'Attempting to mutate public property "$foo".' +
-          'Properties starting with $ are reserved and readonly.'
-      )
-
-      expect(
-        'Attempting to mutate public property "$foo".' +
-          'Properties starting with $ are reserved and readonly.'
-      ).toHaveBeenWarned()
+      try {
+        // @ts-ignore
+        app.$props = null
+      } catch {
+        expect(
+          'Attempting to mutate public property "$props". ' +
+            'Properties starting with $ are reserved and readonly.'
+        ).toHaveBeenWarned()
+      }
     })
 
     test('Attempting to mutate prop', () => {
-      console.warn(`Attempting to mutate prop "foo". Props are readonly.`)
-
-      expect(
-        'Attempting to mutate prop "foo". Props are readonly.'
-      ).toHaveBeenWarned()
+      appProps = { foo: 'foo' }
+      try {
+        // @ts-ignore
+        app.foo = null
+      } catch {
+        expect(
+          'Attempting to mutate prop "foo". Props are readonly.'
+        ).toHaveBeenWarned()
+      }
     })
   })
 })

--- a/packages/runtime-core/__tests__/componentProxy.spec.ts
+++ b/packages/runtime-core/__tests__/componentProxy.spec.ts
@@ -1,30 +1,34 @@
 import { mockWarn } from '@vue/runtime-test'
 
 describe('component proxy', () => {
-  /**
-   * These tests should tests the warnings for PublicInstanceProxyHandlers in componentProxy
-   * {@link @vue/runtime-core/src/componentProxy}
-   *
-   * The function setupStatefulComponent is the location where PublicInstanceProxyHandlers is being used.
-   * {@link @vue/runtime-core/src/createRenderer}
-   *
-   * Currently I haven't found a way to create a component that uses PublicInstanceProxyHandlers
-   */
-  describe('warnings', () => {
-    mockWarn()
+    /**
+     * These tests should tests the warnings for PublicInstanceProxyHandlers in componentProxy
+     * {@link @vue/runtime-core/src/componentProxy}
+     *
+     * The function setupStatefulComponent is the location where PublicInstanceProxyHandlers is being used.
+     * {@link @vue/runtime-core/src/createRenderer}
+     *
+     * Currently I haven't found a way to create a component that uses PublicInstanceProxyHandlers
+     */
+    describe('warnings', () => {
+        mockWarn()
 
-    test('Attempting to mutate public property', () => {
-      console.warn('Attempting to mutate public property "$foo" to "foo"')
+        test('Attempting to mutate public property', () => {
+            console.warn(
+                'Attempting to mutate public property "$foo".' +
+                'Properties starting with $ are reserved and readonly.'
+            )
 
-      expect(
-        'Attempting to mutate public property "$foo" to "foo"'
-      ).toHaveBeenWarned()
+            expect(
+                'Attempting to mutate public property "$foo".' +
+                'Properties starting with $ are reserved and readonly.'
+            ).toHaveBeenWarned()
+        })
+
+        test('Attempting to mutate prop', () => {
+            console.warn('Attempting to mutate prop "$foo" to "foo"')
+
+            expect('Attempting to mutate prop "$foo" to "foo"').toHaveBeenWarned()
+        })
     })
-
-    test('Attempting to mutate prop', () => {
-      console.warn('Attempting to mutate prop "$foo" to "foo"')
-
-      expect('Attempting to mutate prop "$foo" to "foo"').toHaveBeenWarned()
-    })
-  })
 })

--- a/packages/runtime-core/__tests__/componentProxy.spec.ts
+++ b/packages/runtime-core/__tests__/componentProxy.spec.ts
@@ -1,31 +1,22 @@
 import { createApp, nodeOps, mockWarn } from '@vue/runtime-test'
 
+const createTestInstance = (props?: any) => {
+  const component = {
+    render() {}
+  }
+  const root = nodeOps.createElement('div')
+  return createApp().mount(component, root, props)
+}
+
 describe('component proxy', () => {
-  /**
-   * These tests should tests the warnings for PublicInstanceProxyHandlers in componentProxy
-   * {@link @vue/runtime-core/src/componentProxy}
-   *
-   * The function setupStatefulComponent is the location where PublicInstanceProxyHandlers is being used.
-   * {@link @vue/runtime-core/src/createRenderer}
-   *
-   * Currently I haven't found a way to create a component that uses PublicInstanceProxyHandlers
-   */
   describe('warnings', () => {
     mockWarn()
-    let app: any, appProps: any
-
-    beforeEach(() => {
-      const component = {
-        render() {}
-      }
-      const root = nodeOps.createElement('div')
-      app = createApp().mount(component, root, appProps)
-    })
 
     test('Attempting to mutate public property', () => {
+      const app = createTestInstance()
+
       try {
-        // @ts-ignore
-        app.$props = null
+        app.$props = { foo: 'bar' }
       } catch {
         expect(
           'Attempting to mutate public property "$props". ' +
@@ -35,10 +26,10 @@ describe('component proxy', () => {
     })
 
     test('Attempting to mutate prop', () => {
-      appProps = { foo: 'foo' }
+      const app = createTestInstance({ foo: 'foo' })
+
       try {
-        // @ts-ignore
-        app.foo = null
+        app.foo = 'bar'
       } catch {
         expect(
           'Attempting to mutate prop "foo". Props are readonly.'

--- a/packages/runtime-core/__tests__/componentProxy.spec.ts
+++ b/packages/runtime-core/__tests__/componentProxy.spec.ts
@@ -1,0 +1,30 @@
+import { mockWarn } from '@vue/runtime-test'
+
+describe('component proxy', () => {
+  /**
+   * These tests should tests the warnings for PublicInstanceProxyHandlers in componentProxy
+   * {@link @vue/runtime-core/src/componentProxy}
+   *
+   * The function setupStatefulComponent is the location where PublicInstanceProxyHandlers is being used.
+   * {@link @vue/runtime-core/src/createRenderer}
+   *
+   * Currently I haven't found a way to create a component that uses PublicInstanceProxyHandlers
+   */
+  describe('warnings', () => {
+    mockWarn()
+
+    test('Attempting to mutate public property', () => {
+      console.warn('Attempting to mutate public property "$foo" to "foo"')
+
+      expect(
+        'Attempting to mutate public property "$foo" to "foo"'
+      ).toHaveBeenWarned()
+    })
+
+    test('Attempting to mutate prop', () => {
+      console.warn('Attempting to mutate prop "$foo" to "foo"')
+
+      expect('Attempting to mutate prop "$foo" to "foo"').toHaveBeenWarned()
+    })
+  })
+})

--- a/packages/runtime-core/__tests__/componentProxy.spec.ts
+++ b/packages/runtime-core/__tests__/componentProxy.spec.ts
@@ -1,34 +1,36 @@
 import { mockWarn } from '@vue/runtime-test'
 
 describe('component proxy', () => {
-    /**
-     * These tests should tests the warnings for PublicInstanceProxyHandlers in componentProxy
-     * {@link @vue/runtime-core/src/componentProxy}
-     *
-     * The function setupStatefulComponent is the location where PublicInstanceProxyHandlers is being used.
-     * {@link @vue/runtime-core/src/createRenderer}
-     *
-     * Currently I haven't found a way to create a component that uses PublicInstanceProxyHandlers
-     */
-    describe('warnings', () => {
-        mockWarn()
+  /**
+   * These tests should tests the warnings for PublicInstanceProxyHandlers in componentProxy
+   * {@link @vue/runtime-core/src/componentProxy}
+   *
+   * The function setupStatefulComponent is the location where PublicInstanceProxyHandlers is being used.
+   * {@link @vue/runtime-core/src/createRenderer}
+   *
+   * Currently I haven't found a way to create a component that uses PublicInstanceProxyHandlers
+   */
+  describe('warnings', () => {
+    mockWarn()
 
-        test('Attempting to mutate public property', () => {
-            console.warn(
-                'Attempting to mutate public property "$foo".' +
-                'Properties starting with $ are reserved and readonly.'
-            )
+    test('Attempting to mutate public property', () => {
+      console.warn(
+        'Attempting to mutate public property "$foo".' +
+          'Properties starting with $ are reserved and readonly.'
+      )
 
-            expect(
-                'Attempting to mutate public property "$foo".' +
-                'Properties starting with $ are reserved and readonly.'
-            ).toHaveBeenWarned()
-        })
-
-        test('Attempting to mutate prop', () => {
-            console.warn('Attempting to mutate prop "$foo" to "foo"')
-
-            expect('Attempting to mutate prop "$foo" to "foo"').toHaveBeenWarned()
-        })
+      expect(
+        'Attempting to mutate public property "$foo".' +
+          'Properties starting with $ are reserved and readonly.'
+      ).toHaveBeenWarned()
     })
+
+    test('Attempting to mutate prop', () => {
+      console.warn(`Attempting to mutate prop "foo". Props are readonly.`)
+
+      expect(
+        'Attempting to mutate prop "foo". Props are readonly.'
+      ).toHaveBeenWarned()
+    })
+  })
 })

--- a/packages/runtime-core/src/apiOptions.ts
+++ b/packages/runtime-core/src/apiOptions.ts
@@ -267,7 +267,7 @@ export function applyOptions(
         if (isFunction(handler)) {
           watch(getter, handler as any)
         } else if (__DEV__) {
-          warn('invalid watch handler path')
+          warn(`Expected a function as watch handler "${raw}"`)
         }
       } else if (isFunction(raw)) {
         watch(getter, raw.bind(ctx))
@@ -275,7 +275,7 @@ export function applyOptions(
         // TODO 2.x compat
         watch(getter, raw.handler.bind(ctx), raw)
       } else if (__DEV__) {
-        warn('attempting to mutate readonly computed value')
+        warn(`Attempting to mutate readonly computed value "${key}"`)
       }
     }
   }

--- a/packages/runtime-core/src/apiOptions.ts
+++ b/packages/runtime-core/src/apiOptions.ts
@@ -267,7 +267,7 @@ export function applyOptions(
         if (isFunction(handler)) {
           watch(getter, handler as any)
         } else if (__DEV__) {
-          warn(`Expected a function as watch handler "${raw}"`)
+          warn(`Invalid watch handler specified by key "${raw}"`, handler)
         }
       } else if (isFunction(raw)) {
         watch(getter, raw.bind(ctx))
@@ -275,7 +275,7 @@ export function applyOptions(
         // TODO 2.x compat
         watch(getter, raw.handler.bind(ctx), raw)
       } else if (__DEV__) {
-        warn(`Invalid watch options "${key}"`)
+        warn(`Invalid watch option: "${key}"`)
       }
     }
   }

--- a/packages/runtime-core/src/apiOptions.ts
+++ b/packages/runtime-core/src/apiOptions.ts
@@ -267,7 +267,7 @@ export function applyOptions(
         if (isFunction(handler)) {
           watch(getter, handler as any)
         } else if (__DEV__) {
-          // TODO warn invalid watch handler path
+          warn('invalid watch handler path')
         }
       } else if (isFunction(raw)) {
         watch(getter, raw.bind(ctx))
@@ -275,7 +275,7 @@ export function applyOptions(
         // TODO 2.x compat
         watch(getter, raw.handler.bind(ctx), raw)
       } else if (__DEV__) {
-        // TODO warn invalid watch options
+        warn('attempting to mutate readonly computed value')
       }
     }
   }

--- a/packages/runtime-core/src/apiOptions.ts
+++ b/packages/runtime-core/src/apiOptions.ts
@@ -275,7 +275,7 @@ export function applyOptions(
         // TODO 2.x compat
         watch(getter, raw.handler.bind(ctx), raw)
       } else if (__DEV__) {
-        warn(`Attempting to mutate readonly computed value "${key}"`)
+        warn(`Invalid watch options "${key}"`)
       }
     }
   }

--- a/packages/runtime-core/src/componentProxy.ts
+++ b/packages/runtime-core/src/componentProxy.ts
@@ -93,7 +93,8 @@ export const PublicInstanceProxyHandlers = {
     } else if (key[0] === '$' && key.slice(1) in target) {
       __DEV__ &&
         warn(
-          `Attempting to mutate public property "${key}" to "${value}"`,
+          `Attempting to mutate public property "${key}".` +
+          `Properties starting with $ are reserved and readonly.`,
           target
         )
       return false

--- a/packages/runtime-core/src/componentProxy.ts
+++ b/packages/runtime-core/src/componentProxy.ts
@@ -91,10 +91,15 @@ export const PublicInstanceProxyHandlers = {
     } else if (hasOwn(renderContext, key)) {
       renderContext[key] = value
     } else if (key[0] === '$' && key.slice(1) in target) {
-      __DEV__ && warn('attempt of mutating public property')
+      __DEV__ &&
+        warn(
+          `Attempting to mutate public property "${key}" to "${value}"`,
+          target
+        )
       return false
     } else if (key in target.props) {
-      __DEV__ && warn('attempt of mutating prop')
+      __DEV__ &&
+        warn(`Attempting to mutate prop "${key}" to "${value}"`, target)
       return false
     } else {
       target.user[key] = value

--- a/packages/runtime-core/src/componentProxy.ts
+++ b/packages/runtime-core/src/componentProxy.ts
@@ -100,7 +100,7 @@ export const PublicInstanceProxyHandlers = {
       return false
     } else if (key in target.props) {
       __DEV__ &&
-        warn(`Attempting to mutate prop "${key}" to "${value}"`, target)
+        warn(`Attempting to mutate prop "${key}". Props are readonly.`, target)
       return false
     } else {
       target.user[key] = value

--- a/packages/runtime-core/src/componentProxy.ts
+++ b/packages/runtime-core/src/componentProxy.ts
@@ -94,7 +94,7 @@ export const PublicInstanceProxyHandlers = {
       __DEV__ &&
         warn(
           `Attempting to mutate public property "${key}".` +
-          `Properties starting with $ are reserved and readonly.`,
+            `Properties starting with $ are reserved and readonly.`,
           target
         )
       return false

--- a/packages/runtime-core/src/componentProxy.ts
+++ b/packages/runtime-core/src/componentProxy.ts
@@ -16,6 +16,7 @@ export type ComponentPublicInstance<
   M = {},
   PublicProps = P
 > = {
+  [key: string]: any
   $data: D
   $props: PublicProps
   $attrs: Data
@@ -93,7 +94,7 @@ export const PublicInstanceProxyHandlers = {
     } else if (key[0] === '$' && key.slice(1) in target) {
       __DEV__ &&
         warn(
-          `Attempting to mutate public property "${key}".` +
+          `Attempting to mutate public property "${key}". ` +
             `Properties starting with $ are reserved and readonly.`,
           target
         )

--- a/packages/runtime-core/src/componentProxy.ts
+++ b/packages/runtime-core/src/componentProxy.ts
@@ -4,6 +4,7 @@ import { instanceWatch } from './apiWatch'
 import { EMPTY_OBJ, hasOwn, globalsWhitelist } from '@vue/shared'
 import { ExtractComputedReturns } from './apiOptions'
 import { UnwrapRef } from '@vue/reactivity'
+import { warn } from './warning'
 
 // public properties exposed on the proxy, which is used as the render context
 // in templates (as `this` in the render option)
@@ -90,10 +91,10 @@ export const PublicInstanceProxyHandlers = {
     } else if (hasOwn(renderContext, key)) {
       renderContext[key] = value
     } else if (key[0] === '$' && key.slice(1) in target) {
-      // TODO warn attempt of mutating public property
+      __DEV__ && warn('attempt of mutating public property')
       return false
     } else if (key in target.props) {
-      // TODO warn attempt of mutating prop
+      __DEV__ && warn('attempt of mutating prop')
       return false
     } else {
       target.user[key] = value


### PR DESCRIPTION
Added warnings which were marked as TODO (except #81)

- invalid watch handler path
- attempting to mutate readonly computed value
- attempt of mutating public property
- attempt of mutating prop