### PR TITLE
feat(vModel): add support for .trim and .number modifiers

### DIFF
--- a/packages/compiler-core/src/transforms/vModel.ts
+++ b/packages/compiler-core/src/transforms/vModel.ts
@@ -38,6 +38,12 @@ export const transformModel: DirectiveTransform = (dir, node, context) => {
         ])
     : createSimpleExpression('onUpdate:modelValue', true)
 
+  const value = dir.modifiers.includes('number')
+    ? `Number($event)`
+    : dir.modifiers.includes('trim')
+      ? `$event.trim()`
+      : `$event`
+
   const props = [
     createObjectProperty(propName, dir.exp!),
     createObjectProperty(
@@ -45,7 +51,7 @@ export const transformModel: DirectiveTransform = (dir, node, context) => {
       createCompoundExpression([
         `$event => (`,
         ...(exp.type === NodeTypes.SIMPLE_EXPRESSION ? [exp] : exp.children),
-        ` = $event)`
+        ` = ${value})`
       ])
     )
   ]


### PR DESCRIPTION
Add `.trim` and `.number` modifiers support as described in v2 docs:
https://vuejs.org/v2/guide/forms.html#number
https://vuejs.org/v2/guide/forms.html#trim