### PR TITLE
fix(v-model): array checkbox

### DIFF
--- a/packages/runtime-dom/src/directives/vModel.ts
+++ b/packages/runtime-dom/src/directives/vModel.ts
@@ -84,7 +84,7 @@ export const vModelCheckbox: Directive<HTMLInputElement> = {
         if (i > -1) {
           assign([...modelValue.slice(0, i), ...modelValue.slice(i + 1)])
         } else {
-          assign(modelValue.concat(elementValue))
+          assign(modelValue.concat([elementValue]))
         }
       } else {
         assign(el.checked)


### PR DESCRIPTION
`modelValue` should concat `Array`.

contrast:
https://github.com/vuejs/vue/blob/d7d8ff06b70cf1a2345e3839c503fdb08d75ba49/src/platforms/web/compiler/directives/model.js#L91