### PR TITLE
Revert "style(runtime-core): remove useless else"

### DIFF
--- a/packages/runtime-core/src/suspense.ts
+++ b/packages/runtime-core/src/suspense.ts
@@ -68,10 +68,10 @@ export function normalizeSuspenseChildren(
       content: normalizeVNode(isFunction(d) ? d() : d),
       fallback: normalizeVNode(isFunction(fallback) ? fallback() : fallback)
     }
-  }
-
-  return {
-    content: normalizeVNode(children as VNodeChild),
-    fallback: normalizeVNode(null)
+  } else {
+    return {
+      content: normalizeVNode(children as VNodeChild),
+      fallback: normalizeVNode(null)
+    }
   }
 }


### PR DESCRIPTION
Reverts vuejs/vue-next#245.

The `else` signifies the branch relationship so that we don't need to read the content of the first branch to realize it returns early.