### PR TITLE
perf(reactivity): optimize the performance of the `canObserve`

### DIFF
--- a/packages/reactivity/src/reactive.ts
+++ b/packages/reactivity/src/reactive.ts
@@ -27,13 +27,17 @@ const readonlyValues = new WeakSet<any>()
 const nonReactiveValues = new WeakSet<any>()
 
 const collectionTypes = new Set<Function>([Set, Map, WeakMap, WeakSet])
-const observableValueRE = /^\[object (?:Object|Array|Map|Set|WeakMap|WeakSet)\]$/
+const observableTypes = new Set(
+  ['Object', 'Array', 'Map', 'Set', 'WeakMap', 'WeakSet'].map(
+    t => `[object ${t}]`
+  )
+)
 
 const canObserve = (value: any): boolean => {
   return (
     !value._isVue &&
     !value._isVNode &&
-    observableValueRE.test(toTypeString(value)) &&
+    observableTypes.has(toTypeString(value)) &&
     !nonReactiveValues.has(value)
   )
 }

--- a/packages/reactivity/src/reactive.ts
+++ b/packages/reactivity/src/reactive.ts
@@ -28,7 +28,7 @@ const readonlyValues = new WeakSet<any>()
 const nonReactiveValues = new WeakSet<any>()
 
 const collectionTypes = new Set<Function>([Set, Map, WeakMap, WeakSet])
-const observableMap = /*#__PURE__*/ makeMap(
+const isObservableType = /*#__PURE__*/ makeMap(
   ['Object', 'Array', 'Map', 'Set', 'WeakMap', 'WeakSet']
     .map(t => `[object ${t}]`)
     .join(',')
@@ -38,7 +38,7 @@ const canObserve = (value: any): boolean => {
   return (
     !value._isVue &&
     !value._isVNode &&
-    observableMap(toTypeString(value)) &&
+    isObservableType(toTypeString(value)) &&
     !nonReactiveValues.has(value)
   )
 }

--- a/packages/reactivity/src/reactive.ts
+++ b/packages/reactivity/src/reactive.ts
@@ -6,6 +6,7 @@ import {
 } from './collectionHandlers'
 import { ReactiveEffect } from './effect'
 import { UnwrapRef, Ref } from './ref'
+import { makeMap } from '@vue/shared'
 
 // The main WeakMap that stores {target -> key -> dep} connections.
 // Conceptually, it's easier to think of a dependency as a Dep class
@@ -27,17 +28,17 @@ const readonlyValues = new WeakSet<any>()
 const nonReactiveValues = new WeakSet<any>()
 
 const collectionTypes = new Set<Function>([Set, Map, WeakMap, WeakSet])
-const observableTypes = new Set<String>(
-  ['Object', 'Array', 'Map', 'Set', 'WeakMap', 'WeakSet'].map(
-    t => `[object ${t}]`
-  )
+const observableMap = /*#__PURE__*/ makeMap(
+  ['Object', 'Array', 'Map', 'Set', 'WeakMap', 'WeakSet']
+    .map(t => `[object ${t}]`)
+    .join(',')
 )
 
 const canObserve = (value: any): boolean => {
   return (
     !value._isVue &&
     !value._isVNode &&
-    observableTypes.has(toTypeString(value)) &&
+    observableMap(toTypeString(value)) &&
     !nonReactiveValues.has(value)
   )
 }

--- a/packages/reactivity/src/reactive.ts
+++ b/packages/reactivity/src/reactive.ts
@@ -27,7 +27,7 @@ const readonlyValues = new WeakSet<any>()
 const nonReactiveValues = new WeakSet<any>()
 
 const collectionTypes = new Set<Function>([Set, Map, WeakMap, WeakSet])
-const observableTypes = new Set(
+const observableTypes = new Set<String>(
   ['Object', 'Array', 'Map', 'Set', 'WeakMap', 'WeakSet'].map(
     t => `[object ${t}]`
   )


### PR DESCRIPTION
use the `jsperf` to test.
OS:`Mac OS X 10.14.6`

Chrome 77.0.3865

> RE:31,462  ±2.59%    35% slower  
> Set:48,254  ±1.52%   fastest



the test link [https://jsperf.com/regandset](https://jsperf.com/regandset)
