### PR TITLE
chore: improve typings in reactivity tests

### DIFF
--- a/packages/reactivity/__tests__/collections/Map.spec.ts
+++ b/packages/reactivity/__tests__/collections/Map.spec.ts
@@ -247,7 +247,7 @@ describe('reactivity/collections', () => {
         })
       })
       expect(dummy).toBe(1)
-      ;(map.get(1) as any).foo++
+      map.get(1)!.foo++
       expect(dummy).toBe(2)
     })
 
@@ -262,7 +262,7 @@ describe('reactivity/collections', () => {
         }
       })
       expect(dummy).toBe(1)
-      ;(map.get(1) as any).foo++
+      map.get(1)!.foo++
       expect(dummy).toBe(2)
     })
 
@@ -280,7 +280,7 @@ describe('reactivity/collections', () => {
         }
       })
       expect(dummy).toBe(1)
-      ;(map.get(key) as any).foo++
+      map.get(key)!.foo++
       expect(dummy).toBe(2)
     })
 
@@ -298,7 +298,7 @@ describe('reactivity/collections', () => {
         }
       })
       expect(dummy).toBe(1)
-      ;(map.get(key) as any).foo++
+      map.get(key)!.foo++
       expect(dummy).toBe(2)
     })
   })

--- a/packages/reactivity/__tests__/collections/Set.spec.ts
+++ b/packages/reactivity/__tests__/collections/Set.spec.ts
@@ -102,7 +102,7 @@ describe('reactivity/collections', () => {
 
     it('should observe entries iteration', () => {
       let dummy
-      const set = reactive(new Set() as Set<number>)
+      const set = reactive(new Set<number>())
       effect(() => {
         dummy = 0
         // eslint-disable-next-line no-unused-vars
@@ -196,7 +196,7 @@ describe('reactivity/collections', () => {
 
     it('should not observe raw iterations', () => {
       let dummy = 0
-      const set = reactive(new Set() as Set<number>)
+      const set = reactive(new Set<number>())
       effect(() => {
         dummy = 0
         for (let [num] of toRaw(set).entries()) {

--- a/packages/reactivity/__tests__/computed.spec.ts
+++ b/packages/reactivity/__tests__/computed.spec.ts
@@ -2,7 +2,7 @@ import { computed, reactive, effect, stop, ref } from '../src'
 
 describe('reactivity/computed', () => {
   it('should return updated value', () => {
-    const value: any = reactive({})
+    const value = reactive<{ foo?: number }>({})
     const cValue = computed(() => value.foo)
     expect(cValue.value).toBe(undefined)
     value.foo = 1
@@ -10,7 +10,7 @@ describe('reactivity/computed', () => {
   })
 
   it('should compute lazily', () => {
-    const value: any = reactive({})
+    const value = reactive<{ foo?: number }>({})
     const getter = jest.fn(() => value.foo)
     const cValue = computed(getter)
 
@@ -38,7 +38,7 @@ describe('reactivity/computed', () => {
   })
 
   it('should trigger effect', () => {
-    const value: any = reactive({})
+    const value = reactive<{ foo?: number }>({})
     const cValue = computed(() => value.foo)
     let dummy
     effect(() => {
@@ -50,7 +50,7 @@ describe('reactivity/computed', () => {
   })
 
   it('should work when chained', () => {
-    const value: any = reactive({ foo: 0 })
+    const value = reactive({ foo: 0 })
     const c1 = computed(() => value.foo)
     const c2 = computed(() => c1.value + 1)
     expect(c2.value).toBe(1)
@@ -61,7 +61,7 @@ describe('reactivity/computed', () => {
   })
 
   it('should trigger effect when chained', () => {
-    const value: any = reactive({ foo: 0 })
+    const value = reactive({ foo: 0 })
     const getter1 = jest.fn(() => value.foo)
     const getter2 = jest.fn(() => {
       return c1.value + 1
@@ -84,7 +84,7 @@ describe('reactivity/computed', () => {
   })
 
   it('should trigger effect when chained (mixed invocations)', () => {
-    const value: any = reactive({ foo: 0 })
+    const value = reactive({ foo: 0 })
     const getter1 = jest.fn(() => value.foo)
     const getter2 = jest.fn(() => {
       return c1.value + 1
@@ -108,7 +108,7 @@ describe('reactivity/computed', () => {
   })
 
   it('should no longer update when stopped', () => {
-    const value: any = reactive({})
+    const value = reactive<{ foo?: number }>({})
     const cValue = computed(() => value.foo)
     let dummy
     effect(() => {

--- a/packages/reactivity/__tests__/effect.spec.ts
+++ b/packages/reactivity/__tests__/effect.spec.ts
@@ -71,7 +71,7 @@ describe('reactivity/effect', () => {
 
   it('should observe has operations', () => {
     let dummy
-    const obj: any = reactive({ prop: 'value' })
+    const obj = reactive<{ prop: string | number }>({ prop: 'value' })
     effect(() => (dummy = 'prop' in obj))
 
     expect(dummy).toBe(true)
@@ -115,7 +115,7 @@ describe('reactivity/effect', () => {
 
   it('should observe inherited property accessors', () => {
     let dummy, parentDummy, hiddenValue: any
-    const obj: any = reactive({})
+    const obj = reactive<{ prop?: number }>({})
     const parent = reactive({
       set prop(value) {
         hiddenValue = value
@@ -179,7 +179,7 @@ describe('reactivity/effect', () => {
 
   it('should observe sparse array mutations', () => {
     let dummy
-    const list: any[] = reactive([])
+    const list = reactive<string[]>([])
     list[1] = 'World!'
     effect(() => (dummy = list.join(' ')))
 
@@ -192,7 +192,7 @@ describe('reactivity/effect', () => {
 
   it('should observe enumeration', () => {
     let dummy = 0
-    const numbers: any = reactive({ num1: 3 })
+    const numbers = reactive<Record<string, number>>({ num1: 3 })
     effect(() => {
       dummy = 0
       for (let key in numbers) {
@@ -269,7 +269,7 @@ describe('reactivity/effect', () => {
 
   it('should not observe raw mutations', () => {
     let dummy
-    const obj: any = reactive({})
+    const obj = reactive<{ prop?: string }>({})
     effect(() => (dummy = toRaw(obj).prop))
 
     expect(dummy).toBe(undefined)
@@ -279,7 +279,7 @@ describe('reactivity/effect', () => {
 
   it('should not be triggered by raw mutations', () => {
     let dummy
-    const obj: any = reactive({})
+    const obj = reactive<{ prop?: string }>({})
     effect(() => (dummy = obj.prop))
 
     expect(dummy).toBe(undefined)
@@ -289,7 +289,7 @@ describe('reactivity/effect', () => {
 
   it('should not be triggered by inherited raw setters', () => {
     let dummy, parentDummy, hiddenValue: any
-    const obj: any = reactive({})
+    const obj = reactive<{ prop?: number }>({})
     const parent = reactive({
       set prop(value) {
         hiddenValue = value
@@ -437,7 +437,7 @@ describe('reactivity/effect', () => {
 
   it('should not run multiple times for a single mutation', () => {
     let dummy
-    const obj: any = reactive({})
+    const obj = reactive<Record<string, number>>({})
     const fnSpy = jest.fn(() => {
       for (const key in obj) {
         dummy = obj[key]

--- a/packages/reactivity/__tests__/reactive.spec.ts
+++ b/packages/reactivity/__tests__/reactive.spec.ts
@@ -19,7 +19,7 @@ describe('reactivity/reactive', () => {
   })
 
   test('Array', () => {
-    const original: any[] = [{ foo: 1 }]
+    const original = [{ foo: 1 }]
     const observed = reactive(original)
     expect(observed).not.toBe(original)
     expect(isReactive(observed)).toBe(true)
@@ -88,7 +88,7 @@ describe('reactivity/reactive', () => {
   })
 
   test('setting a property with an unobserved value should wrap with reactive', () => {
-    const observed: any = reactive({})
+    const observed = reactive<{ foo?: object }>({})
     const raw = {}
     observed.foo = raw
     expect(observed.foo).not.toBe(raw)

--- a/packages/reactivity/__tests__/readonly.spec.ts
+++ b/packages/reactivity/__tests__/readonly.spec.ts
@@ -106,7 +106,7 @@ describe('reactivity/readonly', () => {
 
   describe('Array', () => {
     it('should make nested values readonly', () => {
-      const original: any[] = [{ foo: 1 }]
+      const original = [{ foo: 1 }]
       const observed = readonly(original)
       expect(observed).not.toBe(original)
       expect(isReactive(observed)).toBe(true)


### PR DESCRIPTION
### Changed
- improve typescript in the tests where types can be specified, some tests were ignored based on the nature of the tests. 


The goal is to prevent the usage of as `any` and some direct casts (since typescript sometimes just trusts the user and we cannot be trusted )