### PR TITLE
fix(codegen): do not extract createVNode and Comment after hoist

### DIFF
--- a/packages/compiler-core/__tests__/transforms/__snapshots__/hoistStatic.spec.ts.snap
+++ b/packages/compiler-core/__tests__/transforms/__snapshots__/hoistStatic.spec.ts.snap
@@ -8,7 +8,7 @@ const _hoisted_1 = _createVNode(\\"div\\", { key: \\"foo\\" })
 
 return function render() {
   with (this) {
-    const { createVNode: _createVNode, createBlock: _createBlock, openBlock: _openBlock } = _Vue
+    const { createBlock: _createBlock, openBlock: _openBlock } = _Vue
     
     return (_openBlock(), _createBlock(\\"div\\", null, [
       _hoisted_1
@@ -28,7 +28,7 @@ const _hoisted_1 = _createVNode(\\"p\\", null, [
 
 return function render() {
   with (this) {
-    const { createVNode: _createVNode, createBlock: _createBlock, openBlock: _openBlock } = _Vue
+    const { createBlock: _createBlock, openBlock: _openBlock } = _Vue
     
     return (_openBlock(), _createBlock(\\"div\\", null, [
       _hoisted_1
@@ -48,7 +48,7 @@ const _hoisted_1 = _createVNode(\\"div\\", null, [
 
 return function render() {
   with (this) {
-    const { createVNode: _createVNode, Comment: _Comment, createBlock: _createBlock, openBlock: _openBlock } = _Vue
+    const { createBlock: _createBlock, openBlock: _openBlock } = _Vue
     
     return (_openBlock(), _createBlock(\\"div\\", null, [
       _hoisted_1
@@ -66,7 +66,7 @@ const _hoisted_2 = _createVNode(\\"div\\")
 
 return function render() {
   with (this) {
-    const { createVNode: _createVNode, createBlock: _createBlock, openBlock: _openBlock } = _Vue
+    const { createBlock: _createBlock, openBlock: _openBlock } = _Vue
     
     return (_openBlock(), _createBlock(\\"div\\", null, [
       _hoisted_1,
@@ -84,7 +84,7 @@ const _hoisted_1 = _createVNode(\\"span\\", { class: \\"inline\\" }, \\"hello\\"
 
 return function render() {
   with (this) {
-    const { createVNode: _createVNode, createBlock: _createBlock, openBlock: _openBlock } = _Vue
+    const { createBlock: _createBlock, openBlock: _openBlock } = _Vue
     
     return (_openBlock(), _createBlock(\\"div\\", null, [
       _hoisted_1
@@ -101,7 +101,7 @@ const _hoisted_1 = { id: \\"foo\\" }
 
 return function render() {
   with (this) {
-    const { createVNode: _createVNode, applyDirectives: _applyDirectives, resolveDirective: _resolveDirective, createBlock: _createBlock, openBlock: _openBlock } = _Vue
+    const { applyDirectives: _applyDirectives, resolveDirective: _resolveDirective, createBlock: _createBlock, openBlock: _openBlock } = _Vue
     
     const _directive_foo = _resolveDirective(\\"foo\\")
     
@@ -122,7 +122,7 @@ const _hoisted_1 = { id: \\"foo\\" }
 
 return function render() {
   with (this) {
-    const { toString: _toString, createVNode: _createVNode, createBlock: _createBlock, openBlock: _openBlock } = _Vue
+    const { toString: _toString, createBlock: _createBlock, openBlock: _openBlock } = _Vue
     
     return (_openBlock(), _createBlock(\\"div\\", null, [
       _createVNode(\\"div\\", _hoisted_1, _toString(hello), 1 /* TEXT */)
@@ -139,7 +139,7 @@ const _hoisted_1 = { id: \\"foo\\" }
 
 return function render() {
   with (this) {
-    const { resolveComponent: _resolveComponent, createVNode: _createVNode, createBlock: _createBlock, openBlock: _openBlock } = _Vue
+    const { resolveComponent: _resolveComponent, createBlock: _createBlock, openBlock: _openBlock } = _Vue
     
     const _component_Comp = _resolveComponent(\\"Comp\\")
     
@@ -217,7 +217,7 @@ const _hoisted_2 = _createVNode(\\"span\\")
 
 return function render() {
   with (this) {
-    const { renderList: _renderList, openBlock: _openBlock, createBlock: _createBlock, Fragment: _Fragment, createVNode: _createVNode } = _Vue
+    const { renderList: _renderList, openBlock: _openBlock, createBlock: _createBlock, Fragment: _Fragment } = _Vue
     
     return (_openBlock(), _createBlock(\\"div\\", null, [
       (_openBlock(), _createBlock(_Fragment, null, _renderList(list, (i) => {
@@ -243,7 +243,7 @@ const _hoisted_2 = _createVNode(\\"span\\")
 
 return function render() {
   with (this) {
-    const { openBlock: _openBlock, createVNode: _createVNode, createBlock: _createBlock, Comment: _Comment } = _Vue
+    const { openBlock: _openBlock, createBlock: _createBlock } = _Vue
     
     return (_openBlock(), _createBlock(\\"div\\", null, [
       (_openBlock(), ok

--- a/packages/compiler-core/src/codegen.ts
+++ b/packages/compiler-core/src/codegen.ts
@@ -190,7 +190,7 @@ export function generate(
     deindent,
     newline
   } = context
-  const hasHelpers = ast.helpers.length > 0
+  let hasHelpers = ast.helpers.length > 0
   const useWithBlock = !prefixIdentifiers && mode !== 'module'
 
   // preambles
@@ -211,9 +211,12 @@ export function generate(
         // to provide the helper here.
         if (ast.hoists.length) {
           push(`const _${helperNameMap[CREATE_VNODE]} = Vue.createVNode\n`)
+          ast.helpers = ast.helpers.filter(h => h !== CREATE_VNODE)
           if (ast.helpers.includes(COMMENT)) {
             push(`const _${helperNameMap[COMMENT]} = Vue.Comment\n`)
+            ast.helpers = ast.helpers.filter(h => h !== COMMENT)
           }
+          hasHelpers = ast.helpers.length > 0
         }
       }
     }

--- a/packages/compiler-dom/__tests__/__snapshots__/index.spec.ts.snap
+++ b/packages/compiler-dom/__tests__/__snapshots__/index.spec.ts.snap
@@ -8,7 +8,7 @@ const _hoisted_1 = {}
 
 return function render() {
   with (this) {
-    const { createVNode: _createVNode, createBlock: _createBlock, Fragment: _Fragment, openBlock: _openBlock } = _Vue
+    const { createBlock: _createBlock, Fragment: _Fragment, openBlock: _openBlock } = _Vue
     
     return (_openBlock(), _createBlock(_Fragment, null, [
       _createVNode(\\"div\\", { textContent: text }, null, 8 /* PROPS */, [\\"textContent\\"]),


### PR DESCRIPTION
Codegen was creating invalid code (redefinition of const) in function mode with hoists. Example of such code:
```js
const _Vue = Vue
// _createVNode is extracted 👇 here
const _createVNode = Vue.createVNode

const _hoisted_1 = _createVNode("span", null, "hello world")

return function render() {
  with (this) {
    // It's extracted again 👇 here
    const { createVNode: _createVNode, createBlock: _createBlock, openBlock: _openBlock } = _Vue
    
    return (_openBlock(), _createBlock("div", null, [
      _hoisted_1
    ]))
  }
}

// Check the console for the AST
```
P.S. it's created from this code:
```vue
<div>
  <span>hello world</span>
</div>
```
with these options:
![image](https://user-images.githubusercontent.com/19504461/66718980-a05f9d00-edf2-11e9-8af3-daa42b7b5f05.png)
