### PR TITLE
refactor(scripts): updated error-message for not-found fuzzy-matching error

### DIFF
--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -1,4 +1,5 @@
 const fs = require('fs')
+const chalk = require('chalk')
 
 const targets = (exports.targets = fs.readdirSync('packages').filter(f => {
   if (!fs.statSync(`packages/${f}`).isDirectory()) {
@@ -26,6 +27,14 @@ exports.fuzzyMatchTarget = (partialTargets, includeAllMatching) => {
   if (matched.length) {
     return matched
   } else {
-    throw new Error(`Target ${partialTargets} not found!`)
+    console.log()
+    console.error(
+      `  ${chalk.bgRed.white(' ERROR ')} ${chalk.red(
+        `Target ${chalk.underline(partialTargets)} not found!`
+      )}`
+    )
+    console.log()
+
+    process.exit(1)
   }
 }


### PR DESCRIPTION
Updated the error message inside the fuzzy-matching util to reflect the style in other files (i.e. scripts/verifyCommit.js)