### PR TITLE
test(runtime-core): test createSlots

### DIFF
--- a/packages/runtime-core/__tests__/helpers/createSlots.spec.ts
+++ b/packages/runtime-core/__tests__/helpers/createSlots.spec.ts
@@ -1,10 +1,13 @@
+import { Slot } from '../../src/componentSlots'
 import { createSlots } from '../../src/helpers/createSlots'
+import { createVNode } from 'vue'
 
 describe('createSlot', () => {
   it('should return a slot', () => {
-    const slot = () => [{}]
-    const slotDescriptor = 'descriptor'
-    const actual = createSlots(slot, slotDescriptor)
+    const record: Record<string, Slot> = {}
+    const slot = () => createVNode(Object)
+    const slotDescriptor = [{ name: 'descriptor', fn: slot }]
+    const actual = createSlots(record, slotDescriptor)
 
     expect(actual).toHaveLength(1)
   })

--- a/packages/runtime-core/__tests__/helpers/createSlots.spec.ts
+++ b/packages/runtime-core/__tests__/helpers/createSlots.spec.ts
@@ -1,0 +1,11 @@
+import { createSlots } from '../../src/helpers/createSlots'
+
+describe('createSlot', () => {
+  it('should return a slot', () => {
+    const slot = () => [{}]
+    const slotDescriptor = 'descriptor'
+    const actual = createSlots(slot, slotDescriptor)
+
+    expect(actual).toHaveLength(1)
+  })
+})


### PR DESCRIPTION
Hi! I'd like to help with the test coverage of Vue 3, but I'm having some difficulty understanding how things work. I'm putting up this PR in the hopes of getting a push in the right direction on how to test some of this stuff. I started with `createSlots`, and the problem I'm running into is that I don't understand how to create a dummy Record to pass into `createSlots`. I have tried looking through the other tests that create slots, such as https://github.com/vuejs/vue-next/blob/8133b3867ae3d67bbd05a8ca06c5659275bc5942/packages/runtime-core/__tests__/h.spec.ts#L31 which creates a Slot, but not a Record. I feel like I'm missing something obvious, but can't see what that might be. Could I have a little help understanding?

Thank you.