### PR TITLE
test(compiler): remove copy-paste comment from v-cloak

### DIFF
--- a/packages/compiler-core/__tests__/transforms/vOnce.spec.ts
+++ b/packages/compiler-core/__tests__/transforms/vOnce.spec.ts
@@ -19,8 +19,6 @@ describe('compiler: v-once transform', () => {
     const node = transformWithOnce(`<div v-once />`)
     const codegenArgs = (node.codegenNode as CallExpression).arguments
 
-    // As v-once adds no properties the codegen should be identical to
-    // rendering a div with no props or reactive data (so just the tag as the arg)
     expect(codegenArgs[1]).toMatchObject(
       createObjectMatcher({
         $once: `[true]`


### PR DESCRIPTION
Comment isn't valid for v-once and could cause confusion