### PR TITLE
chore: use `name` const consistently

### DIFF
--- a/packages/compiler-core/src/transforms/transformElement.ts
+++ b/packages/compiler-core/src/transforms/transformElement.ts
@@ -192,7 +192,7 @@ export function buildProps(
         } else if (name === 'style') {
           hasStyleBinding = true
         } else if (name !== 'key') {
-          dynamicPropNames.push(key.content)
+          dynamicPropNames.push(name)
         }
       }
     } else {


### PR DESCRIPTION
When analyzing the patch flag, we assign `key.content` to `name` variable and use it on all if-else branches except the last one.