### PR TITLE
test: Runtime-core added test and improving type

### DIFF
--- a/packages/runtime-core/__tests__/apiApp.spec.ts
+++ b/packages/runtime-core/__tests__/apiApp.spec.ts
@@ -124,10 +124,10 @@ describe('api: createApp', () => {
       },
       setup() {
         // resolve in setup
-        const FooBar = resolveDirective('foo-bar') as any
+        const FooBar = resolveDirective('foo-bar')!
         return () => {
           // resolve in render
-          const BarBaz = resolveDirective('bar-baz') as any
+          const BarBaz = resolveDirective('bar-baz')!
           return applyDirectives(h('div'), [[FooBar], [BarBaz]])
         }
       }

--- a/packages/runtime-core/__tests__/apiCreateComponent.spec.tsx
+++ b/packages/runtime-core/__tests__/apiCreateComponent.spec.tsx
@@ -5,7 +5,7 @@ import { h } from '../src/h'
 
 // mock React just for TSX testing purposes
 const React = {
-  createElement: () => {}
+  createElement: () => { }
 }
 
 test('createComponent type inference', () => {
@@ -22,10 +22,17 @@ test('createComponent type inference', () => {
         default: 'hello'
       },
       // explicit type casting
-      cc: (Array as any) as PropType<string[]>,
+      cc: Array as PropType<string[]>,
       // required + type casting
       dd: {
-        type: (Array as any) as PropType<string[]>,
+        type: Array as PropType<string[]>,
+        required: true
+      },
+      // explicit type casting with constructor
+      ccc: Array as () => string[],
+      // required + contructor type casting
+      ddd: {
+        type: Array as () => string[],
         required: true
       }
     } as const, // required to narrow for conditional check
@@ -59,8 +66,8 @@ test('createComponent type inference', () => {
       return h('div', this.bb)
     }
   })
-  // test TSX props inference
-  ;(<MyComponent a={1} b="foo" dd={['foo']}/>)
+    // test TSX props inference
+    ; (<MyComponent a={1} b="foo" dd={['foo']} ddd={['foo']}/>)
 })
 
 test('type inference w/ optional props declaration', () => {
@@ -78,14 +85,14 @@ test('type inference w/ optional props declaration', () => {
       return h('div', this.msg)
     }
   })
-  ;(<Comp msg="hello"/>)
+    ; (<Comp msg="hello" />)
 })
 
 test('type inference w/ direct setup function', () => {
   const Comp = createComponent((props: { msg: string }) => {
     return () => <div>{props.msg}</div>
   })
-  ;(<Comp msg="hello"/>)
+    ; (<Comp msg="hello" />)
 })
 
 test('type inference w/ array props declaration', () => {
@@ -106,7 +113,7 @@ test('type inference w/ array props declaration', () => {
       this.c
     }
   })
-  ;(<Comp a={1} b={2}/>)
+    ; (<Comp a={1} b={2} />)
 })
 
 test('with legacy options', () => {

--- a/packages/runtime-core/__tests__/apiCreateComponent.spec.tsx
+++ b/packages/runtime-core/__tests__/apiCreateComponent.spec.tsx
@@ -5,7 +5,7 @@ import { h } from '../src/h'
 
 // mock React just for TSX testing purposes
 const React = {
-  createElement: () => { }
+  createElement: () => {}
 }
 
 test('createComponent type inference', () => {
@@ -66,8 +66,8 @@ test('createComponent type inference', () => {
       return h('div', this.bb)
     }
   })
-    // test TSX props inference
-    ; (<MyComponent a={1} b="foo" dd={['foo']} ddd={['foo']}/>)
+  // test TSX props inference
+  ;(<MyComponent a={1} b="foo" dd={['foo']} ddd={['foo']}/>)
 })
 
 test('type inference w/ optional props declaration', () => {
@@ -85,14 +85,14 @@ test('type inference w/ optional props declaration', () => {
       return h('div', this.msg)
     }
   })
-    ; (<Comp msg="hello" />)
+  ;(<Comp msg="hello"/>)
 })
 
 test('type inference w/ direct setup function', () => {
   const Comp = createComponent((props: { msg: string }) => {
     return () => <div>{props.msg}</div>
   })
-    ; (<Comp msg="hello" />)
+  ;(<Comp msg="hello"/>)
 })
 
 test('type inference w/ array props declaration', () => {
@@ -113,7 +113,7 @@ test('type inference w/ array props declaration', () => {
       this.c
     }
   })
-    ; (<Comp a={1} b={2} />)
+  ;(<Comp a={1} b={2}/>)
 })
 
 test('with legacy options', () => {

--- a/packages/runtime-core/__tests__/apiSetupContext.spec.ts
+++ b/packages/runtime-core/__tests__/apiSetupContext.spec.ts
@@ -74,6 +74,39 @@ describe('api: setup context', () => {
     expect(dummy).toBe(1)
   })
 
+  it('setup props should resolve the correct types from props object', async () => {
+    const count = ref(0)
+    let dummy
+
+    const Parent = {
+      render: () => h(Child, { count: count.value })
+    }
+
+    const Child = createComponent({
+      props: {
+        count: Number
+      },
+
+      setup(props) {
+        watch(() => {
+          dummy = props.count
+        })
+        return () => h('div', props.count)
+      }
+    })
+
+    const root = nodeOps.createElement('div')
+    render(h(Parent), root)
+    expect(serializeInner(root)).toMatch(`<div>0</div>`)
+    expect(dummy).toBe(0)
+
+    // props should be reactive
+    count.value++
+    await nextTick()
+    expect(serializeInner(root)).toMatch(`<div>1</div>`)
+    expect(dummy).toBe(1)
+  })
+
   it('context.attrs', async () => {
     const toggle = ref(true)
 

--- a/packages/runtime-core/__tests__/rendererSuspense.spec.ts
+++ b/packages/runtime-core/__tests__/rendererSuspense.spec.ts
@@ -517,7 +517,7 @@ describe('renderer: suspense', () => {
 
     const Comp = {
       setup() {
-        const error = ref<any>(null)
+        const error = ref<Error | null>(null)
         onErrorCaptured(e => {
           error.value = e
           return true


### PR DESCRIPTION
### Changes
- improve `runtime-core/createComponent type inference`, removed unnecessary `as any` and added as `() => string[]` as an valid option for the type.
- improve typescript in the testing removed `as any` 

### Added
- Test to validate the props passed in the setup are actually with the correct typings