### PR TITLE
refactor(shared): use spread syntax replace split

### DIFF
--- a/packages/shared/src/globalsWhitelist.ts
+++ b/packages/shared/src/globalsWhitelist.ts
@@ -1,7 +1,7 @@
 export const globalsWhitelist = new Set(
-  (
-    'Infinity,undefined,NaN,isFinite,isNaN,parseFloat,parseInt,decodeURI,' +
-    'decodeURIComponent,encodeURI,encodeURIComponent,Math,Number,Date,Array,' +
-    'Object,Boolean,String,RegExp,Map,Set,JSON,Intl'
-  ).split(',')
+  [
+    ...['Infinity', 'undefined', 'NaN', 'isFinite', 'isNaN', 'parseFloat', 'parseInt', 'decodeURI'],
+    ...['decodeURIComponent', 'encodeURI', 'encodeURIComponent', 'Math', 'Number', 'Date', 'Array'],
+    ...['Object', 'Boolean', 'String', 'RegExp', 'Map', 'Set', 'JSON', 'Intl']
+  ]
 )

--- a/packages/shared/src/globalsWhitelist.ts
+++ b/packages/shared/src/globalsWhitelist.ts
@@ -1,7 +1,7 @@
 export const globalsWhitelist = new Set(
   [
-    ...['Infinity', 'undefined', 'NaN', 'isFinite', 'isNaN', 'parseFloat', 'parseInt', 'decodeURI'],
-    ...['decodeURIComponent', 'encodeURI', 'encodeURIComponent', 'Math', 'Number', 'Date', 'Array'],
-    ...['Object', 'Boolean', 'String', 'RegExp', 'Map', 'Set', 'JSON', 'Intl']
+    'Infinity', 'undefined', 'NaN', 'isFinite', 'isNaN', 'parseFloat', 'parseInt', 'decodeURI',
+    'decodeURIComponent', 'encodeURI', 'encodeURIComponent', 'Math', 'Number', 'Date', 'Array',
+    'Object', 'Boolean', 'String', 'RegExp', 'Map', 'Set', 'JSON', 'Intl'
   ]
 )


### PR DESCRIPTION
Use the `benchmark` to test.

Mac OS X 10_14_0

Node v10.16.0
```
set#split x 326,627 ops/sec ±1.36% (86 runs sampled)
set#spread x 714,082 ops/sec ±0.46% (91 runs sampled)
Fastest is set#spread
```

Chrome/76.0.3809.132
```
set#split x 287,831 ops/sec ±3.21% (57 runs sampled)
set#spread x 714,024 ops/sec ±1.01% (60 runs sampled)
Fastest is set#spread
```
