### PR TITLE
types: remove useless type definitions

### DIFF
--- a/packages/compiler-core/src/codeframe.ts
+++ b/packages/compiler-core/src/codeframe.ts
@@ -1,8 +1,8 @@
-const range: number = 2
+const range = 2
 
 export function generateCodeFrame(
   source: string,
-  start: number = 0,
+  start = 0,
   end: number = source.length
 ): string {
   const lines = source.split(/\r?\n/)


### PR DESCRIPTION
Number or string constants do not require type definitions.