### PR TITLE
fix(compiler-core): assest id

### DIFF
--- a/packages/compiler-core/__tests__/__snapshots__/codegen.spec.ts.snap
+++ b/packages/compiler-core/__tests__/__snapshots__/codegen.spec.ts.snap
@@ -54,7 +54,8 @@ exports[`compiler: codegen assets 1`] = `
 return function render() {
   with (this) {
     const _component_Foo = _resolveComponent(\\"Foo\\")
-    const _component_barbaz = _resolveComponent(\\"bar-baz\\")
+    const _component_bar_baz = _resolveComponent(\\"bar-baz\\")
+    const _component_barbaz = _resolveComponent(\\"barbaz\\")
     const _directive_my_dir = _resolveDirective(\\"my_dir\\")
     
     return null

--- a/packages/compiler-core/__tests__/codegen.spec.ts
+++ b/packages/compiler-core/__tests__/codegen.spec.ts
@@ -89,7 +89,7 @@ describe('compiler: codegen', () => {
 
   test('assets', () => {
     const root = createRoot({
-      components: [`Foo`, `bar-baz`],
+      components: [`Foo`, `bar-baz`, `barbaz`],
       directives: [`my_dir`]
     })
     const { code } = generate(root, { mode: 'function' })
@@ -97,9 +97,14 @@ describe('compiler: codegen', () => {
       `const _component_Foo = _${helperNameMap[RESOLVE_COMPONENT]}("Foo")\n`
     )
     expect(code).toMatch(
-      `const _component_barbaz = _${
+      `const _component_bar_baz = _${
         helperNameMap[RESOLVE_COMPONENT]
       }("bar-baz")\n`
+    )
+    expect(code).toMatch(
+      `const _component_barbaz = _${
+        helperNameMap[RESOLVE_COMPONENT]
+      }("barbaz")\n`
     )
     expect(code).toMatch(
       `const _directive_my_dir = _${

--- a/packages/compiler-core/src/utils.ts
+++ b/packages/compiler-core/src/utils.ts
@@ -235,5 +235,5 @@ export function toValidAssetId(
   name: string,
   type: 'component' | 'directive'
 ): string {
-  return `_${type}_${name.replace(/[^\w]/g, '')}`
+  return `_${type}_${name.replace(/[^\w]/g, '_')}`
 }


### PR DESCRIPTION
https://github.com/vuejs/vue-next/blob/cbb4b19cfbef2fac9c2c41e412245e69a433885a/packages/compiler-core/src/utils.ts#L240-L245

`toValidAssetId` converts both `bar-baz` and `barbaz` to `_component_barbaz`, this may cause repeated definition of constant `_component_barbaz` in the generated code: 

``` js
const _component_barbaz = resolveComponent("bar-baz")
const _component_barbaz = resolveComponent("barbaz")
```
