### PR TITLE
fix(runtime-dom): nodeops insert unkeyed element

### DIFF
--- a/packages/runtime-dom/src/nodeOps.ts
+++ b/packages/runtime-dom/src/nodeOps.ts
@@ -4,6 +4,10 @@ const svgNS = 'http://www.w3.org/2000/svg'
 export const nodeOps = {
   insert: (child: Node, parent: Node, anchor?: Node) => {
     if (anchor != null) {
+      parent =
+        anchor.parentNode && parent != anchor.parentNode
+          ? anchor.parentNode
+          : parent
       parent.insertBefore(child, anchor)
     } else {
       parent.appendChild(child)

--- a/packages/vue/__tests__/vfor.spec.ts
+++ b/packages/vue/__tests__/vfor.spec.ts
@@ -1,8 +1,6 @@
 import * as Vue from '../src'
-import { createApp, reactive, onMounted } from '../src'
-import { nextTick } from '../../runtime-test/src'
+import { createApp, reactive, nextTick } from '../src'
 ;(window as any).Vue = Vue
-const click = jest.fn()
 
 test('render new items added', async () => {
   const container = document.createElement('div')
@@ -24,12 +22,7 @@ test('render new items added', async () => {
       function addItem() {
         const number = Number(testList.length) + 1
         testList.push(number)
-        click()
       }
-
-      onMounted(() => {
-        addItem()
-      })
 
       return {
         testList,
@@ -38,6 +31,7 @@ test('render new items added', async () => {
     }
   }
   createApp().mount(App, container)
+  container!.querySelector('button')!.click()
   await nextTick()
   let text = container!.querySelector('ul')!.innerHTML
 

--- a/packages/vue/__tests__/vfor.spec.ts
+++ b/packages/vue/__tests__/vfor.spec.ts
@@ -1,0 +1,45 @@
+import * as Vue from '../src'
+import { createApp, reactive, onMounted } from '../src'
+import { nextTick } from '../../runtime-test/src'
+;(window as any).Vue = Vue
+const click = jest.fn()
+
+test('render new items added', async () => {
+  const container = document.createElement('div')
+  const App = {
+    template: `<div>
+        <button @click="addItem()" id="test-button"> AddToList </button>
+  
+        <ul>
+          <li v-for="(item, index) in testList" :key="index"> 
+            {{ item }}
+          </li>
+        </ul>
+      </div>
+      `,
+
+    setup() {
+      const testList = reactive([1])
+
+      function addItem() {
+        const number = Number(testList.length) + 1
+        testList.push(number)
+        click()
+      }
+
+      onMounted(() => {
+        addItem()
+      })
+
+      return {
+        testList,
+        addItem
+      }
+    }
+  }
+  createApp().mount(App, container)
+  await nextTick()
+  let text = container!.querySelector('ul')!.innerHTML
+
+  expect(text).toBe('<!----><li>1</li><li>2</li><!---->')
+})


### PR DESCRIPTION
**build distribution:** `global`

**problem:** when adding new items to a v-for list nodeops.insert recieve the app container element insted of the parent of the child

**Here is the error:**

![image](https://user-images.githubusercontent.com/17421742/66253039-8823ba00-e730-11e9-8db0-7c69718988bd.png)

**context:**
I just was playing around the new composition API and made a simple app to custom tasks. I found out it rendered the list but failed to render the new items added to the list.

**My code:**

``` html
<!DOCTYPE html>
<html lang="en">
<head>
    <meta charset="UTF-8">
    <meta name="viewport" content="width=device-width, initial-scale=1.0">
    <meta http-equiv="X-UA-Compatible" content="ie=edge">
    <title>Document</title>
</head>
<body>
    <div id="app"></div>
</body>

<script src="assets/vue.global.prod.js"></script>
<script>
    const { reactive, computed, ref } = Vue;

    const App = {
    template: `<div>
      <button @click="addItem" id="test-button"> AddToList </button>

      <ul>
        <li v-for="(item, index) in testList" :key="index"> 
          {{ item }}
        </li>
      </ul>
    </div>
    `,

    setup() {
      const testList = reactive([1])
      
      function addItem() {
        const number = Number(testList.length) + 1; 
        testList.push(number)
      }

      return {
        testList,
        addItem
      }
    }
  }
  const app = Vue.createApp();
  app.mount( App, document.querySelector('#app'));
</script>
</html>
```


