### PR TITLE
chore: support debug single jest test file in vscode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,25 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Jest",
+      "type": "node",
+      "request": "launch",
+      "program": "${workspaceFolder}/scripts/jest.js",
+      "stopOnEntry": false,
+      "args": ["${fileBasename}", "--runInBand", "--detectOpenHandles"],
+      "cwd": "${workspaceFolder}",
+      "preLaunchTask": null,
+      "runtimeExecutable": null,
+      "runtimeArgs": ["--nolazy"],
+      "env": {
+        "NODE_ENV": "development"
+      },
+      "console": "integratedTerminal",
+      "sourceMaps": true
+    }
+  ]
+}

--- a/scripts/jest.js
+++ b/scripts/jest.js
@@ -1,14 +1,7 @@
 /**
  * This file is the entry for debug single test file in vscode
  *
- * Why not use node_modules/.bin/jest ?
- * The node_modules/.bin/jest is not work for all operating system, see this issue https://github.com/microsoft/vscode-recipes/issues/107
+ * Not using node_modules/.bin/jest due to cross platform issues, see
+ * https://github.com/microsoft/vscode-recipes/issues/107
  */
-
-const jest = require('jest')
-
-const argv = process.argv
-
-argv.push('--config', 'jest.config.js')
-
-jest.run(argv)
+require('jest').run(process.argv)

--- a/scripts/jest.js
+++ b/scripts/jest.js
@@ -1,0 +1,7 @@
+const jest = require('jest')
+
+const argv = process.argv
+
+argv.push('--config', 'jest.config.js')
+
+jest.run(argv)

--- a/scripts/jest.js
+++ b/scripts/jest.js
@@ -1,3 +1,10 @@
+/**
+ * This file is the entry for debug single test file in vscode
+ *
+ * Why not use node_modules/.bin/jest ?
+ * The node_modules/.bin/jest is not work for all operating system, see this issue https://github.com/microsoft/vscode-recipes/issues/107
+ */
+
 const jest = require('jest')
 
 const argv = process.argv


### PR DESCRIPTION
Four steps:
1. Open the object file
2. Add it.only for object test (Optional)
3. Make breakpoint
4. Click Start debugging