### PR TITLE
fix(reactivity): not trigger effect when deleting property returns false

### DIFF
--- a/packages/reactivity/src/baseHandlers.ts
+++ b/packages/reactivity/src/baseHandlers.ts
@@ -70,7 +70,7 @@ function deleteProperty(target: any, key: string | symbol): boolean {
   const hadKey = hasOwn(target, key)
   const oldValue = target[key]
   const result = Reflect.deleteProperty(target, key)
-  if (hadKey) {
+  if (result && hadKey) {
     /* istanbul ignore else */
     if (__DEV__) {
       trigger(target, OperationTypes.DELETE, key, { oldValue })


### PR DESCRIPTION
In non-strict mode, should not trigger effect when deleting property returns false.
In strict mode, deleteing property returning false will arise an error and this is ok.