### PR TITLE
fix: add missing compiler to the full build on Windows

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -77,9 +77,7 @@ function createConfig(output, plugins = []) {
   const isGlobalBuild = /\.global(\.prod)?\.js$/.test(output.file)
   const isBundlerESMBuild = /\.esm-bundler\.js$/.test(output.file)
   const isBrowserESMBuild = /esm-browser(\.prod)?\.js$/.test(output.file)
-  const isRuntimeCompileBuild = /\/vue\./.test(output.file)
-
-  console.log(isBundlerESMBuild)
+  const isRuntimeCompileBuild = /vue\./.test(output.file)
 
   if (isGlobalBuild) {
     output.name = packageOptions.name


### PR DESCRIPTION
Full build is missing compiler due to the wrong regexp, testing against `/vue`, when it's actually system-dependent, so it can be both `\vue` or `/vue`. Also removed unnecessary console.log.