### PR TITLE
refactor(VNode): use symbol instead of _isVNode key

### DIFF
--- a/packages/reactivity/src/reactive.ts
+++ b/packages/reactivity/src/reactive.ts
@@ -8,6 +8,7 @@ import {
 
 import { UnwrapNestedRefs } from './ref'
 import { ReactiveEffect } from './effect'
+import { vnodeSymbol } from '@vue/runtime-core'
 
 // The main WeakMap that stores {target -> key -> dep} connections.
 // Conceptually, it's easier to think of a dependency as a Dep class
@@ -34,7 +35,7 @@ const observableValueRE = /^\[object (?:Object|Array|Map|Set|WeakMap|WeakSet)\]$
 const canObserve = (value: any): boolean => {
   return (
     !value._isVue &&
-    !value._isVNode &&
+    value._isVNode !== vnodeSymbol &&
     observableValueRE.test(toTypeString(value)) &&
     !nonReactiveValues.has(value)
   )

--- a/packages/reactivity/src/reactive.ts
+++ b/packages/reactivity/src/reactive.ts
@@ -35,7 +35,7 @@ const observableValueRE = /^\[object (?:Object|Array|Map|Set|WeakMap|WeakSet)\]$
 const canObserve = (value: any): boolean => {
   return (
     !value._isVue &&
-    value._isVNode !== vnodeSymbol &&
+    !value[vnodeSymbol] &&
     observableValueRE.test(toTypeString(value)) &&
     !nonReactiveValues.has(value)
   )

--- a/packages/runtime-core/src/h.ts
+++ b/packages/runtime-core/src/h.ts
@@ -4,7 +4,8 @@ import {
   createVNode,
   VNodeChildren,
   Fragment,
-  Portal
+  Portal,
+  vnodeSymbol
 } from './vnode'
 import { isObject, isArray } from '@vue/shared'
 import { Ref } from '@vue/reactivity'
@@ -52,7 +53,7 @@ export interface RawProps {
   key?: string | number
   ref?: string | Ref<any> | Function
   // used to differ from a single VNode object as children
-  _isVNode?: never
+  [vnodeSymbol]?: never
   // used to differ from Array children
   [Symbol.iterator]?: never
 }

--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -16,7 +16,8 @@ export {
   cloneVNode,
   mergeProps,
   openBlock,
-  createBlock
+  createBlock,
+  vnodeSymbol
 } from './vnode'
 // VNode type symbols
 export { Text, Comment, Fragment, Portal, Suspense } from './vnode'

--- a/packages/runtime-core/src/vnode.ts
+++ b/packages/runtime-core/src/vnode.ts
@@ -19,8 +19,7 @@ export const Text = __DEV__ ? Symbol('Text') : Symbol()
 export const Comment = __DEV__ ? Symbol('Empty') : Symbol()
 export const Portal = __DEV__ ? Symbol('Portal') : Symbol()
 export const Suspense = __DEV__ ? Symbol('Suspense') : Symbol()
-
-export const vnodeSymbol = Symbol()
+export const vnodeSymbol = __DEV__ ? Symbol('isVNode') : Symbol()
 
 export type VNodeTypes =
   | string

--- a/packages/runtime-core/src/vnode.ts
+++ b/packages/runtime-core/src/vnode.ts
@@ -57,7 +57,7 @@ export type NormalizedChildren<HostNode = any, HostElement = any> =
   | null
 
 export interface VNode<HostNode = any, HostElement = any> {
-  _isVNode: typeof vnodeSymbol
+  [vnodeSymbol]: true
   type: VNodeTypes
   props: Record<any, any> | null
   key: string | number | null
@@ -128,7 +128,7 @@ export function createBlock(
 }
 
 export function isVNode(value: any): boolean {
-  return value ? value._isVNode === vnodeSymbol : false
+  return value ? value[vnodeSymbol] === true : false
 }
 
 export function createVNode(
@@ -170,7 +170,7 @@ export function createVNode(
         : 0
 
   const vnode: VNode = {
-    _isVNode: vnodeSymbol,
+    [vnodeSymbol]: true,
     type,
     props,
     key: (props && props.key) || null,
@@ -215,7 +215,7 @@ function trackDynamicNode(vnode: VNode) {
 
 export function cloneVNode(vnode: VNode): VNode {
   return {
-    _isVNode: vnodeSymbol,
+    [vnodeSymbol]: true,
     type: vnode.type,
     props: vnode.props,
     key: vnode.key,

--- a/packages/runtime-core/src/vnode.ts
+++ b/packages/runtime-core/src/vnode.ts
@@ -20,6 +20,8 @@ export const Comment = __DEV__ ? Symbol('Empty') : Symbol()
 export const Portal = __DEV__ ? Symbol('Portal') : Symbol()
 export const Suspense = __DEV__ ? Symbol('Suspense') : Symbol()
 
+export const vnodeSymbol = Symbol()
+
 export type VNodeTypes =
   | string
   | Function
@@ -55,7 +57,7 @@ export type NormalizedChildren<HostNode = any, HostElement = any> =
   | null
 
 export interface VNode<HostNode = any, HostElement = any> {
-  _isVNode: true
+  _isVNode: typeof vnodeSymbol
   type: VNodeTypes
   props: Record<any, any> | null
   key: string | number | null
@@ -126,7 +128,7 @@ export function createBlock(
 }
 
 export function isVNode(value: any): boolean {
-  return value ? value._isVNode === true : false
+  return value ? value._isVNode === vnodeSymbol : false
 }
 
 export function createVNode(
@@ -168,7 +170,7 @@ export function createVNode(
         : 0
 
   const vnode: VNode = {
-    _isVNode: true,
+    _isVNode: vnodeSymbol,
     type,
     props,
     key: (props && props.key) || null,
@@ -213,7 +215,7 @@ function trackDynamicNode(vnode: VNode) {
 
 export function cloneVNode(vnode: VNode): VNode {
   return {
-    _isVNode: true,
+    _isVNode: vnodeSymbol,
     type: vnode.type,
     props: vnode.props,
     key: vnode.key,

--- a/packages/runtime-core/src/vnode.ts
+++ b/packages/runtime-core/src/vnode.ts
@@ -19,7 +19,8 @@ export const Text = __DEV__ ? Symbol('Text') : Symbol()
 export const Comment = __DEV__ ? Symbol('Empty') : Symbol()
 export const Portal = __DEV__ ? Symbol('Portal') : Symbol()
 export const Suspense = __DEV__ ? Symbol('Suspense') : Symbol()
-export const vnodeSymbol = __DEV__ ? Symbol('isVNode') : Symbol()
+
+export const vnodeSymbol = Symbol()
 
 export type VNodeTypes =
   | string


### PR DESCRIPTION
Just as #114, but for VNode. Use a new Symbol as `_isVNode` value. I can make such changes for e.g. `_isVue` too if it's needed.