### PR TITLE
fix(runtime-core): add missing empty type vnode

### DIFF
--- a/packages/runtime-core/src/createRenderer.ts
+++ b/packages/runtime-core/src/createRenderer.ts
@@ -7,7 +7,8 @@ import {
   VNode,
   VNodeChildren,
   Suspense,
-  createVNode
+  createVNode,
+  Empty
 } from './vnode'
 import {
   ComponentInternalInstance,
@@ -195,6 +196,9 @@ export function createRenderer<
         break
       case Comment:
         processCommentNode(n1, n2, container, anchor)
+        break
+      case Empty:
+        processEmpty(n1, n2, container, anchor)
         break
       case Fragment:
         processFragment(
@@ -569,6 +573,18 @@ export function createRenderer<
           }
         }
       }
+    }
+  }
+
+  function processEmpty(
+    n1: HostVNode | null,
+    n2: HostVNode,
+    container: HostElement,
+    anchor: HostNode | null
+  ) {
+    const emptyAnchor = (n2.el = n1 ? n1.el : hostCreateComment(''))!
+    if (n1 == null) {
+      hostInsert(emptyAnchor, container, anchor)
     }
   }
 

--- a/packages/runtime-core/src/h.ts
+++ b/packages/runtime-core/src/h.ts
@@ -5,7 +5,8 @@ import {
   VNodeChildren,
   Fragment,
   Portal,
-  isVNode
+  isVNode,
+  Empty
 } from './vnode'
 import { isObject, isArray } from '@vue/shared'
 import { Ref } from '@vue/reactivity'
@@ -85,6 +86,9 @@ export function h(
   props?: RawProps | null,
   children?: RawChildren
 ): VNode
+
+// empty
+export function h(type: typeof Empty): VNode
 
 // keyed fragment
 export function h(type: typeof Fragment, children?: RawChildren): VNode

--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -19,7 +19,7 @@ export {
   createBlock
 } from './vnode'
 // VNode type symbols
-export { Text, Comment, Fragment, Portal, Suspense } from './vnode'
+export { Empty, Text, Comment, Fragment, Portal, Suspense } from './vnode'
 // VNode flags
 export { PublicShapeFlags as ShapeFlags } from './shapeFlags'
 export { PublicPatchFlags as PatchFlags } from '@vue/shared'

--- a/packages/runtime-core/src/vnode.ts
+++ b/packages/runtime-core/src/vnode.ts
@@ -19,6 +19,7 @@ import { isReactive } from '@vue/reactivity'
 import { AppContext } from './apiApp'
 import { SuspenseBoundary } from './suspense'
 
+export const Empty = __DEV__ ? Symbol('Empty') : Symbol()
 export const Fragment = __DEV__ ? Symbol('Fragment') : Symbol()
 export const Text = __DEV__ ? Symbol('Text') : Symbol()
 export const Comment = __DEV__ ? Symbol('Empty') : Symbol()
@@ -28,6 +29,7 @@ export const Suspense = __DEV__ ? Symbol('Suspense') : Symbol()
 export type VNodeTypes =
   | string
   | Component
+  | typeof Empty
   | typeof Fragment
   | typeof Portal
   | typeof Text


### PR DESCRIPTION
Some transforms will generate a vnode with type `Empty` (e.g., `v-if`), and this will make renderer throw error.

```js
{
  // error if condition falsy.
  template: `<div v-if='condition'>content</div>`
}
```