### PR TITLE
feat(compiler-core): more hoisting optimizations

### DIFF
--- a/packages/compiler-core/__tests__/__snapshots__/parse.spec.ts.snap
+++ b/packages/compiler-core/__tests__/__snapshots__/parse.spec.ts.snap
@@ -3986,6 +3986,7 @@ Object {
         Object {
           "content": Object {
             "content": "a < b",
+            "hasPrefixedIdentifier": true,
             "isStatic": false,
             "loc": Object {
               "end": Object {
@@ -7151,6 +7152,7 @@ Object {
         Object {
           "content": Object {
             "content": "'</div>'",
+            "hasPrefixedIdentifier": true,
             "isStatic": false,
             "loc": Object {
               "end": Object {
@@ -7320,6 +7322,7 @@ Object {
         Object {
           "arg": Object {
             "content": "se",
+            "hasPrefixedIdentifier": true,
             "isStatic": false,
             "loc": Object {
               "end": Object {
@@ -7640,6 +7643,7 @@ Object {
     Object {
       "content": Object {
         "content": "",
+        "hasPrefixedIdentifier": true,
         "isStatic": false,
         "loc": Object {
           "end": Object {
@@ -7798,6 +7802,7 @@ Object {
         Object {
           "arg": Object {
             "content": "class",
+            "hasPrefixedIdentifier": false,
             "isStatic": true,
             "loc": Object {
               "end": Object {
@@ -7816,6 +7821,7 @@ Object {
           },
           "exp": Object {
             "content": "{ some: condition }",
+            "hasPrefixedIdentifier": true,
             "isStatic": false,
             "loc": Object {
               "end": Object {
@@ -7876,6 +7882,7 @@ Object {
         Object {
           "arg": Object {
             "content": "style",
+            "hasPrefixedIdentifier": false,
             "isStatic": true,
             "loc": Object {
               "end": Object {
@@ -7894,6 +7901,7 @@ Object {
           },
           "exp": Object {
             "content": "{ color: 'red' }",
+            "hasPrefixedIdentifier": true,
             "isStatic": false,
             "loc": Object {
               "end": Object {
@@ -7983,6 +7991,7 @@ Object {
             Object {
               "arg": Object {
                 "content": "style",
+                "hasPrefixedIdentifier": false,
                 "isStatic": true,
                 "loc": Object {
                   "end": Object {
@@ -8001,6 +8010,7 @@ Object {
               },
               "exp": Object {
                 "content": "{ color: 'red' }",
+                "hasPrefixedIdentifier": true,
                 "isStatic": false,
                 "loc": Object {
                   "end": Object {
@@ -8080,6 +8090,7 @@ Object {
         Object {
           "arg": Object {
             "content": "class",
+            "hasPrefixedIdentifier": false,
             "isStatic": true,
             "loc": Object {
               "end": Object {
@@ -8098,6 +8109,7 @@ Object {
           },
           "exp": Object {
             "content": "{ some: condition }",
+            "hasPrefixedIdentifier": true,
             "isStatic": false,
             "loc": Object {
               "end": Object {

--- a/packages/compiler-core/__tests__/__snapshots__/parse.spec.ts.snap
+++ b/packages/compiler-core/__tests__/__snapshots__/parse.spec.ts.snap
@@ -3986,7 +3986,7 @@ Object {
         Object {
           "content": Object {
             "content": "a < b",
-            "hasPrefixedIdentifier": true,
+            "isConstant": false,
             "isStatic": false,
             "loc": Object {
               "end": Object {
@@ -7152,7 +7152,7 @@ Object {
         Object {
           "content": Object {
             "content": "'</div>'",
-            "hasPrefixedIdentifier": true,
+            "isConstant": false,
             "isStatic": false,
             "loc": Object {
               "end": Object {
@@ -7322,7 +7322,7 @@ Object {
         Object {
           "arg": Object {
             "content": "se",
-            "hasPrefixedIdentifier": true,
+            "isConstant": false,
             "isStatic": false,
             "loc": Object {
               "end": Object {
@@ -7643,7 +7643,7 @@ Object {
     Object {
       "content": Object {
         "content": "",
-        "hasPrefixedIdentifier": true,
+        "isConstant": false,
         "isStatic": false,
         "loc": Object {
           "end": Object {
@@ -7802,7 +7802,7 @@ Object {
         Object {
           "arg": Object {
             "content": "class",
-            "hasPrefixedIdentifier": false,
+            "isConstant": true,
             "isStatic": true,
             "loc": Object {
               "end": Object {
@@ -7821,7 +7821,7 @@ Object {
           },
           "exp": Object {
             "content": "{ some: condition }",
-            "hasPrefixedIdentifier": true,
+            "isConstant": false,
             "isStatic": false,
             "loc": Object {
               "end": Object {
@@ -7882,7 +7882,7 @@ Object {
         Object {
           "arg": Object {
             "content": "style",
-            "hasPrefixedIdentifier": false,
+            "isConstant": true,
             "isStatic": true,
             "loc": Object {
               "end": Object {
@@ -7901,7 +7901,7 @@ Object {
           },
           "exp": Object {
             "content": "{ color: 'red' }",
-            "hasPrefixedIdentifier": true,
+            "isConstant": false,
             "isStatic": false,
             "loc": Object {
               "end": Object {
@@ -7991,7 +7991,7 @@ Object {
             Object {
               "arg": Object {
                 "content": "style",
-                "hasPrefixedIdentifier": false,
+                "isConstant": true,
                 "isStatic": true,
                 "loc": Object {
                   "end": Object {
@@ -8010,7 +8010,7 @@ Object {
               },
               "exp": Object {
                 "content": "{ color: 'red' }",
-                "hasPrefixedIdentifier": true,
+                "isConstant": false,
                 "isStatic": false,
                 "loc": Object {
                   "end": Object {
@@ -8090,7 +8090,7 @@ Object {
         Object {
           "arg": Object {
             "content": "class",
-            "hasPrefixedIdentifier": false,
+            "isConstant": true,
             "isStatic": true,
             "loc": Object {
               "end": Object {
@@ -8109,7 +8109,7 @@ Object {
           },
           "exp": Object {
             "content": "{ some: condition }",
-            "hasPrefixedIdentifier": true,
+            "isConstant": false,
             "isStatic": false,
             "loc": Object {
               "end": Object {

--- a/packages/compiler-core/__tests__/parse.spec.ts
+++ b/packages/compiler-core/__tests__/parse.spec.ts
@@ -298,6 +298,7 @@ describe('compiler: parse', () => {
           type: NodeTypes.SIMPLE_EXPRESSION,
           content: `message`,
           isStatic: false,
+          hasPrefixedIdentifier: true,
           loc: {
             start: { offset: 2, line: 1, column: 3 },
             end: { offset: 9, line: 1, column: 10 },
@@ -322,6 +323,7 @@ describe('compiler: parse', () => {
           type: NodeTypes.SIMPLE_EXPRESSION,
           content: `a<b`,
           isStatic: false,
+          hasPrefixedIdentifier: true,
           loc: {
             start: { offset: 3, line: 1, column: 4 },
             end: { offset: 6, line: 1, column: 7 },
@@ -347,6 +349,7 @@ describe('compiler: parse', () => {
           type: NodeTypes.SIMPLE_EXPRESSION,
           content: `a<b`,
           isStatic: false,
+          hasPrefixedIdentifier: true,
           loc: {
             start: { offset: 3, line: 1, column: 4 },
             end: { offset: 6, line: 1, column: 7 },
@@ -365,6 +368,7 @@ describe('compiler: parse', () => {
         content: {
           type: NodeTypes.SIMPLE_EXPRESSION,
           isStatic: false,
+          hasPrefixedIdentifier: true,
           content: 'c>d',
           loc: {
             start: { offset: 12, line: 1, column: 13 },
@@ -390,6 +394,8 @@ describe('compiler: parse', () => {
         content: {
           type: NodeTypes.SIMPLE_EXPRESSION,
           isStatic: false,
+          // The `hasPrefixedIdentifier` is the default value and will be determined in `transformExpression`.
+          hasPrefixedIdentifier: true,
           content: '"</div>"',
           loc: {
             start: { offset: 8, line: 1, column: 9 },
@@ -974,6 +980,7 @@ describe('compiler: parse', () => {
           type: NodeTypes.SIMPLE_EXPRESSION,
           content: 'a',
           isStatic: false,
+          hasPrefixedIdentifier: true,
           loc: {
             start: { offset: 11, line: 1, column: 12 },
             end: { offset: 12, line: 1, column: 13 },
@@ -999,6 +1006,7 @@ describe('compiler: parse', () => {
           type: NodeTypes.SIMPLE_EXPRESSION,
           content: 'click',
           isStatic: true,
+          hasPrefixedIdentifier: false,
 
           loc: {
             source: 'click',
@@ -1071,6 +1079,7 @@ describe('compiler: parse', () => {
           type: NodeTypes.SIMPLE_EXPRESSION,
           content: 'click',
           isStatic: true,
+          hasPrefixedIdentifier: false,
 
           loc: {
             source: 'click',
@@ -1107,6 +1116,7 @@ describe('compiler: parse', () => {
           type: NodeTypes.SIMPLE_EXPRESSION,
           content: 'a',
           isStatic: true,
+          hasPrefixedIdentifier: false,
 
           loc: {
             source: 'a',
@@ -1127,6 +1137,7 @@ describe('compiler: parse', () => {
           type: NodeTypes.SIMPLE_EXPRESSION,
           content: 'b',
           isStatic: false,
+          hasPrefixedIdentifier: true,
 
           loc: {
             start: { offset: 8, line: 1, column: 9 },
@@ -1153,6 +1164,7 @@ describe('compiler: parse', () => {
           type: NodeTypes.SIMPLE_EXPRESSION,
           content: 'a',
           isStatic: true,
+          hasPrefixedIdentifier: false,
 
           loc: {
             source: 'a',
@@ -1173,6 +1185,7 @@ describe('compiler: parse', () => {
           type: NodeTypes.SIMPLE_EXPRESSION,
           content: 'b',
           isStatic: false,
+          hasPrefixedIdentifier: true,
 
           loc: {
             start: { offset: 13, line: 1, column: 14 },
@@ -1199,6 +1212,7 @@ describe('compiler: parse', () => {
           type: NodeTypes.SIMPLE_EXPRESSION,
           content: 'a',
           isStatic: true,
+          hasPrefixedIdentifier: false,
 
           loc: {
             source: 'a',
@@ -1219,6 +1233,7 @@ describe('compiler: parse', () => {
           type: NodeTypes.SIMPLE_EXPRESSION,
           content: 'b',
           isStatic: false,
+          hasPrefixedIdentifier: true,
 
           loc: {
             start: { offset: 8, line: 1, column: 9 },
@@ -1245,6 +1260,7 @@ describe('compiler: parse', () => {
           type: NodeTypes.SIMPLE_EXPRESSION,
           content: 'a',
           isStatic: true,
+          hasPrefixedIdentifier: false,
 
           loc: {
             source: 'a',
@@ -1265,6 +1281,7 @@ describe('compiler: parse', () => {
           type: NodeTypes.SIMPLE_EXPRESSION,
           content: 'b',
           isStatic: false,
+          hasPrefixedIdentifier: true,
 
           loc: {
             start: { offset: 14, line: 1, column: 15 },
@@ -1291,6 +1308,7 @@ describe('compiler: parse', () => {
           type: NodeTypes.SIMPLE_EXPRESSION,
           content: 'a',
           isStatic: true,
+          hasPrefixedIdentifier: false,
           loc: {
             source: 'a',
             start: {
@@ -1310,6 +1328,8 @@ describe('compiler: parse', () => {
           type: NodeTypes.SIMPLE_EXPRESSION,
           content: '{ b }',
           isStatic: false,
+          // The `hasPrefixedIdentifier` is the default value and will be determined in transformExpression
+          hasPrefixedIdentifier: true,
           loc: {
             start: { offset: 10, line: 1, column: 11 },
             end: { offset: 15, line: 1, column: 16 },

--- a/packages/compiler-core/__tests__/parse.spec.ts
+++ b/packages/compiler-core/__tests__/parse.spec.ts
@@ -298,7 +298,7 @@ describe('compiler: parse', () => {
           type: NodeTypes.SIMPLE_EXPRESSION,
           content: `message`,
           isStatic: false,
-          hasPrefixedIdentifier: true,
+          isConstant: false,
           loc: {
             start: { offset: 2, line: 1, column: 3 },
             end: { offset: 9, line: 1, column: 10 },
@@ -323,7 +323,7 @@ describe('compiler: parse', () => {
           type: NodeTypes.SIMPLE_EXPRESSION,
           content: `a<b`,
           isStatic: false,
-          hasPrefixedIdentifier: true,
+          isConstant: false,
           loc: {
             start: { offset: 3, line: 1, column: 4 },
             end: { offset: 6, line: 1, column: 7 },
@@ -349,7 +349,7 @@ describe('compiler: parse', () => {
           type: NodeTypes.SIMPLE_EXPRESSION,
           content: `a<b`,
           isStatic: false,
-          hasPrefixedIdentifier: true,
+          isConstant: false,
           loc: {
             start: { offset: 3, line: 1, column: 4 },
             end: { offset: 6, line: 1, column: 7 },
@@ -368,7 +368,7 @@ describe('compiler: parse', () => {
         content: {
           type: NodeTypes.SIMPLE_EXPRESSION,
           isStatic: false,
-          hasPrefixedIdentifier: true,
+          isConstant: false,
           content: 'c>d',
           loc: {
             start: { offset: 12, line: 1, column: 13 },
@@ -394,8 +394,8 @@ describe('compiler: parse', () => {
         content: {
           type: NodeTypes.SIMPLE_EXPRESSION,
           isStatic: false,
-          // The `hasPrefixedIdentifier` is the default value and will be determined in `transformExpression`.
-          hasPrefixedIdentifier: true,
+          // The `isConstant` is the default value and will be determined in `transformExpression`.
+          isConstant: false,
           content: '"</div>"',
           loc: {
             start: { offset: 8, line: 1, column: 9 },
@@ -980,7 +980,7 @@ describe('compiler: parse', () => {
           type: NodeTypes.SIMPLE_EXPRESSION,
           content: 'a',
           isStatic: false,
-          hasPrefixedIdentifier: true,
+          isConstant: false,
           loc: {
             start: { offset: 11, line: 1, column: 12 },
             end: { offset: 12, line: 1, column: 13 },
@@ -1006,7 +1006,7 @@ describe('compiler: parse', () => {
           type: NodeTypes.SIMPLE_EXPRESSION,
           content: 'click',
           isStatic: true,
-          hasPrefixedIdentifier: false,
+          isConstant: true,
 
           loc: {
             source: 'click',
@@ -1079,7 +1079,7 @@ describe('compiler: parse', () => {
           type: NodeTypes.SIMPLE_EXPRESSION,
           content: 'click',
           isStatic: true,
-          hasPrefixedIdentifier: false,
+          isConstant: true,
 
           loc: {
             source: 'click',
@@ -1116,7 +1116,7 @@ describe('compiler: parse', () => {
           type: NodeTypes.SIMPLE_EXPRESSION,
           content: 'a',
           isStatic: true,
-          hasPrefixedIdentifier: false,
+          isConstant: true,
 
           loc: {
             source: 'a',
@@ -1137,7 +1137,7 @@ describe('compiler: parse', () => {
           type: NodeTypes.SIMPLE_EXPRESSION,
           content: 'b',
           isStatic: false,
-          hasPrefixedIdentifier: true,
+          isConstant: false,
 
           loc: {
             start: { offset: 8, line: 1, column: 9 },
@@ -1164,7 +1164,7 @@ describe('compiler: parse', () => {
           type: NodeTypes.SIMPLE_EXPRESSION,
           content: 'a',
           isStatic: true,
-          hasPrefixedIdentifier: false,
+          isConstant: true,
 
           loc: {
             source: 'a',
@@ -1185,7 +1185,7 @@ describe('compiler: parse', () => {
           type: NodeTypes.SIMPLE_EXPRESSION,
           content: 'b',
           isStatic: false,
-          hasPrefixedIdentifier: true,
+          isConstant: false,
 
           loc: {
             start: { offset: 13, line: 1, column: 14 },
@@ -1212,7 +1212,7 @@ describe('compiler: parse', () => {
           type: NodeTypes.SIMPLE_EXPRESSION,
           content: 'a',
           isStatic: true,
-          hasPrefixedIdentifier: false,
+          isConstant: true,
 
           loc: {
             source: 'a',
@@ -1233,7 +1233,7 @@ describe('compiler: parse', () => {
           type: NodeTypes.SIMPLE_EXPRESSION,
           content: 'b',
           isStatic: false,
-          hasPrefixedIdentifier: true,
+          isConstant: false,
 
           loc: {
             start: { offset: 8, line: 1, column: 9 },
@@ -1260,7 +1260,7 @@ describe('compiler: parse', () => {
           type: NodeTypes.SIMPLE_EXPRESSION,
           content: 'a',
           isStatic: true,
-          hasPrefixedIdentifier: false,
+          isConstant: true,
 
           loc: {
             source: 'a',
@@ -1281,7 +1281,7 @@ describe('compiler: parse', () => {
           type: NodeTypes.SIMPLE_EXPRESSION,
           content: 'b',
           isStatic: false,
-          hasPrefixedIdentifier: true,
+          isConstant: false,
 
           loc: {
             start: { offset: 14, line: 1, column: 15 },
@@ -1308,7 +1308,7 @@ describe('compiler: parse', () => {
           type: NodeTypes.SIMPLE_EXPRESSION,
           content: 'a',
           isStatic: true,
-          hasPrefixedIdentifier: false,
+          isConstant: true,
           loc: {
             source: 'a',
             start: {
@@ -1328,8 +1328,8 @@ describe('compiler: parse', () => {
           type: NodeTypes.SIMPLE_EXPRESSION,
           content: '{ b }',
           isStatic: false,
-          // The `hasPrefixedIdentifier` is the default value and will be determined in transformExpression
-          hasPrefixedIdentifier: true,
+          // The `isConstant` is the default value and will be determined in transformExpression
+          isConstant: false,
           loc: {
             start: { offset: 10, line: 1, column: 11 },
             end: { offset: 15, line: 1, column: 16 },

--- a/packages/compiler-core/__tests__/transforms/__snapshots__/hoistStatic.spec.ts.snap
+++ b/packages/compiler-core/__tests__/transforms/__snapshots__/hoistStatic.spec.ts.snap
@@ -203,6 +203,42 @@ return function render() {
 }"
 `;
 
+exports[`compiler: hoistStatic transform prefixIdentifiers should NOT hoist expressions that with scope variable (2) 1`] = `
+"const _Vue = Vue
+
+return function render() {
+  with (this) {
+    const { renderList: _renderList, openBlock: _openBlock, createBlock: _createBlock, Fragment: _Fragment, toString: _toString, createVNode: _createVNode } = _Vue
+    
+    return (_openBlock(), _createBlock(\\"div\\", null, [
+      (_openBlock(), _createBlock(_Fragment, null, _renderList(_ctx.list, (o) => {
+        return (_openBlock(), _createBlock(\\"p\\", null, [
+          _createVNode(\\"span\\", null, _toString(o + 'foo'), 1 /* TEXT */)
+        ]))
+      }), 128 /* UNKEYED_FRAGMENT */))
+    ]))
+  }
+}"
+`;
+
+exports[`compiler: hoistStatic transform prefixIdentifiers should NOT hoist expressions that with scope variable 1`] = `
+"const _Vue = Vue
+
+return function render() {
+  with (this) {
+    const { renderList: _renderList, openBlock: _openBlock, createBlock: _createBlock, Fragment: _Fragment, toString: _toString, createVNode: _createVNode } = _Vue
+    
+    return (_openBlock(), _createBlock(\\"div\\", null, [
+      (_openBlock(), _createBlock(_Fragment, null, _renderList(_ctx.list, (o) => {
+        return (_openBlock(), _createBlock(\\"p\\", null, [
+          _createVNode(\\"span\\", null, _toString(o), 1 /* TEXT */)
+        ]))
+      }), 128 /* UNKEYED_FRAGMENT */))
+    ]))
+  }
+}"
+`;
+
 exports[`compiler: hoistStatic transform should NOT hoist components 1`] = `
 "const _Vue = Vue
 

--- a/packages/compiler-core/__tests__/transforms/__snapshots__/hoistStatic.spec.ts.snap
+++ b/packages/compiler-core/__tests__/transforms/__snapshots__/hoistStatic.spec.ts.snap
@@ -152,6 +152,57 @@ return function render() {
 }"
 `;
 
+exports[`compiler: hoistStatic transform prefixIdentifiers hoist class with static object value 1`] = `
+"const _Vue = Vue
+const _createVNode = Vue.createVNode
+
+const _hoisted_1 = { class: { foo: true }}
+
+return function render() {
+  with (this) {
+    const { toString: _toString, createVNode: _createVNode, createBlock: _createBlock, openBlock: _openBlock } = _Vue
+    
+    return (_openBlock(), _createBlock(\\"div\\", null, [
+      _createVNode(\\"span\\", _hoisted_1, _toString(_ctx.bar), 1 /* TEXT */)
+    ]))
+  }
+}"
+`;
+
+exports[`compiler: hoistStatic transform prefixIdentifiers hoist nested static tree with static interpolation 1`] = `
+"const _Vue = Vue
+const _createVNode = Vue.createVNode
+
+const _hoisted_1 = _createVNode(\\"span\\", null, [\\"foo \\", _toString(1), _toString(2)])
+
+return function render() {
+  with (this) {
+    const { toString: _toString, createVNode: _createVNode, createBlock: _createBlock, openBlock: _openBlock } = _Vue
+    
+    return (_openBlock(), _createBlock(\\"div\\", null, [
+      _hoisted_1
+    ]))
+  }
+}"
+`;
+
+exports[`compiler: hoistStatic transform prefixIdentifiers hoist nested static tree with static prop value 1`] = `
+"const _Vue = Vue
+const _createVNode = Vue.createVNode
+
+const _hoisted_1 = _createVNode(\\"span\\", { foo: 0 }, _toString(1), 1 /* TEXT */)
+
+return function render() {
+  with (this) {
+    const { toString: _toString, createVNode: _createVNode, createBlock: _createBlock, openBlock: _openBlock } = _Vue
+    
+    return (_openBlock(), _createBlock(\\"div\\", null, [
+      _hoisted_1
+    ]))
+  }
+}"
+`;
+
 exports[`compiler: hoistStatic transform should NOT hoist components 1`] = `
 "const _Vue = Vue
 

--- a/packages/compiler-core/__tests__/transforms/hoistStatic.spec.ts
+++ b/packages/compiler-core/__tests__/transforms/hoistStatic.spec.ts
@@ -1,4 +1,10 @@
-import { parse, transform, NodeTypes, generate } from '../../src'
+import {
+  parse,
+  transform,
+  NodeTypes,
+  generate,
+  CompilerOptions
+} from '../../src'
 import {
   OPEN_BLOCK,
   CREATE_BLOCK,
@@ -8,17 +14,24 @@ import {
   RENDER_LIST
 } from '../../src/runtimeHelpers'
 import { transformElement } from '../../src/transforms/transformElement'
+import { transformExpression } from '../../src/transforms/transformExpression'
 import { transformIf } from '../../src/transforms/vIf'
 import { transformFor } from '../../src/transforms/vFor'
 import { transformBind } from '../../src/transforms/vBind'
 import { createObjectMatcher, genFlagText } from '../testUtils'
 import { PatchFlags } from '@vue/shared'
 
-function transformWithHoist(template: string) {
+function transformWithHoist(template: string, options: CompilerOptions = {}) {
   const ast = parse(template)
   transform(ast, {
     hoistStatic: true,
-    nodeTransforms: [transformIf, transformFor, transformElement],
+    prefixIdentifiers: options.prefixIdentifiers,
+    nodeTransforms: [
+      transformIf,
+      transformFor,
+      ...(options.prefixIdentifiers ? [transformExpression] : []),
+      transformElement
+    ],
     directiveTransforms: {
       bind: transformBind
     }
@@ -428,5 +441,163 @@ describe('compiler: hoistStatic transform', () => {
       ]
     })
     expect(generate(root).code).toMatchSnapshot()
+  })
+
+  describe('prefixIdentifiers', () => {
+    test('hoist nested static tree with static interpolation', () => {
+      const { root, args } = transformWithHoist(
+        `<div><span>foo {{ 1 }} {{ 2 }}</span></div>`,
+        {
+          prefixIdentifiers: true
+        }
+      )
+      expect(root.hoists).toMatchObject([
+        {
+          type: NodeTypes.JS_CALL_EXPRESSION,
+          callee: CREATE_VNODE,
+          arguments: [
+            `"span"`,
+            `null`,
+            [
+              {
+                type: NodeTypes.TEXT,
+                content: `foo `
+              },
+              {
+                type: NodeTypes.INTERPOLATION,
+                content: {
+                  content: `1`,
+                  isStatic: false,
+                  hasPrefixedIdentifier: false
+                }
+              },
+              {
+                type: NodeTypes.INTERPOLATION,
+                content: {
+                  content: `2`,
+                  isStatic: false,
+                  hasPrefixedIdentifier: false
+                }
+              }
+            ]
+          ]
+        }
+      ])
+      expect(args).toMatchObject([
+        `"div"`,
+        `null`,
+        [
+          {
+            type: NodeTypes.ELEMENT,
+            codegenNode: {
+              type: NodeTypes.SIMPLE_EXPRESSION,
+              content: `_hoisted_1`
+            }
+          }
+        ]
+      ])
+      expect(generate(root).code).toMatchSnapshot()
+    })
+
+    test('hoist nested static tree with static prop value', () => {
+      const { root, args } = transformWithHoist(
+        `<div><span :foo="0">{{ 1 }}</span></div>`,
+        {
+          prefixIdentifiers: true
+        }
+      )
+
+      expect(root.hoists).toMatchObject([
+        {
+          type: NodeTypes.JS_CALL_EXPRESSION,
+          callee: CREATE_VNODE,
+          arguments: [
+            `"span"`,
+            createObjectMatcher({ foo: `[0]` }),
+            {
+              type: NodeTypes.INTERPOLATION,
+              content: {
+                content: `1`,
+                isStatic: false,
+                hasPrefixedIdentifier: false
+              }
+            },
+            '1 /* TEXT */'
+          ]
+        }
+      ])
+      expect(args).toMatchObject([
+        `"div"`,
+        `null`,
+        [
+          {
+            type: NodeTypes.ELEMENT,
+            codegenNode: {
+              type: NodeTypes.SIMPLE_EXPRESSION,
+              content: `_hoisted_1`
+            }
+          }
+        ]
+      ])
+      expect(generate(root).code).toMatchSnapshot()
+    })
+
+    test('hoist class with static object value', () => {
+      const { root, args } = transformWithHoist(
+        `<div><span :class="{ foo: true }">{{ bar }}</span></div>`,
+        {
+          prefixIdentifiers: true
+        }
+      )
+
+      expect(root.hoists).toMatchObject([
+        {
+          type: NodeTypes.JS_OBJECT_EXPRESSION,
+          properties: [
+            {
+              key: {
+                content: `class`,
+                hasPrefixedIdentifier: false,
+                isStatic: true
+              },
+              value: {
+                content: `{ foo: true }`,
+                hasPrefixedIdentifier: false,
+                isStatic: false
+              }
+            }
+          ]
+        }
+      ])
+      expect(args).toMatchObject([
+        `"div"`,
+        `null`,
+        [
+          {
+            type: NodeTypes.ELEMENT,
+            codegenNode: {
+              callee: CREATE_VNODE,
+              arguments: [
+                `"span"`,
+                {
+                  type: NodeTypes.SIMPLE_EXPRESSION,
+                  content: `_hoisted_1`
+                },
+                {
+                  type: NodeTypes.INTERPOLATION,
+                  content: {
+                    content: `_ctx.bar`,
+                    hasPrefixedIdentifier: true,
+                    isStatic: false
+                  }
+                },
+                `1 /* TEXT */`
+              ]
+            }
+          }
+        ]
+      ])
+      expect(generate(root).code).toMatchSnapshot()
+    })
   })
 })

--- a/packages/compiler-core/__tests__/transforms/hoistStatic.spec.ts
+++ b/packages/compiler-core/__tests__/transforms/hoistStatic.spec.ts
@@ -468,7 +468,7 @@ describe('compiler: hoistStatic transform', () => {
                 content: {
                   content: `1`,
                   isStatic: false,
-                  hasPrefixedIdentifier: false
+                  isConstant: true
                 }
               },
               {
@@ -476,7 +476,7 @@ describe('compiler: hoistStatic transform', () => {
                 content: {
                   content: `2`,
                   isStatic: false,
-                  hasPrefixedIdentifier: false
+                  isConstant: true
                 }
               }
             ]
@@ -519,7 +519,7 @@ describe('compiler: hoistStatic transform', () => {
               content: {
                 content: `1`,
                 isStatic: false,
-                hasPrefixedIdentifier: false
+                isConstant: true
               }
             },
             '1 /* TEXT */'
@@ -557,12 +557,12 @@ describe('compiler: hoistStatic transform', () => {
             {
               key: {
                 content: `class`,
-                hasPrefixedIdentifier: false,
+                isConstant: true,
                 isStatic: true
               },
               value: {
                 content: `{ foo: true }`,
-                hasPrefixedIdentifier: false,
+                isConstant: true,
                 isStatic: false
               }
             }
@@ -587,7 +587,7 @@ describe('compiler: hoistStatic transform', () => {
                   type: NodeTypes.INTERPOLATION,
                   content: {
                     content: `_ctx.bar`,
-                    hasPrefixedIdentifier: true,
+                    isConstant: false,
                     isStatic: false
                   }
                 },
@@ -597,6 +597,30 @@ describe('compiler: hoistStatic transform', () => {
           }
         ]
       ])
+      expect(generate(root).code).toMatchSnapshot()
+    })
+
+    test('should NOT hoist expressions that with scope variable', () => {
+      const { root } = transformWithHoist(
+        `<div><p v-for="o in list"><span>{{ o }}</span></p></div>`,
+        {
+          prefixIdentifiers: true
+        }
+      )
+
+      expect(root.hoists.length).toBe(0)
+      expect(generate(root).code).toMatchSnapshot()
+    })
+
+    test('should NOT hoist expressions that with scope variable (2)', () => {
+      const { root } = transformWithHoist(
+        `<div><p v-for="o in list"><span>{{ o + 'foo' }}</span></p></div>`,
+        {
+          prefixIdentifiers: true
+        }
+      )
+
+      expect(root.hoists.length).toBe(0)
       expect(generate(root).code).toMatchSnapshot()
     })
   })

--- a/packages/compiler-core/__tests__/utils.spec.ts
+++ b/packages/compiler-core/__tests__/utils.spec.ts
@@ -79,7 +79,7 @@ describe('isEmptyExpression', () => {
         content: '',
         type: NodeTypes.SIMPLE_EXPRESSION,
         isStatic: true,
-        hasPrefixedIdentifier: false,
+        isConstant: true,
         loc: null as any
       })
     ).toBe(true)
@@ -91,7 +91,7 @@ describe('isEmptyExpression', () => {
         content: '  \t  ',
         type: NodeTypes.SIMPLE_EXPRESSION,
         isStatic: true,
-        hasPrefixedIdentifier: false,
+        isConstant: true,
         loc: null as any
       })
     ).toBe(true)
@@ -103,7 +103,7 @@ describe('isEmptyExpression', () => {
         content: 'foo',
         type: NodeTypes.SIMPLE_EXPRESSION,
         isStatic: true,
-        hasPrefixedIdentifier: false,
+        isConstant: true,
         loc: null as any
       })
     ).toBe(false)

--- a/packages/compiler-core/__tests__/utils.spec.ts
+++ b/packages/compiler-core/__tests__/utils.spec.ts
@@ -79,7 +79,7 @@ describe('isEmptyExpression', () => {
         content: '',
         type: NodeTypes.SIMPLE_EXPRESSION,
         isStatic: true,
-        hasPrefixedIdentifier: true,
+        hasPrefixedIdentifier: false,
         loc: null as any
       })
     ).toBe(true)
@@ -91,7 +91,7 @@ describe('isEmptyExpression', () => {
         content: '  \t  ',
         type: NodeTypes.SIMPLE_EXPRESSION,
         isStatic: true,
-        hasPrefixedIdentifier: true,
+        hasPrefixedIdentifier: false,
         loc: null as any
       })
     ).toBe(true)
@@ -103,7 +103,7 @@ describe('isEmptyExpression', () => {
         content: 'foo',
         type: NodeTypes.SIMPLE_EXPRESSION,
         isStatic: true,
-        hasPrefixedIdentifier: true,
+        hasPrefixedIdentifier: false,
         loc: null as any
       })
     ).toBe(false)

--- a/packages/compiler-core/__tests__/utils.spec.ts
+++ b/packages/compiler-core/__tests__/utils.spec.ts
@@ -79,6 +79,7 @@ describe('isEmptyExpression', () => {
         content: '',
         type: NodeTypes.SIMPLE_EXPRESSION,
         isStatic: true,
+        hasPrefixedIdentifier: true,
         loc: null as any
       })
     ).toBe(true)
@@ -90,6 +91,7 @@ describe('isEmptyExpression', () => {
         content: '  \t  ',
         type: NodeTypes.SIMPLE_EXPRESSION,
         isStatic: true,
+        hasPrefixedIdentifier: true,
         loc: null as any
       })
     ).toBe(true)
@@ -101,6 +103,7 @@ describe('isEmptyExpression', () => {
         content: 'foo',
         type: NodeTypes.SIMPLE_EXPRESSION,
         isStatic: true,
+        hasPrefixedIdentifier: true,
         loc: null as any
       })
     ).toBe(false)

--- a/packages/compiler-core/src/ast.ts
+++ b/packages/compiler-core/src/ast.ts
@@ -165,9 +165,7 @@ export interface SimpleExpressionNode extends Node {
   type: NodeTypes.SIMPLE_EXPRESSION
   content: string
   isStatic: boolean
-  // Is used to indicate whether there is an identifier
-  // in an expression that needs to be prefixed with `_ctx.`.
-  hasPrefixedIdentifier: boolean
+  isConstant: boolean
   // an expression parsed as the params of a function will track
   // the identifiers declared inside the function body.
   identifiers?: string[]
@@ -498,12 +496,12 @@ export function createSimpleExpression(
   content: SimpleExpressionNode['content'],
   isStatic: SimpleExpressionNode['isStatic'],
   loc: SourceLocation = locStub,
-  hasPrefixedIdentifier: boolean = true
+  isConstant: boolean = false
 ): SimpleExpressionNode {
   return {
     type: NodeTypes.SIMPLE_EXPRESSION,
     loc,
-    hasPrefixedIdentifier,
+    isConstant,
     content,
     isStatic
   }

--- a/packages/compiler-core/src/ast.ts
+++ b/packages/compiler-core/src/ast.ts
@@ -165,6 +165,9 @@ export interface SimpleExpressionNode extends Node {
   type: NodeTypes.SIMPLE_EXPRESSION
   content: string
   isStatic: boolean
+  // Is used to indicate whether there is an identifier
+  // in an expression that needs to be prefixed with `_ctx.`.
+  hasPrefixedIdentifier: boolean
   // an expression parsed as the params of a function will track
   // the identifiers declared inside the function body.
   identifiers?: string[]
@@ -494,11 +497,13 @@ export function createObjectProperty(
 export function createSimpleExpression(
   content: SimpleExpressionNode['content'],
   isStatic: SimpleExpressionNode['isStatic'],
-  loc: SourceLocation = locStub
+  loc: SourceLocation = locStub,
+  hasPrefixedIdentifier: boolean = true
 ): SimpleExpressionNode {
   return {
     type: NodeTypes.SIMPLE_EXPRESSION,
     loc,
+    hasPrefixedIdentifier,
     content,
     isStatic
   }

--- a/packages/compiler-core/src/parse.ts
+++ b/packages/compiler-core/src/parse.ts
@@ -563,13 +563,12 @@ function parseAttribute(
       )
       let content = match[2]
       let isStatic = true
-      // Used to indicate whether the arg needs to be prefixed,
-      // only dynamic arg need to be prefixed
-      let hasPrefixedIdentifier = false
+      // Non-dynamic arg is a constant.
+      let isConstant = true
 
       if (content.startsWith('[')) {
         isStatic = false
-        hasPrefixedIdentifier = true
+        isConstant = false
 
         if (!content.endsWith(']')) {
           emitError(
@@ -585,7 +584,7 @@ function parseAttribute(
         type: NodeTypes.SIMPLE_EXPRESSION,
         content,
         isStatic,
-        hasPrefixedIdentifier,
+        isConstant,
         loc
       }
     }
@@ -611,8 +610,8 @@ function parseAttribute(
         type: NodeTypes.SIMPLE_EXPRESSION,
         content: value.content,
         isStatic: false,
-        // Set `hasPrefixedIdentifier` to true by default and will decide in transformExpression
-        hasPrefixedIdentifier: true,
+        // Set `isConstant` to false by default and will decide in transformExpression
+        isConstant: false,
         loc: value.loc
       },
       arg,
@@ -719,8 +718,8 @@ function parseInterpolation(
     content: {
       type: NodeTypes.SIMPLE_EXPRESSION,
       isStatic: false,
-      // Set `hasPrefixedIdentifier` to true by default and will decide in transformExpression
-      hasPrefixedIdentifier: true,
+      // Set `isConstant` to false by default and will decide in transformExpression
+      isConstant: false,
       content,
       loc: getSelection(context, innerStart, innerEnd)
     },

--- a/packages/compiler-core/src/parse.ts
+++ b/packages/compiler-core/src/parse.ts
@@ -563,9 +563,13 @@ function parseAttribute(
       )
       let content = match[2]
       let isStatic = true
+      // Used to indicate whether the arg needs to be prefixed,
+      // only dynamic arg need to be prefixed
+      let hasPrefixedIdentifier = false
 
       if (content.startsWith('[')) {
         isStatic = false
+        hasPrefixedIdentifier = true
 
         if (!content.endsWith(']')) {
           emitError(
@@ -581,6 +585,7 @@ function parseAttribute(
         type: NodeTypes.SIMPLE_EXPRESSION,
         content,
         isStatic,
+        hasPrefixedIdentifier,
         loc
       }
     }
@@ -606,6 +611,8 @@ function parseAttribute(
         type: NodeTypes.SIMPLE_EXPRESSION,
         content: value.content,
         isStatic: false,
+        // Set `hasPrefixedIdentifier` to true by default and will decide in transformExpression
+        hasPrefixedIdentifier: true,
         loc: value.loc
       },
       arg,
@@ -712,6 +719,8 @@ function parseInterpolation(
     content: {
       type: NodeTypes.SIMPLE_EXPRESSION,
       isStatic: false,
+      // Set `hasPrefixedIdentifier` to true by default and will decide in transformExpression
+      hasPrefixedIdentifier: true,
       content,
       loc: getSelection(context, innerStart, innerEnd)
     },

--- a/packages/compiler-core/src/transforms/transformElement.ts
+++ b/packages/compiler-core/src/transforms/transformElement.ts
@@ -187,7 +187,7 @@ export function buildProps(
         value.type !== NodeTypes.SIMPLE_EXPRESSION ||
         // E.g: <p :foo="1 + 2" />.
         // Do not add prop `foo` to `dynamicPropNames`.
-        (!value.isStatic && value.hasPrefixedIdentifier)
+        (!value.isStatic && !value.isConstant)
       ) {
         const name = key.content
         if (name === 'ref') {

--- a/packages/compiler-core/src/transforms/transformElement.ts
+++ b/packages/compiler-core/src/transforms/transformElement.ts
@@ -183,7 +183,12 @@ export function buildProps(
 
   const analyzePatchFlag = ({ key, value }: Property) => {
     if (key.type === NodeTypes.SIMPLE_EXPRESSION && key.isStatic) {
-      if (value.type !== NodeTypes.SIMPLE_EXPRESSION || !value.isStatic) {
+      if (
+        value.type !== NodeTypes.SIMPLE_EXPRESSION ||
+        // E.g: <p :foo="1 + 2" />.
+        // Do not add prop `foo` to `dynamicPropNames`.
+        (!value.isStatic && value.hasPrefixedIdentifier)
+      ) {
         const name = key.content
         if (name === 'ref') {
           hasRef = true

--- a/packages/compiler-core/src/transforms/transformExpression.ts
+++ b/packages/compiler-core/src/transforms/transformExpression.ts
@@ -61,6 +61,7 @@ export const transformExpression: NodeTransform = (node, context) => {
 
 interface PrefixMeta {
   prefix?: string
+  prefixedName: boolean
   start: number
   end: number
   scopeIds?: Set<string>
@@ -108,6 +109,7 @@ export function processExpression(
   const ids: (Identifier & PrefixMeta)[] = []
   const knownIds = Object.create(context.identifiers)
 
+  let hasPrefixedIdentifier = false
   // walk the AST and look for identifiers that need to be prefixed with `_ctx.`.
   walkJS(ast, {
     enter(node: Node & PrefixMeta, parent) {
@@ -120,10 +122,13 @@ export function processExpression(
               node.prefix = `${node.name}: `
             }
             node.name = `_ctx.${node.name}`
+            hasPrefixedIdentifier = true
+            node.prefixedName = true
             ids.push(node)
           } else if (!isStaticPropertyKey(node, parent)) {
             // also generate sub-expressions for other identifiers for better
             // source map support. (except for property keys which are static)
+            node.prefixedName = false
             ids.push(node)
           }
         }
@@ -190,11 +195,16 @@ export function processExpression(
     }
     const source = rawExp.slice(start, end)
     children.push(
-      createSimpleExpression(id.name, false, {
-        source,
-        start: advancePositionWithClone(node.loc.start, source, start),
-        end: advancePositionWithClone(node.loc.start, source, end)
-      })
+      createSimpleExpression(
+        id.name,
+        false,
+        {
+          source,
+          start: advancePositionWithClone(node.loc.start, source, start),
+          end: advancePositionWithClone(node.loc.start, source, end)
+        },
+        id.prefixedName /* hasPrefixedIdentifier */
+      )
     )
     if (i === ids.length - 1 && end < rawExp.length) {
       children.push(rawExp.slice(end))
@@ -206,6 +216,7 @@ export function processExpression(
     ret = createCompoundExpression(children, node.loc)
   } else {
     ret = node
+    ret.hasPrefixedIdentifier = hasPrefixedIdentifier
   }
   ret.identifiers = Object.keys(knownIds)
   return ret

--- a/packages/compiler-dom/__tests__/parse.spec.ts
+++ b/packages/compiler-dom/__tests__/parse.spec.ts
@@ -117,6 +117,7 @@ describe('DOM parser', () => {
           type: NodeTypes.SIMPLE_EXPRESSION,
           content: `a < b`,
           isStatic: false,
+          hasPrefixedIdentifier: true,
           loc: {
             start: { offset: 8, line: 1, column: 9 },
             end: { offset: 16, line: 1, column: 17 },

--- a/packages/compiler-dom/__tests__/parse.spec.ts
+++ b/packages/compiler-dom/__tests__/parse.spec.ts
@@ -117,7 +117,7 @@ describe('DOM parser', () => {
           type: NodeTypes.SIMPLE_EXPRESSION,
           content: `a < b`,
           isStatic: false,
-          hasPrefixedIdentifier: true,
+          isConstant: false,
           loc: {
             start: { offset: 8, line: 1, column: 9 },
             end: { offset: 16, line: 1, column: 17 },


### PR DESCRIPTION
This PR enhances hoisting optimization:
## 1. Dynamic attribute with static value:
```html
<div><span :foo="0"></span></div>
```

Before:

```JS
import { createVNode, createBlock, openBlock } from "vue"

export default function render() {
  const _ctx = this
  return (openBlock(), createBlock("div", null, [
    createVNode("span", { foo: 0 }, null, 8 /* PROPS */, ["foo"])
  ]))
}
```
Now: 
```js
import { createVNode, createBlock, openBlock } from "vue"

const _hoisted_1 = createVNode("span", { foo: 0 })

export default function render() {
  const _ctx = this
  return (openBlock(), createBlock("div", null, [
    _hoisted_1
  ]))
}
```
## 2. Static interpolation:
```html
<div><span>{{ 1 + 2 }}</span></div>
```

Before:

```js
import { toString, createVNode, createBlock, openBlock } from "vue"

export default function render() {
  const _ctx = this
  return (openBlock(), createBlock("div", null, [
    createVNode("span", null, toString(1 + 2), 1 /* TEXT */)
  ]))
}
```

Now:

```js
import { toString, createVNode, createBlock, openBlock } from "vue"
// Maybe patchFlag can be removed.
const _hoisted_1 = createVNode("span", null, toString(1 + 2), 1 /* TEXT */)

export default function render() {
  const _ctx = this
  return (openBlock(), createBlock("div", null, [
    _hoisted_1
  ]))
}
```

## 3. Write inline styles/class for better performance:
```html
<div><span :class="{ foo: true }">{{ bar }}</span></div>
```

Before:

```js
import { toString, createVNode, createBlock, openBlock } from "vue"

export default function render() {
  const _ctx = this
  return (openBlock(), createBlock("div", null, [
    createVNode("span", { class: { foo: true }}, toString(_ctx.bar), 3 /* TEXT, CLASS */)
  ]))
}
```

Now:

```js
import { toString, createVNode, createBlock, openBlock } from "vue"

const _hoisted_1 = { class: { foo: true }}

export default function render() {
  const _ctx = this
  return (openBlock(), createBlock("div", null, [
    createVNode("span", _hoisted_1, toString(_ctx.bar), 1 /* TEXT */)
  ]))
}
```
This can avoid class being patched.

If there is a more suitable implementation, or if this feature does not match the plan, or for other reasons, then this PR can be closed at any time, thanks