### PR TITLE
fix: avoid compiler generating incorrect code

### DIFF
--- a/packages/compiler-core/__tests__/transforms/transformExpressions.spec.ts
+++ b/packages/compiler-core/__tests__/transforms/transformExpressions.spec.ts
@@ -32,6 +32,24 @@ describe('compiler: expression transform', () => {
     })
   })
 
+  test('empty interpolation', () => {
+    const node = parseWithExpressionTransform(`{{}}`) as InterpolationNode
+    const node2 = parseWithExpressionTransform(`{{ }}`) as InterpolationNode
+    const node3 = parseWithExpressionTransform(
+      `<div>{{ }}</div>`
+    ) as ElementNode
+
+    const objectToBeMatched = {
+      type: NodeTypes.SIMPLE_EXPRESSION,
+      content: ``
+    }
+    expect(node.content).toMatchObject(objectToBeMatched)
+    expect(node2.content).toMatchObject(objectToBeMatched)
+    expect((node3.children[0] as InterpolationNode).content).toMatchObject(
+      objectToBeMatched
+    )
+  })
+
   test('interpolation (children)', () => {
     const el = parseWithExpressionTransform(
       `<div>{{ foo }}</div>`

--- a/packages/compiler-core/src/transforms/transformExpression.ts
+++ b/packages/compiler-core/src/transforms/transformExpression.ts
@@ -76,7 +76,7 @@ export function processExpression(
   // function params
   asParams: boolean = false
 ): ExpressionNode {
-  if (!context.prefixIdentifiers) {
+  if (!context.prefixIdentifiers || !node.content.trim()) {
     return node
   }
 


### PR DESCRIPTION
I noticed that empty interpolation will be compiled into `toString(_ctx.)`.

E.g:

```html
{{}}
```

Generated:

```js
import { toString } from "vue"

export default function render() {
  const _ctx = this
  return toString(_ctx.)
}
```