### PR TITLE
fix(v-if): add simple expression node opening bracket

### DIFF
--- a/packages/compiler-core/__tests__/__snapshots__/compile.spec.ts.snap
+++ b/packages/compiler-core/__tests__/__snapshots__/compile.spec.ts.snap
@@ -35,7 +35,7 @@ return function render() {
     class: _ctx.bar.baz
   }, [
     toString(_ctx.world.burn()),
-    (openBlock(), _ctx.ok)
+    (openBlock(), (_ctx.ok)
       ? createBlock(\\"div\\", { key: 0 }, \\"yes\\")
       : createBlock(Fragment, { key: 1 }, [\\"no\\"])),
     (openBlock(), createBlock(Fragment, null, renderList(_ctx.list, (value, index) => {
@@ -57,7 +57,7 @@ export default function render() {
     class: _ctx.bar.baz
   }, [
     _toString(_ctx.world.burn()),
-    (openBlock(), _ctx.ok)
+    (openBlock(), (_ctx.ok)
       ? createBlock(\\"div\\", { key: 0 }, \\"yes\\")
       : createBlock(Fragment, { key: 1 }, [\\"no\\"])),
     (openBlock(), createBlock(Fragment, null, renderList(_ctx.list, (value, index) => {

--- a/packages/compiler-core/__tests__/transforms/__snapshots__/vSlot.spec.ts.snap
+++ b/packages/compiler-core/__tests__/transforms/__snapshots__/vSlot.spec.ts.snap
@@ -71,7 +71,7 @@ return function render() {
   const _component_Comp = resolveComponent(\\"Comp\\")
   
   return (openBlock(), createBlock(_component_Comp, null, createSlots({ _compiled: true }, [
-    _ctx.ok)
+    (_ctx.ok)
       ? {
           name: \\"one\\",
           fn: (props) => [toString(props)]

--- a/packages/compiler-core/src/codegen.ts
+++ b/packages/compiler-core/src/codegen.ts
@@ -528,6 +528,7 @@ function genConditionalExpression(
   const { push, indent, deindent, newline } = context
   if (test.type === NodeTypes.SIMPLE_EXPRESSION) {
     const needsParens = !isSimpleIdentifier(test.content)
+    needsParens && push(`(`)
     genExpression(test, context)
     needsParens && push(`)`)
   } else {


### PR DESCRIPTION
Added missing opening bracket in codegen.

[example](https://vue-next-template-explorer.netlify.com/#%3Cdiv%20v-if%3D%22count%20%3C%203%22%3ECount%3A%20%7B%7B%20count%20%7D%7D%3C%2Fdiv%3E)