### PR TITLE
refactor(runtime-core): isBuiltInTag -> use makeMap instead of Set

### DIFF
--- a/packages/runtime-core/src/component.ts
+++ b/packages/runtime-core/src/component.ts
@@ -22,7 +22,8 @@ import {
   NOOP,
   isArray,
   isObject,
-  NO
+  NO,
+  makeMap
 } from '@vue/shared'
 import { SuspenseBoundary } from './suspense'
 import {
@@ -224,8 +225,7 @@ export const setCurrentInstance = (
   currentInstance = instance
 }
 
-const BuiltInTagSet = new Set(['slot', 'component'])
-const isBuiltInTag = (tag: string) => BuiltInTagSet.has(tag)
+const isBuiltInTag = /*@__PURE__*/ makeMap('slot,component')
 
 export function validateComponentName(name: string, config: AppConfig) {
   const appIsNativeTag = config.isNativeTag || NO

--- a/packages/runtime-core/src/component.ts
+++ b/packages/runtime-core/src/component.ts
@@ -225,7 +225,7 @@ export const setCurrentInstance = (
   currentInstance = instance
 }
 
-const isBuiltInTag = /*@__PURE__*/ makeMap('slot,component')
+const isBuiltInTag = /*#__PURE__*/ makeMap('slot,component')
 
 export function validateComponentName(name: string, config: AppConfig) {
   const appIsNativeTag = config.isNativeTag || NO


### PR DESCRIPTION
Another Set can be replaced by the makeMap method.