### PR TITLE
feat(reactivity): support computed setter as a second arg

### DIFF
--- a/packages/reactivity/__tests__/computed.spec.ts
+++ b/packages/reactivity/__tests__/computed.spec.ts
@@ -149,6 +149,23 @@ describe('reactivity/computed', () => {
     expect(n.value).toBe(-1)
   })
 
+  it('should support setter as second arg', () => {
+    const n = ref(1)
+    const plusOne = computed(
+      () => n.value + 1,
+      val => {
+        n.value = val - 1
+      }
+    )
+
+    expect(plusOne.value).toBe(2)
+    n.value++
+    expect(plusOne.value).toBe(3)
+
+    plusOne.value = 0
+    expect(n.value).toBe(-1)
+  })
+
   it('should trigger effect w/ setter', () => {
     const n = ref(1)
     const plusOne = computed({

--- a/packages/reactivity/src/computed.ts
+++ b/packages/reactivity/src/computed.ts
@@ -20,19 +20,24 @@ export function computed<T>(
   options: WritableComputedOptions<T>
 ): WritableComputedRef<T>
 export function computed<T>(
-  getterOrOptions: (() => T) | WritableComputedOptions<T>
+  getter: () => T,
+  setter: (v: T) => void
+): WritableComputedRef<T>
+export function computed<T>(
+  getterOrOptions: (() => T) | WritableComputedOptions<T>,
+  setter?: (v: T) => void
 ): any {
-  const isReadonly = isFunction(getterOrOptions)
-  const getter = isReadonly
+  const isReadonly = isFunction(getterOrOptions) && setter === undefined
+  const getter = isFunction(getterOrOptions)
     ? (getterOrOptions as (() => T))
     : (getterOrOptions as WritableComputedOptions<T>).get
-  const setter = isReadonly
+  const set = isReadonly
     ? __DEV__
       ? () => {
           console.warn('Write operation failed: computed value is readonly')
         }
       : NOOP
-    : (getterOrOptions as WritableComputedOptions<T>).set
+    : setter || (getterOrOptions as WritableComputedOptions<T>).set
 
   let dirty = true
   let value: T
@@ -61,7 +66,7 @@ export function computed<T>(
       return value
     },
     set value(newValue: T) {
-      setter(newValue)
+      set(newValue)
     }
   }
 }


### PR DESCRIPTION
Support `computed(get, set)` call as [RFC](https://github.com/vuejs/rfcs/blob/function-apis/active-rfcs/0000-function-api.md#computed-values) describes