### PR TITLE
refactor(runtime-core): add `isIterableSource`

### DIFF
--- a/packages/runtime-core/src/helpers/renderList.ts
+++ b/packages/runtime-core/src/helpers/renderList.ts
@@ -1,32 +1,28 @@
 import { VNodeChild } from '../vnode'
 import { isArray, isString, isObject } from '@vue/shared'
 
+const isIterable = (object: any) =>
+  isArray(object) ||
+  isString(object) ||
+  (isObject(object) && object[Symbol.iterator as any])
+
 export function renderList(
   source: any,
   renderItem: (value: any, key: string | number, index?: number) => VNodeChild
 ): VNodeChild[] {
   let ret: VNodeChild[] = []
-  if (isArray(source) || isString(source)) {
-    for (let i = 0, l = source.length; i < l; i++) {
-      ret.push(renderItem(source[i], i))
-    }
+  if (isIterable(source)) {
+    ret = Array.from(source as Iterable<any>, renderItem)
   } else if (typeof source === 'number') {
     for (let i = 0; i < source; i++) {
       ret.push(renderItem(i + 1, i))
     }
   } else if (isObject(source)) {
-    if (source[Symbol.iterator as any]) {
-      ret = Array.from(
-        source as Iterable<any>, 
-        renderItem
-      )
-    } else {
-      const keys = Object.keys(source)
-      ret = new Array(keys.length)
-      for (let i = 0, l = keys.length; i < l; i++) {
-        const key = keys[i]
-        ret[i] = renderItem(source[key], key, i)
-      }
+    const keys = Object.keys(source)
+    ret = new Array(keys.length)
+    for (let i = 0, l = keys.length; i < l; i++) {
+      const key = keys[i]
+      ret[i] = renderItem(source[key], key, i)
     }
   }
   return ret

--- a/packages/runtime-core/src/helpers/renderList.ts
+++ b/packages/runtime-core/src/helpers/renderList.ts
@@ -1,17 +1,17 @@
 import { VNodeChild } from '../vnode'
 import { isArray, isString, isObject } from '@vue/shared'
 
-const isIterable = (object: any): boolean =>
-  isArray(object) ||
-  isString(object) ||
-  (isObject(object) && object[Symbol.iterator as any])
+const isIterableSource = (source: any): boolean =>
+  isArray(source) ||
+  isString(source) ||
+  (isObject(source) && source[Symbol.iterator as any])
 
 export function renderList(
   source: any,
   renderItem: (value: any, key: string | number, index?: number) => VNodeChild
 ): VNodeChild[] {
   let ret: VNodeChild[] = []
-  if (isIterable(source)) {
+  if (isIterableSource(source)) {
     ret = Array.from(source as Iterable<any>, renderItem)
   } else if (typeof source === 'number') {
     for (let i = 0; i < source; i++) {

--- a/packages/runtime-core/src/helpers/renderList.ts
+++ b/packages/runtime-core/src/helpers/renderList.ts
@@ -1,7 +1,7 @@
 import { VNodeChild } from '../vnode'
 import { isArray, isString, isObject } from '@vue/shared'
 
-const isIterable = (object: any) =>
+const isIterable = (object: any): boolean =>
   isArray(object) ||
   isString(object) ||
   (isObject(object) && object[Symbol.iterator as any])


### PR DESCRIPTION
This merge `isArray/isString` and `iterable` into one branch.

`Array/String` also Iterable, but `isArray` and `isString` should be faster, so we should keep it