### PR TITLE
type: improve typing

### DIFF
--- a/packages/reactivity/__tests__/ref.spec.ts
+++ b/packages/reactivity/__tests__/ref.spec.ts
@@ -80,12 +80,23 @@ describe('reactivity/ref', () => {
     expect(typeof (c.value.b + 1)).toBe('number')
   })
 
-  it('should pass type check on ref', () => {
-    const arrRef = ref([1, new Map<any, any>(), ref('1')] as const)
-    const [one, two, three] = arrRef.value
-    one + 1
-    two.has(1)
-    three + 'foo'
+  it('should properly unwrap ref types nested inside arrays', () => {
+    const arr = ref([1, ref(1)]).value
+    // should unwrap to number[]
+    arr[0]++
+    arr[1]++
+
+    const arr2 = ref([1, new Map<string, any>(), ref('1')]).value
+    const value = arr2[0]
+    if (typeof value === 'string') {
+      value + 'foo'
+    } else if (typeof value === 'number') {
+      value + 1
+    } else {
+      // should narrow down to Map type
+      // and not contain any Ref type
+      value.has('foo')
+    }
   })
 
   test('isRef', () => {

--- a/packages/reactivity/__tests__/ref.spec.ts
+++ b/packages/reactivity/__tests__/ref.spec.ts
@@ -80,6 +80,14 @@ describe('reactivity/ref', () => {
     expect(typeof (c.value.b + 1)).toBe('number')
   })
 
+  it('should pass type check on ref', () => {
+    const arrRef = ref([1, new Map<any, any>(), ref('1')] as const)
+    const [one, two, three] = arrRef.value
+    one + 1
+    two.has(1)
+    three + 'foo'
+  })
+
   test('isRef', () => {
     expect(isRef(ref(1))).toBe(true)
     expect(isRef(computed(() => 1))).toBe(true)

--- a/packages/reactivity/src/ref.ts
+++ b/packages/reactivity/src/ref.ts
@@ -74,7 +74,6 @@ export type UnwrapRef<T> = {
   ref: T extends Ref<infer V> ? UnwrapRef<V> : T
   array: T extends Array<infer V> ? Array<UnwrapRef<V>> : T
   object: { [K in keyof T]: UnwrapRef<T[K]> }
-  stop: T
 }[T extends ComputedRef<any>
   ? 'cRef'
   : T extends Ref
@@ -82,5 +81,5 @@ export type UnwrapRef<T> = {
     : T extends Array<any>
       ? 'array'
       : T extends BailTypes
-        ? 'stop' // bail out on types that shouldn't be unwrapped
-        : T extends object ? 'object' : 'stop']
+        ? 'ref' // bail out on types that shouldn't be unwrapped
+        : T extends object ? 'object' : 'ref']


### PR DESCRIPTION
I filter the ref type in the array on type `UnwrapRef`

---

before:

```ts
type ArrayA = Ref<[number, Ref<string>, Ref<Ref<boolean>>, Ref<string>]>
```

will display

```ts
value: (string | number | boolean | Ref<string> | Ref<Ref<boolean>>)[]
```

but now

```ts
value: (string | number | boolean)[]
```