### PR TITLE
fix(compile): compile error TS2345 for typescript 3.6.4.

### DIFF
--- a/packages/compiler-core/src/transforms/transformExpression.ts
+++ b/packages/compiler-core/src/transforms/transformExpression.ts
@@ -110,7 +110,7 @@ export function processExpression(
 
   // walk the AST and look for identifiers that need to be prefixed with `_ctx.`.
   walkJS(ast, {
-    enter(node: Node & PrefixMeta, parent) {
+    enter(node: Node & PrefixMeta, parent: any) {
       if (node.type === 'Identifier') {
         if (!ids.includes(node)) {
           if (!knownIds[node.name] && shouldPrefix(node, parent)) {
@@ -131,8 +131,8 @@ export function processExpression(
         // walk function expressions and add its arguments to known identifiers
         // so that we don't prefix them
         node.params.forEach(p =>
-          walkJS(p, {
-            enter(child, parent) {
+          walkJS(p as any, {
+            enter(child: any, parent: any) {
               if (
                 child.type === 'Identifier' &&
                 // do not record as scope variable if is a destructured key


### PR DESCRIPTION
compile and test error for typescript 3.6.4
packages/compiler-core/src/transforms/transformExpression.ts:134:18 - error TS2345: Argument of type 'Pattern' is not assignable to parameter of type 'Node'.

packages/compiler-core/src/transforms/transformExpression.ts:117:43 - error TS2345: Argument of type 'Node | undefined' is not assignable to parameter of type 'Node'.

 packages/compiler-core/src/transforms/transformExpression.ts:116:58 - error TS2345: Argument of type 'Node | undefined' is not assignable to parameter of type 'Node'.

yarn list typescript

├─ @microsoft/api-extractor@7.5.0
│  └─ typescript@3.5.3
└─ typescript@3.6.4