### PR TITLE
chore(runtime-core): use new Array.fill to populate array

### DIFF
--- a/packages/runtime-core/src/createRenderer.ts
+++ b/packages/runtime-core/src/createRenderer.ts
@@ -1503,7 +1503,8 @@ export function createRenderer<
       // and oldIndex = 0 is a special value indicating the new node has
       // no corresponding old node.
       // used for determining longest stable subsequence
-      const newIndexToOldIndexMap = new Array(toBePatched).fill(0)
+      const newIndexToOldIndexMap = new Array(toBePatched)
+      for (i = 0; i < toBePatched; i++) newIndexToOldIndexMap[i] = 0
 
       for (i = s1; i <= e1; i++) {
         const prevChild = c1[i]

--- a/packages/runtime-core/src/createRenderer.ts
+++ b/packages/runtime-core/src/createRenderer.ts
@@ -1503,8 +1503,7 @@ export function createRenderer<
       // and oldIndex = 0 is a special value indicating the new node has
       // no corresponding old node.
       // used for determining longest stable subsequence
-      const newIndexToOldIndexMap = []
-      for (i = 0; i < toBePatched; i++) newIndexToOldIndexMap.push(0)
+      const newIndexToOldIndexMap = new Array(toBePatched).fill(0)
 
       for (i = s1; i <= e1; i++) {
         const prevChild = c1[i]


### PR DESCRIPTION
using Array.fill seems a bit faster than looping.

Array.fill is not supported on IE maybe use a polyfill when the time comes?