### PR TITLE
fix(reactivity): explicitly do type conversions in template string

### DIFF
--- a/packages/reactivity/__tests__/readonly.spec.ts
+++ b/packages/reactivity/__tests__/readonly.spec.ts
@@ -13,6 +13,11 @@ import {
 } from '../src'
 import { mockWarn } from '@vue/runtime-test'
 
+/**
+ * @see https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-4.html
+ */
+type Writable<T> = { -readonly [P in keyof T]: T[P] }
+
 describe('reactivity/readonly', () => {
   mockWarn()
 
@@ -38,26 +43,50 @@ describe('reactivity/readonly', () => {
     })
 
     it('should not allow mutation', () => {
-      const observed: any = readonly({ foo: 1, bar: { baz: 2 } })
+      const qux = Symbol('qux')
+      const original = {
+        foo: 1,
+        bar: {
+          baz: 2
+        },
+        [qux]: 3
+      }
+      const observed: Writable<typeof original> = readonly(original)
+
       observed.foo = 2
       expect(observed.foo).toBe(1)
       expect(
         `Set operation on key "foo" failed: target is readonly.`
       ).toHaveBeenWarnedLast()
+
       observed.bar.baz = 3
       expect(observed.bar.baz).toBe(2)
       expect(
         `Set operation on key "baz" failed: target is readonly.`
       ).toHaveBeenWarnedLast()
+
+      observed[qux] = 4
+      expect(observed[qux]).toBe(3)
+      expect(
+        `Set operation on key "Symbol(qux)" failed: target is readonly.`
+      ).toHaveBeenWarnedLast()
+
       delete observed.foo
       expect(observed.foo).toBe(1)
       expect(
         `Delete operation on key "foo" failed: target is readonly.`
       ).toHaveBeenWarnedLast()
+
       delete observed.bar.baz
       expect(observed.bar.baz).toBe(2)
       expect(
         `Delete operation on key "baz" failed: target is readonly.`
+      ).toHaveBeenWarnedLast()
+
+      delete observed[qux]
+      expect(observed[qux]).toBe(3)
+      expect(
+        `Delete operation on key "Symbol(qux)" failed: target is readonly.`
       ).toHaveBeenWarnedLast()
     })
 

--- a/packages/reactivity/src/baseHandlers.ts
+++ b/packages/reactivity/src/baseHandlers.ts
@@ -107,7 +107,7 @@ export const readonlyHandlers: ProxyHandler<any> = {
     if (LOCKED) {
       if (__DEV__) {
         console.warn(
-          `Set operation on key "${key as any}" failed: target is readonly.`,
+          `Set operation on key "${String(key)}" failed: target is readonly.`,
           target
         )
       }
@@ -121,7 +121,9 @@ export const readonlyHandlers: ProxyHandler<any> = {
     if (LOCKED) {
       if (__DEV__) {
         console.warn(
-          `Delete operation on key "${key as any}" failed: target is readonly.`,
+          `Delete operation on key "${String(
+            key
+          )}" failed: target is readonly.`,
           target
         )
       }


### PR DESCRIPTION
``` ts
const qux = Symbol('qux')
const original = {
  foo: 1,
  bar: {
    baz: 2
  },
  [qux]: 3
}
const observed = readonly(original)
```

If we try to mutate a symbol type key property like `observed[qux]`, will get an error: 
```
TypeError: Cannot convert a Symbol value to a string
```

https://github.com/vuejs/vue-next/blob/31345b5af922c3093e38ab20a90c6dce61560043/packages/reactivity/src/baseHandlers.ts#L106-L118