### PR TITLE
Enable prettier for vscode formatting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,17 @@
 {
+  // Use the project's typescript version
   "typescript.tsdk": "node_modules/typescript/lib",
-  "cSpell.enabledLanguageIds": [
-    "markdown",
-    "plaintext",
-    "text",
-    "yml"
-  ]
+
+  "cSpell.enabledLanguageIds": ["markdown", "plaintext", "text", "yml"],
+
+  // Use prettier to format typescript, javascript and JSON files
+  "[typescript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+	"[javascript]": {
+		"editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+	"[json]": {
+		"editor.defaultFormatter": "esbenp.prettier-vscode"
+	},
 }


### PR DESCRIPTION
By default, VSCode uses its own formatting tool to format javascript and typescript files. These changes force VSCode to use Prettier.

This is especially useful for devs who have already selected VSCode's formatting tool as their default tool.