### PR TITLE
feat(component): add parent and root to setup context

### DIFF
--- a/packages/runtime-core/__tests__/apiSetupContext.spec.ts
+++ b/packages/runtime-core/__tests__/apiSetupContext.spec.ts
@@ -204,4 +204,36 @@ describe('api: setup context', () => {
     await nextTick()
     expect(serializeInner(root)).toMatch(`<div>1</div>`)
   })
+
+  it('context.root', () => {
+    const Parent = {
+      render: () => h(Child)
+    }
+
+    const Child = createComponent({
+      setup(props, { root }) {
+        return () => h('div', root.vnode._isVNode)
+      }
+    })
+
+    const root = nodeOps.createElement('div')
+    render(h(Parent), root)
+    expect(serializeInner(root)).toMatch(`<div>true</div>`)
+  })
+
+  it('context.parent', () => {
+    const Parent = {
+      render: () => h(Child)
+    }
+
+    const Child = createComponent({
+      setup(props, { parent }) {
+        return () => h('div', parent!.vnode._isVNode)
+      }
+    })
+
+    const root = nodeOps.createElement('div')
+    render(h(Parent), root)
+    expect(serializeInner(root)).toMatch(`<div>true</div>`)
+  })
 })

--- a/packages/runtime-core/src/component.ts
+++ b/packages/runtime-core/src/component.ts
@@ -67,6 +67,8 @@ export interface SetupContext {
   attrs: Data
   slots: Slots
   emit: Emit
+  parent: ComponentInternalInstance | null
+  root: ComponentInternalInstance
 }
 
 export type RenderFunction = () => VNodeChild
@@ -430,7 +432,9 @@ function createSetupContext(instance: ComponentInternalInstance): SetupContext {
     attrs: new Proxy(instance, SetupProxyHandlers.attrs),
     slots: new Proxy(instance, SetupProxyHandlers.slots),
     refs: new Proxy(instance, SetupProxyHandlers.refs),
-    emit: instance.emit
+    emit: instance.emit,
+    parent: instance.parent,
+    root: instance.root
   }
   return __DEV__ ? Object.freeze(context) : context
 }

--- a/packages/runtime-core/src/componentRenderUtils.ts
+++ b/packages/runtime-core/src/componentRenderUtils.ts
@@ -22,7 +22,9 @@ export function renderComponentRoot(
     props,
     slots,
     attrs,
-    emit
+    emit,
+    parent,
+    root
   } = instance
 
   let result
@@ -38,7 +40,9 @@ export function renderComponentRoot(
           ? render(props, {
               attrs,
               slots,
-              emit
+              emit,
+              parent,
+              root
             })
           : render(props, null as any /* we know it doesn't it */)
       )


### PR DESCRIPTION
Add `parent` and `root` fields to setup context according to [the RFC](https://vue-composition-api-rfc.netlify.com/api.html#setup)