### PR TITLE
ci: use `--frozen-lockfile` when install

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
           - v1-dependencies-{{ checksum "yarn.lock" }}
           - v1-dependencies-
 
-      - run: yarn install
+      - run: yarn --frozen-lockfile
 
       - save_cache:
           paths:


### PR DESCRIPTION
Should use `--frozen-lockfile` on ci run, prevent lock file update & dependencies version difference.

~https://github.com/vuejs/vue-next/pull/246#discussion_r334264415~

Update: not version problem, but still should frozen