### PR TITLE
fix(compiler-core): fix codegen's comment render error

### DIFF
--- a/packages/compiler-core/src/codegen.ts
+++ b/packages/compiler-core/src/codegen.ts
@@ -211,6 +211,7 @@ export function generate(
         // to provide the helper here.
         if (ast.hoists.length) {
           push(`const _${helperNameMap[CREATE_VNODE]} = Vue.createVNode\n`)
+          push(`const _${helperNameMap[COMMENT]} = Vue.Comment\n`)
         }
       }
     }
@@ -484,7 +485,7 @@ function genComment(node: CommentNode, context: CodegenContext) {
   if (__DEV__) {
     const { push, helper } = context
     push(
-      `${helper(CREATE_VNODE)}(${helper(COMMENT)}, 0, ${JSON.stringify(
+      `${helper(CREATE_VNODE)}(${helper(COMMENT)}, void 0, ${JSON.stringify(
         node.content
       )})`,
       node


### PR DESCRIPTION
When the template contains html comment, the generated code will be error to render. For example,

```html
<div><span><!-- comment --> content</span></div>
```

the generated code in browser is:

```js
const _Vue = Vue
const _createVNode = Vue.createVNode

const _hoisted_1 = _createVNode("span", null, [
  // 1. the second argument isn't correct
  // 2. `_Comment` cannot be found
  _createVNode(_Comment, 0, "comment"),
  " content"
])

return function render() {
  with (this) {
    const { createVNode: _createVNode, Comment: _Comment, createBlock: _createBlock, openBlock: _openBlock } = _Vue
    
    return (_openBlock(), _createBlock("div", null, [
      _hoisted_1
    ]))
  }
}
```

The above code results in two types of error:

1. the arguments in `createVNode` are not correct.
2. `_Comment` cannot be found.