### PR TITLE
types(watch): allow to accept readonly arrays

### DIFF
--- a/packages/runtime-core/__tests__/apiWatch.spec.ts
+++ b/packages/runtime-core/__tests__/apiWatch.spec.ts
@@ -103,6 +103,28 @@ describe('api: watch', () => {
     expect(dummy).toMatchObject([[2, 2, 3], [1, 1, 2]])
   })
 
+  it('watching multiple sources: readonly array', async () => {
+    const state = reactive({ count: 1 })
+    const status = ref(false)
+
+    let dummy
+    watch([() => state.count, status] as const, (vals, oldVals) => {
+      dummy = [vals, oldVals]
+      let [count] = vals
+      let [, oldStatus] = oldVals
+      // assert types
+      count + 1
+      oldStatus === true
+    })
+    await nextTick()
+    expect(dummy).toMatchObject([[1, false], []])
+
+    state.count++
+    status.value = false
+    await nextTick()
+    expect(dummy).toMatchObject([[2, false], [1, false]])
+  })
+
   it('stopping the watcher', async () => {
     const state = reactive({ count: 0 })
     let dummy

--- a/packages/runtime-core/src/apiWatch.ts
+++ b/packages/runtime-core/src/apiWatch.ts
@@ -56,7 +56,7 @@ export function watch<T>(
 ): StopHandle
 
 // overload #3: array of multiple sources + cb
-export function watch<T extends WatcherSource<unknown>[]>(
+export function watch<T extends readonly WatcherSource<unknown>[]>(
   sources: T,
   cb: (
     newValues: MapSources<T>,


### PR DESCRIPTION
This PR updates `watchApi` array type to allow pass readonly arrays. When we mark array as const, its length and order of contained types is being preserved, so it allows for better type inference without type checking of each array element. It doesn't break current behaviour and it is allowed to pass non-readonly arrays aswell.

No `const` casting.
We have to check if element is a object or number, since it is an array of any length with these two types:
```ts
const count = ref(0);
const state = reactive({ count: 1 })

watch(
  [() => state, count], // ({ count: number } | number)[]
  ([state, count]) => {
    if (typeof state === 'object') {
      state.count++;
    }
    if (typeof count === 'number') {
      count++;
    }
  }
);
```

With `const` casting.
More type information is being preserved and array has constant length (array became a tuple):
```ts
const count = ref(0);
const state = reactive({ count: 1 })

watch(
  [() => state, count] as const, // [{ count: number }, number]
  ([state, count]) => {
    state.count++;
    count++;
  }
)
```