### PR TITLE
feat: implementing v-pre transform 

### DIFF
--- a/packages/compiler-core/src/parse.ts
+++ b/packages/compiler-core/src/parse.ts
@@ -356,7 +356,6 @@ function parseElement(
   }
 
   element.loc = getSelection(context, element.loc.start)
-  
   return element
 }
 

--- a/packages/compiler-core/src/parse.ts
+++ b/packages/compiler-core/src/parse.ts
@@ -356,22 +356,6 @@ function parseElement(
   }
 
   element.loc = getSelection(context, element.loc.start)
-
-  const hasPre = element.props.some(x=>x.type === NodeTypes.DIRECTIVE && x.name === "pre");
-  // if has-pre get the source for the children
-  if(hasPre && element.children.length > 0){
-    const firstChild =  element.children[0];
-    const lastChild = element.children[element.children.length - 1];
-
-    const loc = getSelection(context, firstChild.loc.start, lastChild.loc.end );
-    // override the children with only the source of the node content
-    element.children = [{
-      type: NodeTypes.TEXT,
-      content: loc.source,
-      loc: loc,
-      isEmpty: false
-    }]
-  }
   
   return element
 }

--- a/packages/compiler-dom/__tests__/transforms/__snapshots__/vPre.spec.ts.snap
+++ b/packages/compiler-dom/__tests__/transforms/__snapshots__/vPre.spec.ts.snap
@@ -1,0 +1,178 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`compiler: pre transform should not compile inner content 1`] = `
+Object {
+  "children": Array [
+    Object {
+      "children": Array [
+        Object {
+          "content": "{{ a }}",
+          "isEmpty": false,
+          "loc": Object {
+            "end": Object {
+              "column": 29,
+              "line": 2,
+              "offset": 34,
+            },
+            "source": "{{ a }}",
+            "start": Object {
+              "column": 22,
+              "line": 2,
+              "offset": 27,
+            },
+          },
+          "type": 2,
+        },
+      ],
+      "codegenNode": undefined,
+      "isSelfClosing": false,
+      "loc": Object {
+        "end": Object {
+          "column": 35,
+          "line": 2,
+          "offset": 40,
+        },
+        "source": "<div v-pre>{{ a }}</div>",
+        "start": Object {
+          "column": 11,
+          "line": 2,
+          "offset": 16,
+        },
+      },
+      "ns": 0,
+      "props": Array [],
+      "tag": "div",
+      "tagType": 0,
+      "type": 1,
+    },
+    Object {
+      "children": Array [
+        Object {
+          "content": Object {
+            "content": "a",
+            "isStatic": false,
+            "loc": Object {
+              "end": Object {
+                "column": 20,
+                "line": 3,
+                "offset": 60,
+              },
+              "source": "a",
+              "start": Object {
+                "column": 19,
+                "line": 3,
+                "offset": 59,
+              },
+            },
+            "type": 4,
+          },
+          "loc": Object {
+            "end": Object {
+              "column": 23,
+              "line": 3,
+              "offset": 63,
+            },
+            "source": "{{ a }}",
+            "start": Object {
+              "column": 16,
+              "line": 3,
+              "offset": 56,
+            },
+          },
+          "type": 5,
+        },
+      ],
+      "codegenNode": undefined,
+      "isSelfClosing": false,
+      "loc": Object {
+        "end": Object {
+          "column": 29,
+          "line": 3,
+          "offset": 69,
+        },
+        "source": "<div>{{ a }}</div>",
+        "start": Object {
+          "column": 11,
+          "line": 3,
+          "offset": 51,
+        },
+      },
+      "ns": 0,
+      "props": Array [],
+      "tag": "div",
+      "tagType": 0,
+      "type": 1,
+    },
+    Object {
+      "children": Array [
+        Object {
+          "content": "<component is=\\"div\\"></component>",
+          "isEmpty": false,
+          "loc": Object {
+            "end": Object {
+              "column": 45,
+              "line": 5,
+              "offset": 136,
+            },
+            "source": "<component is=\\"div\\"></component>",
+            "start": Object {
+              "column": 13,
+              "line": 5,
+              "offset": 104,
+            },
+          },
+          "type": 2,
+        },
+      ],
+      "codegenNode": undefined,
+      "isSelfClosing": false,
+      "loc": Object {
+        "end": Object {
+          "column": 17,
+          "line": 6,
+          "offset": 153,
+        },
+        "source": "<div v-pre>
+            <component is=\\"div\\"></component>
+          </div>",
+        "start": Object {
+          "column": 11,
+          "line": 4,
+          "offset": 80,
+        },
+      },
+      "ns": 0,
+      "props": Array [],
+      "tag": "div",
+      "tagType": 0,
+      "type": 1,
+    },
+  ],
+  "codegenNode": undefined,
+  "isSelfClosing": false,
+  "loc": Object {
+    "end": Object {
+      "column": 15,
+      "line": 7,
+      "offset": 168,
+    },
+    "source": "<div>
+          <div v-pre>{{ a }}</div>
+          <div>{{ a }}</div>
+          <div v-pre>
+            <component is=\\"div\\"></component>
+          </div>
+        </div>",
+    "start": Object {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "ns": 0,
+  "props": Array [],
+  "tag": "div",
+  "tagType": 0,
+  "type": 1,
+}
+`;

--- a/packages/compiler-dom/__tests__/transforms/vPre.spec.ts
+++ b/packages/compiler-dom/__tests__/transforms/vPre.spec.ts
@@ -1,0 +1,49 @@
+import {
+    parse,
+    transform,
+    CompilerOptions,
+    ElementNode,
+    NodeTypes,
+  } from '@vue/compiler-core'
+import { transformPre } from '../../src/transforms/vPre'
+  
+  function transformWithStyleTransform(
+    template: string,
+    options: CompilerOptions = {}
+  ) {
+    const ast = parse(template)
+    transform(ast, {
+      nodeTransforms: [transformPre],
+      ...options
+    })
+    return {
+      root: ast,
+      node: ast.children[0] as ElementNode
+    }
+  }
+  
+
+describe('compiler: pre transform', function () {
+    it('should not compile on root node', function () {
+        const {node} = transformWithStyleTransform("<div v-pre>{{ a }}</div>");
+
+        expect(node.props).toHaveLength(0);
+        expect(node.children).toHaveLength(1);
+        expect(node.children[0]).toMatchObject({
+            type: NodeTypes.TEXT,
+            content: "{{ a }}"
+        })
+      })
+
+    it('should not compile inner content', function () {
+      const {node} = transformWithStyleTransform(`<div>
+          <div v-pre>{{ a }}</div>
+          <div>{{ a }}</div>
+          <div v-pre>
+            <component is="div"></component>
+          </div>
+        </div>`)
+      expect(node).toMatchSnapshot();
+    })
+  })
+  

--- a/packages/compiler-dom/src/index.ts
+++ b/packages/compiler-dom/src/index.ts
@@ -2,6 +2,7 @@ import { baseCompile, CompilerOptions, CodegenResult } from '@vue/compiler-core'
 import { parserOptionsMinimal } from './parserOptionsMinimal'
 import { parserOptionsStandard } from './parserOptionsStandard'
 import { transformStyle } from './transforms/transformStyle'
+import { transformPre } from './transforms/vPre'
 
 export function compile(
   template: string,
@@ -10,7 +11,7 @@ export function compile(
   return baseCompile(template, {
     ...options,
     ...(__BROWSER__ ? parserOptionsMinimal : parserOptionsStandard),
-    nodeTransforms: [transformStyle, ...(options.nodeTransforms || [])],
+    nodeTransforms: [transformStyle, transformPre, ...(options.nodeTransforms || [])],
     directiveTransforms: {
       // TODO include DOM-specific directiveTransforms
       ...(options.directiveTransforms || {})

--- a/packages/compiler-dom/src/transforms/vPre.ts
+++ b/packages/compiler-dom/src/transforms/vPre.ts
@@ -1,0 +1,13 @@
+import {
+  NodeTypes,
+  NodeTransform,
+} from '@vue/compiler-core'
+
+export const transformPre: NodeTransform = (node, context) => {
+  if (node.type === NodeTypes.ELEMENT) {
+    const index = node.props.findIndex(x => x.type === NodeTypes.DIRECTIVE && x.name === 'pre')
+    if (index>=0) {
+        node.props.splice(index, 1);
+    }
+  }
+}

--- a/packages/compiler-dom/src/transforms/vPre.ts
+++ b/packages/compiler-dom/src/transforms/vPre.ts
@@ -1,13 +1,39 @@
-import {
-  NodeTypes,
-  NodeTransform,
-} from '@vue/compiler-core'
+import { NodeTypes, NodeTransform, DirectiveNode, SimpleExpressionNode } from '@vue/compiler-core'
 
 export const transformPre: NodeTransform = (node, context) => {
   if (node.type === NodeTypes.ELEMENT) {
-    const index = node.props.findIndex(x => x.type === NodeTypes.DIRECTIVE && x.name === 'pre')
-    if (index>=0) {
-        node.props.splice(index, 1);
+    const index = node.props.findIndex(
+      x => x.type === NodeTypes.DIRECTIVE && x.name === 'pre'
+    );
+    if (index >= 0) {
+      const prop = node.props[index] as DirectiveNode
+      if(__DEV__ && prop.exp && !!(prop.exp as SimpleExpressionNode).content.trim()){
+        console.warn(`Unexpected expression on "v-pre".`, prop.exp)
+      }
+      
+      node.props.splice(index, 1);
+
+      const start = node.children[0].loc.start
+      const end = node.children[node.children.length - 1].loc.end
+
+      const loc = {
+        start: start,
+        end: end,
+        source: context.root.loc.source.slice(
+          start.offset,
+          end.offset
+        )
+      }
+
+      // override the children with only the source of the node content
+      node.children = [
+        {
+          type: NodeTypes.TEXT,
+          content: loc.source,
+          loc: loc,
+          isEmpty: false
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
`v-pre`

```jsx
// template
<div v-pre>{{a}}</div>
// generates
export default function render() {
  const _ctx = this
  return (openBlock(), createBlock("div", null, "{{a}}"))
}
```

```jsx
// template
<div>
  <div v-pre>{{ a }}</div>
  <div>{{ a }}</div>
  <div v-pre>
    <component is="div"></component>
  </div>
</div>
// generates
export default function render() {
  const _ctx = this
  return (openBlock(), createBlock("div", null, [
    createVNode("div", null, "{{ a }}"),
    createVNode("div", null, toString(_ctx.a), 1 /* TEXT */),
    createVNode("div", null, "<component is=\"div\"></component>")
  ]))
}
```

Notes: I made the implementation on the `compiler-core`, when started doing that was thinking in not parsing the children if I found the `v-pre` but it turn to be hard to find where the current node ends without parsing the children. The transformer possible can be moved to `compiler-code` if is decided to keep the implementation there. 
**This implementation can be moved to be a `NodeTransform` if needed**
