### PR TITLE
:fix: mount third param has type error

### DIFF
--- a/packages/runtime-core/src/componentProps.ts
+++ b/packages/runtime-core/src/componentProps.ts
@@ -124,7 +124,7 @@ export function resolveProps(
   // allow mutation of propsProxy (which is readonly by default)
   unlock()
 
-  if (rawProps != null) {
+  if (isObject(rawProps)) {
     for (const key in rawProps) {
       // key, ref are reserved
       if (isReservedProp(key)) continue

--- a/packages/runtime-core/src/vnode.ts
+++ b/packages/runtime-core/src/vnode.ts
@@ -163,7 +163,7 @@ export function createVNode(
   dynamicProps: string[] | null = null
 ): VNode {
   // class & style normalization.
-  if (props !== null) {
+  if (isObject(props)) {
     // for reactive or proxy objects, we need to clone it to enable mutation.
     if (isReactive(props) || SetupProxySymbol in props) {
       props = extend({}, props)


### PR DESCRIPTION
When I pass in the third argument in the mount function, but it is not an object form, but a string, the mount function will report Cannot use 'in' operator to search for 'Symbol()' in test and interrupt the rendering. And quit directly