### PR TITLE
types(ref): improve UnwrapRef types

### DIFF
--- a/packages/reactivity/src/computed.ts
+++ b/packages/reactivity/src/computed.ts
@@ -7,7 +7,7 @@ export interface ComputedRef<T> extends WritableComputedRef<T> {
 }
 
 export interface WritableComputedRef<T> extends Ref<T> {
-  readonly effect: ReactiveEffect
+  readonly effect: ReactiveEffect<T>
 }
 
 export interface WritableComputedOptions<T> {

--- a/packages/reactivity/src/computed.ts
+++ b/packages/reactivity/src/computed.ts
@@ -7,7 +7,7 @@ export interface ComputedRef<T> extends WritableComputedRef<T> {
 }
 
 export interface WritableComputedRef<T> extends Ref<T> {
-  readonly effect: ReactiveEffect<T>
+  readonly effect: ReactiveEffect
 }
 
 export interface WritableComputedOptions<T> {

--- a/packages/reactivity/src/ref.ts
+++ b/packages/reactivity/src/ref.ts
@@ -72,20 +72,23 @@ type BailTypes =
 
 // Recursively unwraps nested value bindings.
 export type UnwrapRef<T> = {
-  computedRef: T extends ComputedRef<infer V> ? UnwrapRef<V> : T
+  cRef: T extends ComputedRef<infer V> ? UnwrapRef<V> : T
+  wcRef: T extends WritableComputedRef<infer V> ? UnwrapRef<V> : T
   ref: T extends Ref<infer V> ? UnwrapRef<V> : T
   array: T extends Array<infer V> ? Array<UnwrapRef<V>> : T
   object: { [K in keyof T]: UnwrapRef<T[K]> }
   stop: T
 }[T extends ComputedRef<any>
-  ? 'computedRef'
-  : T extends Ref
-    ? 'ref'
-    : T extends Array<any>
-      ? 'array'
-      : T extends BailTypes
-        ? 'stop' // bail out on types that shouldn't be unwrapped
-        : T extends object ? 'object' : 'stop']
+  ? 'cRef'
+  : T extends WritableComputedRef<any>
+    ? 'wcRef'
+    : T extends Ref
+      ? 'ref'
+      : T extends Array<any>
+        ? 'array'
+        : T extends BailTypes
+          ? 'stop' // bail out on types that shouldn't be unwrapped
+          : T extends object ? 'object' : 'stop']
 
 // only unwrap nested ref
 export type UnwrapNestedRefs<T> = T extends Ref ? T : UnwrapRef<T>

--- a/packages/reactivity/src/ref.ts
+++ b/packages/reactivity/src/ref.ts
@@ -2,6 +2,7 @@ import { track, trigger } from './effect'
 import { OperationTypes } from './operations'
 import { isObject } from '@vue/shared'
 import { reactive } from './reactive'
+import { ComputedRef } from './computed'
 
 export const refSymbol = Symbol(__DEV__ ? 'refSymbol' : '')
 
@@ -71,17 +72,20 @@ type BailTypes =
 
 // Recursively unwraps nested value bindings.
 export type UnwrapRef<T> = {
+  computedRef: T extends ComputedRef<infer V> ? UnwrapRef<V> : T
   ref: T extends Ref<infer V> ? UnwrapRef<V> : T
   array: T extends Array<infer V> ? Array<UnwrapRef<V>> : T
   object: { [K in keyof T]: UnwrapRef<T[K]> }
   stop: T
-}[T extends Ref
-  ? 'ref'
-  : T extends Array<any>
-    ? 'array'
-    : T extends BailTypes
-      ? 'stop' // bail out on types that shouldn't be unwrapped
-      : T extends object ? 'object' : 'stop']
+}[T extends ComputedRef<any>
+  ? 'computedRef'
+  : T extends Ref
+    ? 'ref'
+    : T extends Array<any>
+      ? 'array'
+      : T extends BailTypes
+        ? 'stop' // bail out on types that shouldn't be unwrapped
+        : T extends object ? 'object' : 'stop']
 
 // only unwrap nested ref
 export type UnwrapNestedRefs<T> = T extends Ref ? T : UnwrapRef<T>

--- a/packages/reactivity/src/ref.ts
+++ b/packages/reactivity/src/ref.ts
@@ -2,7 +2,7 @@ import { track, trigger } from './effect'
 import { OperationTypes } from './operations'
 import { isObject } from '@vue/shared'
 import { reactive } from './reactive'
-import { ComputedRef } from './computed'
+import { ComputedRef, WritableComputedRef } from './computed'
 
 export const refSymbol = Symbol(__DEV__ ? 'refSymbol' : '')
 


### PR DESCRIPTION
``` js
const a = ref(0)
const b = computed(() => a.value)
const c = reactive({ b }) // The type of C is unknow, but it should actually be number
```
![image](https://user-images.githubusercontent.com/16385416/66718307-12e17480-ee15-11e9-8ae2-97ce5bbc3769.png)
![image](https://user-images.githubusercontent.com/16385416/66718334-65229580-ee15-11e9-930b-79e6f0de5d54.png)
