### PR TITLE
chore: Add commitizen configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "size-compiler": "node scripts/build.js compiler-dom -p -f esm-browser",
     "size": "yarn size-runtime && yarn size-compiler",
     "lint": "prettier --write --parser typescript 'packages/**/*.ts'",
-    "test": "jest"
+    "test": "jest",
+    "commit": "git-cz"
   },
   "gitHooks": {
     "pre-commit": "lint-staged",
@@ -31,6 +32,7 @@
     "@types/jest": "^24.0.18",
     "brotli": "^1.3.2",
     "chalk": "^2.4.2",
+    "cz-conventional-changelog": "^3.0.2",
     "execa": "^2.0.4",
     "fs-extra": "^8.1.0",
     "jest": "^24.9.0",
@@ -47,5 +49,11 @@
     "ts-jest": "^24.0.2",
     "typescript": "^3.5.3",
     "yorkie": "^2.0.0"
+  },
+  "config": {
+    "commitizen": {
+      "path": "./node_modules/cz-conventional-changelog",
+      "maxHeaderWidth": 50
+    }
   }
 }


### PR DESCRIPTION
Commitizen provides a tool for better writting commit messages, matching a commit convention (conventional-changelog in this case).
This commit provides the configuration for commitizen and adds it as a devDependency.

Also, the main vue repository uses commitizen with this configuration (exept for the max 50 commit header length which is described in the scripts/verifyMessage.js file). This same file, tells the user to commit messages using `npm run commit` if it fails do match a commit message, so, this dependency was missing anyway.