### PR TITLE
fix: not need to throw error after warning for set readonly property.

### DIFF
--- a/packages/runtime-core/__tests__/componentProxy.spec.ts
+++ b/packages/runtime-core/__tests__/componentProxy.spec.ts
@@ -14,27 +14,19 @@ describe('component proxy', () => {
 
     test('Attempting to mutate public property', () => {
       const app = createTestInstance()
-
-      try {
-        app.$props = { foo: 'bar' }
-      } catch {
-        expect(
-          'Attempting to mutate public property "$props". ' +
-            'Properties starting with $ are reserved and readonly.'
-        ).toHaveBeenWarned()
-      }
+      app.$props = { foo: 'bar' }
+      expect(
+        'Attempting to mutate public property "$props". ' +
+          'Properties starting with $ are reserved and readonly.'
+      ).toHaveBeenWarned()
     })
 
     test('Attempting to mutate prop', () => {
       const app = createTestInstance({ foo: 'foo' })
-
-      try {
-        app.foo = 'bar'
-      } catch {
-        expect(
-          'Attempting to mutate prop "foo". Props are readonly.'
-        ).toHaveBeenWarned()
-      }
+      app.foo = 'bar'
+      expect(
+        'Attempting to mutate prop "foo". Props are readonly.'
+      ).toHaveBeenWarned()
     })
   })
 })

--- a/packages/runtime-core/src/componentProxy.ts
+++ b/packages/runtime-core/src/componentProxy.ts
@@ -98,11 +98,9 @@ export const PublicInstanceProxyHandlers = {
             `Properties starting with $ are reserved and readonly.`,
           target
         )
-      return false
     } else if (key in target.props) {
       __DEV__ &&
         warn(`Attempting to mutate prop "${key}". Props are readonly.`, target)
-      return false
     } else {
       target.user[key] = value
     }


### PR DESCRIPTION
return false will throw error after warning in strict mode