### PR TITLE
feat(Portal): add ability to use element as target

### DIFF
--- a/packages/runtime-core/src/createRenderer.ts
+++ b/packages/runtime-core/src/createRenderer.ts
@@ -657,7 +657,7 @@ export function createRenderer<
     if (n1 == null) {
       const target = (n2.target = isString(targetSelector)
         ? hostQuerySelector(targetSelector)
-        : null)
+        : targetSelector)
       if (target != null) {
         if (shapeFlag & ShapeFlags.TEXT_CHILDREN) {
           hostSetElementText(target, children as string)


### PR DESCRIPTION
example:
```ts
const el = document.createElement('div')

h(Portal, {
  target: el
}, children)

document.body.appendChild(el)
```

This can also help us write tests for portals since we don't have `querySelector` in `runtime-test`. I'd like to do that. Also, we could probably create `querySelector` there. @yyx990803 what do you think?