### PR TITLE
chore: fix typo in runtime-core/__tests__/errorHandling.spec.ts

### DIFF
--- a/packages/runtime-core/__tests__/errorHandling.spec.ts
+++ b/packages/runtime-core/__tests__/errorHandling.spec.ts
@@ -365,8 +365,8 @@ describe('error handling', () => {
 
     const onError = jest.spyOn(console, 'error')
     onError.mockImplementation(() => {})
-    const groupCollpased = jest.spyOn(console, 'groupCollapsed')
-    groupCollpased.mockImplementation(() => {})
+    const groupCollapsed = jest.spyOn(console, 'groupCollapsed')
+    groupCollapsed.mockImplementation(() => {})
     const log = jest.spyOn(console, 'log')
     log.mockImplementation(() => {})
 
@@ -397,7 +397,7 @@ describe('error handling', () => {
     expect(onError).toHaveBeenCalledWith(err)
 
     onError.mockRestore()
-    groupCollpased.mockRestore()
+    groupCollapsed.mockRestore()
     log.mockRestore()
     process.env.NODE_ENV = 'test'
   })


### PR DESCRIPTION
typo fix : groupCollpased renamed to groupCollapsed

@znck 