### PR TITLE
feat(compiler-core): error if portal doesn't have target

### DIFF
--- a/packages/compiler-core/__tests__/transforms/transformElement.spec.ts
+++ b/packages/compiler-core/__tests__/transforms/transformElement.spec.ts
@@ -288,6 +288,26 @@ describe('compiler: element transform', () => {
     ])
   })
 
+  test('should error on <portal> element with no target', () => {
+    const onError = jest.fn()
+    parseWithElementTransform(`<portal foo="bar"><span /></portal>`, {
+      onError
+    })
+
+    expect(onError.mock.calls[0][0]).toMatchObject({
+      code: ErrorCodes.X_PORTAL_NO_TARGET
+    })
+  })
+
+  test('should not error on <portal> element with bound target', () => {
+    const onError = jest.fn()
+    parseWithElementTransform(`<portal :target="bar"><span /></portal>`, {
+      onError
+    })
+
+    expect(onError).not.toHaveBeenCalled()
+  })
+
   test('should handle <Portal> element', () => {
     const { node } = parseWithElementTransform(
       `<Portal target="#foo"><span /></Portal>`

--- a/packages/compiler-core/src/errors.ts
+++ b/packages/compiler-core/src/errors.ts
@@ -83,6 +83,7 @@ export const enum ErrorCodes {
   X_V_MODEL_MALFORMED_EXPRESSION,
   X_V_MODEL_ON_SCOPE_VARIABLE,
   X_INVALID_EXPRESSION,
+  X_PORTAL_NO_TARGET,
 
   // generic errors
   X_PREFIX_ID_NOT_SUPPORTED,
@@ -175,6 +176,7 @@ export const errorMessages: { [code: number]: string } = {
   [ErrorCodes.X_V_MODEL_MALFORMED_EXPRESSION]: `v-model value must be a valid JavaScript member expression.`,
   [ErrorCodes.X_V_MODEL_ON_SCOPE_VARIABLE]: `v-model cannot be used on v-for or v-slot scope variables because they are not writable.`,
   [ErrorCodes.X_INVALID_EXPRESSION]: `Invalid JavaScript expression.`,
+  [ErrorCodes.X_PORTAL_NO_TARGET]: `Portal doesn't have "target" prop.`,
 
   // generic errors
   [ErrorCodes.X_PREFIX_ID_NOT_SUPPORTED]: `"prefixIdentifiers" option is not supported in this build of compiler.`,

--- a/packages/compiler-core/src/transforms/transformElement.ts
+++ b/packages/compiler-core/src/transforms/transformElement.ts
@@ -114,6 +114,35 @@ export const transformElement: NodeTransform = (node, context) => {
         args.push(propsBuildResult.props)
       }
     }
+
+    if (node.tagType === ElementTypes.PORTAL) {
+      // If node is a portal, check if it has target
+      let noTarget = true
+
+      for (let i = 0; i < node.props.length; i++) {
+        const prop = node.props[i]
+        if (prop.type === NodeTypes.ATTRIBUTE && prop.name === 'target') {
+          noTarget = false
+          break
+        } else if (
+          prop.type === NodeTypes.DIRECTIVE &&
+          prop.name === 'bind' &&
+          prop.arg &&
+          prop.arg.type === NodeTypes.SIMPLE_EXPRESSION &&
+          prop.arg.content === 'target'
+        ) {
+          noTarget = false
+          break
+        }
+      }
+
+      if (noTarget) {
+        context.onError(
+          createCompilerError(ErrorCodes.X_PORTAL_NO_TARGET, node.loc)
+        )
+      }
+    }
+
     // children
     const hasChildren = node.children.length > 0
     if (hasChildren) {


### PR DESCRIPTION
This will help people see their mistakes, erroring compilation of code failing in runtime. E.g. if user uses Vetur, they'll see mistakes in dev-time, not in runtime.

Examples of valid code:
```vue
<portal :target="a">
  <div>Portal content</div>
</portal>
<portal target="#a">
  <div>Portal content</div>
</portal>
```

Examples of erroring code:
```vue
<portal>
  I'm an error
</portal>
<portal a="b">
  I'm an error
</portal>
```