### PR TITLE
fix(effect): vue-next effect function will be called more than once when Array.prototype.shift be called #10705

### DIFF
--- a/packages/reactivity/__tests__/effect.spec.ts
+++ b/packages/reactivity/__tests__/effect.spec.ts
@@ -156,13 +156,21 @@ describe('reactivity/effect', () => {
   it('should observe iteration', () => {
     let dummy
     const list = reactive(['Hello'])
-    effect(() => (dummy = list.join(' ')))
+    const fn = jest.fn(() => (dummy = list.join(' ')))
+    effect(fn)
+
+    expect(fn).toHaveBeenCalledTimes(1) // normal
 
     expect(dummy).toBe('Hello')
     list.push('World!')
     expect(dummy).toBe('Hello World!')
+
+    expect(fn).toHaveBeenCalledTimes(2) // normal
+
     list.shift()
     expect(dummy).toBe('World!')
+
+    expect(fn).toHaveBeenCalledTimes(5) // It depends on list.length
   })
 
   it('should observe implicit array length changes', () => {


### PR DESCRIPTION
I think I may have found a bug  [#10705](https://github.com/vuejs/vue/issues/10705)

effect function will be called more than once when Array.prototype.shift be called
``` js
 it('should observe iteration', () => {
    let dummy
    const list = reactive(['Hello'])
    const fn = jest.fn(() => (dummy = list.join(' ')));
    effect(fn)

    expect(fn).toHaveBeenCalledTimes(1) // normal

    expect(dummy).toBe('Hello')
    list.push('World!')
    expect(dummy).toBe('Hello World!')

    expect(fn).toHaveBeenCalledTimes(2) // normal

    list.shift()
    expect(dummy).toBe('World!')

    expect(fn).toHaveBeenCalledTimes(5) // It depends on list.length
  })
```

should cache effect funtion, like Watch Object in Vue 2, and trigger it nexttick？