### PR TITLE
feat(instanceWatch): watch nested value by path

### DIFF
--- a/packages/runtime-core/__tests__/componentProxy.spec.ts
+++ b/packages/runtime-core/__tests__/componentProxy.spec.ts
@@ -2,7 +2,8 @@ import {
   createApp,
   getCurrentInstance,
   nodeOps,
-  mockWarn
+  mockWarn,
+  nextTick
 } from '@vue/runtime-test'
 import { ComponentInternalInstance } from '../src/component'
 
@@ -128,5 +129,39 @@ describe('component: proxy', () => {
     instanceProxy.foo = 1
     expect(instanceProxy.foo).toBe(1)
     expect(instance!.user.foo).toBe(1)
+  })
+
+  it('watch', async () => {
+    const foobar = jest.fn()
+
+    const app = createApp()
+    let instanceProxy: any
+    const Comp = {
+      data() {
+        return {
+          foo: {
+            bar: 1,
+            baz: 2
+          }
+        }
+      },
+      mounted() {
+        instanceProxy = this
+      },
+      render() {
+        return null
+      }
+    }
+    app.mount(Comp, nodeOps.createElement('div'))
+    instanceProxy.$watch('foo.bar', foobar)
+
+    instanceProxy.foo.bar++
+    await nextTick()
+    expect(foobar).toHaveBeenCalledTimes(1)
+    expect(foobar.mock.calls[0][0]).toBe(2)
+
+    instanceProxy.foo.baz++
+    await nextTick()
+    expect(foobar).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/runtime-core/src/apiWatch.ts
+++ b/packages/runtime-core/src/apiWatch.ts
@@ -203,6 +203,24 @@ function doWatch(
   }
 }
 
+function getValueByPath<T>(
+  object: any,
+  path: string,
+  fallback?: T
+): T | undefined {
+  const pathSegments = path.split('.')
+
+  for (let i = 0; i < pathSegments.length; i++) {
+    if (object[pathSegments[i]]) {
+      object = object[pathSegments[i]]
+    } else {
+      return fallback
+    }
+  }
+
+  return object
+}
+
 // this.$watch
 export function instanceWatch(
   this: ComponentInternalInstance,
@@ -211,7 +229,9 @@ export function instanceWatch(
   options?: WatchOptions
 ): StopHandle {
   const ctx = this.renderProxy!
-  const getter = isString(source) ? () => ctx[source] : source.bind(ctx)
+  const getter = isString(source)
+    ? () => getValueByPath(ctx, source)
+    : source.bind(ctx)
   const stop = watch(getter, cb.bind(ctx), options)
   onBeforeUnmount(stop, this)
   return stop


### PR DESCRIPTION
Reason: backwards compatibility with v2 (https://vuejs.org/v2/api/#vm-watch)