### PR TITLE
feat(runtime-test): serialize void tags as self-closing

### DIFF
--- a/packages/runtime-test/__tests__/testRuntime.spec.ts
+++ b/packages/runtime-test/__tests__/testRuntime.spec.ts
@@ -128,14 +128,20 @@ describe('test renderer', () => {
           {
             id: 'test'
           },
-          [h('span', 'foo'), 'hello', h('br')]
+          [
+            h('span', 'foo'),
+            'hello',
+            h('br', {
+              id: 'br'
+            })
+          ]
         )
       }
     }
     const root = nodeOps.createElement('div')
     render(h(App), root)
     expect(serialize(root)).toEqual(
-      `<div><div id="test"><span>foo</span>hello<br/></div></div>`
+      `<div><div id="test"><span>foo</span>hello<br id="br"/></div></div>`
     )
     // indented output
     expect(serialize(root, 2)).toEqual(
@@ -145,7 +151,7 @@ describe('test renderer', () => {
       foo
     </span>
     hello
-    <br/>
+    <br id="br"/>
   </div>
 </div>`
     )

--- a/packages/runtime-test/__tests__/testRuntime.spec.ts
+++ b/packages/runtime-test/__tests__/testRuntime.spec.ts
@@ -128,14 +128,14 @@ describe('test renderer', () => {
           {
             id: 'test'
           },
-          [h('span', 'foo'), 'hello']
+          [h('span', 'foo'), 'hello', h('br')]
         )
       }
     }
     const root = nodeOps.createElement('div')
     render(h(App), root)
     expect(serialize(root)).toEqual(
-      `<div><div id="test"><span>foo</span>hello</div></div>`
+      `<div><div id="test"><span>foo</span>hello<br/></div></div>`
     )
     // indented output
     expect(serialize(root, 2)).toEqual(
@@ -145,6 +145,7 @@ describe('test renderer', () => {
       foo
     </span>
     hello
+    <br/>
   </div>
 </div>`
     )

--- a/packages/runtime-test/src/serialize.ts
+++ b/packages/runtime-test/src/serialize.ts
@@ -32,6 +32,25 @@ export function serializeInner(
     : ``
 }
 
+const voidTags = [
+  'area',
+  'base',
+  'br',
+  'col',
+  'command',
+  'embed',
+  'hr',
+  'img',
+  'input',
+  'keygen',
+  'link',
+  'meta',
+  'param',
+  'source',
+  'track',
+  'wbr'
+]
+
 function serializeElement(
   node: TestElement,
   indent: number,
@@ -45,6 +64,9 @@ function serializeElement(
     .filter(_ => _)
     .join(' ')
   const padding = indent ? ` `.repeat(indent).repeat(depth) : ``
+  if (voidTags.includes(node.tag)) {
+    return `${padding}<${node.tag}${props ? ` ${props}` : ``}/>`
+  }
   return (
     `${padding}<${node.tag}${props ? ` ${props}` : ``}>` +
     `${serializeInner(node, indent, depth)}` +


### PR DESCRIPTION
Void tags list is from HTML 5 specs.