### PR TITLE
test: Add tests for interactions between portals and async components

### DIFF
--- a/packages/runtime-core/__tests__/rendererPortal.spec.ts
+++ b/packages/runtime-core/__tests__/rendererPortal.spec.ts
@@ -1,3 +1,67 @@
+import {
+  mockWarn,
+  h,
+  Portal,
+  render,
+  nodeOps,
+  serializeInner,
+  nextTick,
+  ref
+} from '@vue/runtime-test'
+
 describe('renderer: portal', () => {
-  test.todo('should work')
+  mockWarn()
+
+  test('portals require a target', async () => {
+    const Parent = () => h(Portal, [h(Child)])
+
+    const Child = () => h('div', 'child')
+
+    const Comp = () => [h(Parent), h('div', { id: 'target' })]
+
+    const root = nodeOps.createElement('div')
+    render(h(Comp), root)
+
+    expect('Invalid Portal target on mount:').toHaveBeenWarned()
+  })
+
+  test('portals can render to host nodes', async () => {
+    const portalRoot = nodeOps.createElement('div')
+
+    const PortalContent = () => h('div', 'portal content')
+    const Comp = () => h(Portal, { target: portalRoot }, [h(PortalContent)])
+
+    const root = nodeOps.createElement('div')
+    render(h(Comp), root)
+
+    await nextTick()
+
+    expect(serializeInner(root)).toBe(`<!--[object Object]-->`)
+    expect(serializeInner(portalRoot)).toBe(`<div>portal content</div>`)
+  })
+
+  test('portals require a valid, in DOM target after updates', async () => {
+    const portalRoot = nodeOps.createElement('div')
+
+    const PortalContent = () => h('div', 'portal content')
+
+    const useValidTarget = ref(true)
+    const Comp = () =>
+      h(Portal, { target: useValidTarget.value ? portalRoot : null }, [
+        h(PortalContent)
+      ])
+
+    const root = nodeOps.createElement('div')
+    render(h(Comp), root)
+
+    await nextTick()
+
+    expect(serializeInner(root)).toBe(`<!--[object Object]-->`)
+    expect(serializeInner(portalRoot)).toBe(`<div>portal content</div>`)
+
+    useValidTarget.value = false
+
+    await nextTick()
+    expect('Invalid Portal target on update:').toHaveBeenWarned()
+  })
 })

--- a/packages/runtime-core/src/createRenderer.ts
+++ b/packages/runtime-core/src/createRenderer.ts
@@ -705,7 +705,7 @@ export function createRenderer<
       if (targetSelector !== (n1.props && n1.props.target)) {
         const nextTarget = (n2.target = isString(targetSelector)
           ? hostQuerySelector(targetSelector)
-          : null)
+          : targetSelector)
         if (nextTarget != null) {
           // move content
           if (shapeFlag & ShapeFlags.TEXT_CHILDREN) {

--- a/packages/runtime-dom/__tests__/portal.spec.ts
+++ b/packages/runtime-dom/__tests__/portal.spec.ts
@@ -1,0 +1,71 @@
+import { mockWarn } from '@vue/runtime-test'
+import { h, Portal, render, ref, nextTick } from '@vue/runtime-dom'
+
+describe('renderer: portal', () => {
+  mockWarn()
+
+  test('portals warn when their selector does not exist', async () => {
+    document.documentElement.innerHTML = `<div><div id="app"></div><div id="target"></div></div>`
+
+    const PortalContent = () => h('div', 'portal content')
+    const Comp = () => [
+      h(Portal, { target: '#idonotexist' }, [h(PortalContent)])
+    ]
+
+    const appDiv = document.querySelector('#app')!
+    const targetDiv = document.querySelector('#target')!
+
+    render(h(Comp), appDiv)
+
+    expect(appDiv.innerHTML).toBe(`<!----><!--[object Object]--><!---->`)
+    expect(targetDiv.innerHTML).toBe(``)
+
+    expect('Invalid Portal target on mount:').toHaveBeenWarned()
+  })
+
+  test('portals can render to an element by its selector', async () => {
+    document.documentElement.innerHTML = `<div><div id="app"></div><div id="target"></div></div>`
+
+    const PortalContent = () => h('div', 'portal content')
+    const Comp = () => [h(Portal, { target: '#target' }, [h(PortalContent)])]
+
+    const appDiv = document.querySelector('#app')!
+    const targetDiv = document.querySelector('#target')!
+
+    render(h(Comp), appDiv)
+
+    expect(appDiv.innerHTML).toBe(`<!----><!--[object Object]--><!---->`)
+    expect(targetDiv.innerHTML).toBe(`<div>portal content</div>`)
+  })
+
+  test('portals can render different elements by its selector', async () => {
+    document.documentElement.innerHTML = `<div><div id="app"></div><div id="target1"></div><div id="target2"></div></div>`
+
+    const whichTarget = ref('#target1')
+
+    const PortalContent = () => h('div', 'portal content')
+    const Comp = () => [
+      h(Portal, { target: whichTarget.value }, [h(PortalContent)])
+    ]
+
+    const appDiv = document.querySelector('#app')!
+    const target1Div = document.querySelector('#target1')!
+    const target2Div = document.querySelector('#target2')!
+
+    render(h(Comp), appDiv)
+    await nextTick()
+
+    expect(appDiv.innerHTML).toBe(`<!----><!--[object Object]--><!---->`)
+    expect(target1Div.innerHTML).toBe(`<div>portal content</div>`)
+    expect(target2Div.innerHTML).toBe(``)
+
+    // Move to a new portal target
+    whichTarget.value = '#target2'
+
+    await nextTick()
+
+    expect(appDiv.innerHTML).toBe(`<!----><!--[object Object]--><!---->`)
+    expect(target1Div.innerHTML).toBe(``)
+    expect(target2Div.innerHTML).toBe(`<div>portal content</div>`)
+  })
+})


### PR DESCRIPTION
This adds tests for portals and async components. The method to do so is a bit tricky but it definitely reveals some interesting results which generally appear correct sans one small thing (will comment) which doesn't seem to cause problems but is strange.