### PR TITLE
refactor(scheduler): replace try catch with callWithErrorHandling

### DIFF
--- a/packages/runtime-core/src/scheduler.ts
+++ b/packages/runtime-core/src/scheduler.ts
@@ -1,4 +1,4 @@
-import { handleError, ErrorCodes } from './errorHandling'
+import { ErrorCodes, callWithErrorHandling } from './errorHandling'
 
 const queue: Function[] = []
 const postFlushCbs: Function[] = []
@@ -69,11 +69,7 @@ function flushJobs(seenJobs?: JobCountMap) {
         }
       }
     }
-    try {
-      job()
-    } catch (err) {
-      handleError(err, null, ErrorCodes.SCHEDULER)
-    }
+    callWithErrorHandling(job, null, ErrorCodes.SCHEDULER)
   }
   flushPostFlushCbs()
   isFlushing = false


### PR DESCRIPTION
I found all the `trycatch` under packages and found that only this place can be replaced with`callWithErrorHandling`