### PR TITLE
fix: wrong scope for event value

### DIFF
--- a/packages/runtime-dom/src/modules/events.ts
+++ b/packages/runtime-dom/src/modules/events.ts
@@ -47,18 +47,12 @@ export function patchEvent(
   nextValue: EventValue | null,
   instance: ComponentInternalInstance | null = null
 ) {
-  const invoker = prevValue && prevValue.invoker
-  if (nextValue) {
-    if (invoker) {
-      ;(prevValue as EventValue).invoker = null
-      invoker.value = nextValue
-      nextValue.invoker = invoker
-      invoker.lastUpdated = getNow()
-    } else {
-      el.addEventListener(name, createInvoker(nextValue, instance))
-    }
-  } else if (invoker) {
-    el.removeEventListener(name, invoker as any)
+  const prevInvoker = prevValue && prevValue.invoker
+  if (prevInvoker) {
+    el.removeEventListener(name, prevInvoker as any)
+  }
+  if (nextValue) {  
+    el.addEventListener(name, createInvoker(nextValue, instance))
   }
 }
 


### PR DESCRIPTION
Minimal test case (haven't found runtime dom tests so didn't commit this):

```javascript
{
    setup() {
        return {
            clicked: false,
        }
    },
    render() {
        const clicked = this.clicked ? h('button', { onClick: () => this.clicked = false, }, 'Clicked') : null;
        const notClicked = !this.clicked ? h('button', { onClick: () => this.clicked = true, }, 'Not clicked') : null;
        return h('div', [
            clicked,
            notClicked,
        ]);
    }
}
```

After we click the button once the new callback won't be assigned and nothing will happen on click.