### PR TITLE
fix: add missing Vue reference to compiled template

### DIFF
--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -1,6 +1,7 @@
 // This package is the "full-build" that includes both the runtime
 // and the compiler, and supports on-the-fly compilation of the template option.
 import { compile, CompilerOptions } from '@vue/compiler-dom'
+import * as runtimeDom from '@vue/runtime-dom'
 import { registerRuntimeCompiler, RenderFunction } from '@vue/runtime-dom'
 
 function compileToFunction(
@@ -11,7 +12,7 @@ function compileToFunction(
     hoistStatic: true,
     ...options
   })
-  return new Function(code)() as RenderFunction
+  return new Function('Vue', code)(runtimeDom) as RenderFunction
 }
 
 registerRuntimeCompiler(compileToFunction)


### PR DESCRIPTION
This would allow us to play with templates in runtime esm build.
Otherwise you'd get:

> vue.esm-browser.js:23 Uncaught ReferenceError: Vue is not defined
    at eval (eval at compileToFunction (vue.esm-browser.js:6769), <anonymous>:1:14)
    at compileToFunction (vue.esm-browser.js:6769)
    at finishComponentSetup (vue.esm-browser.js:6644)
    at handleSetupResult (vue.esm-browser.js:6629)
    at setupStatefulComponent (vue.esm-browser.js:6605)
    at mountComponent (vue.esm-browser.js:5454)
    at processComponent (vue.esm-browser.js:5408)
    at patch (vue.esm-browser.js:5030)
    at render (vue.esm-browser.js:5983)
    at Object.mount (vue.esm-browser.js:4880)