### PR TITLE
No need to support IE11

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ However, there are still some 2.x parity features not completed yet:
   - [ ] `v-html`
   - [ ] `v-show`
 
-The current implementation also requires native ES2015+ in the runtime environment and does not support IE11 (yet).
+The current implementation also requires native ES2015+ in the runtime environment and does not support IE11.
 
 ## Contribution
 


### PR DESCRIPTION
IE11 is at 2.x% marketshare and decreasing: https://www.w3counter.com/globalstats.php
Why support it?