### PR TITLE
feat(compiler-core): process dynamic directive modifiers

### DIFF
--- a/packages/compiler-core/src/ast.ts
+++ b/packages/compiler-core/src/ast.ts
@@ -178,7 +178,7 @@ export interface DirectiveNode extends Node {
   name: string
   exp: ExpressionNode | undefined
   arg: ExpressionNode | undefined
-  modifiers: string[]
+  modifiers: ExpressionNode[]
   // optional property to cache the expression parse result for v-for
   parseResult?: ForParseResult
 }

--- a/packages/compiler-core/src/errors.ts
+++ b/packages/compiler-core/src/errors.ts
@@ -65,6 +65,7 @@ export const enum ErrorCodes {
   X_MISSING_END_TAG,
   X_MISSING_INTERPOLATION_END,
   X_MISSING_DYNAMIC_DIRECTIVE_ARGUMENT_END,
+  X_MISSING_DYNAMIC_DIRECTIVE_MODIFIER_END,
 
   // transform errors
   X_V_IF_NO_EXPRESSION,
@@ -150,6 +151,9 @@ export const errorMessages: { [code: number]: string } = {
   [ErrorCodes.X_MISSING_DYNAMIC_DIRECTIVE_ARGUMENT_END]:
     'End bracket for dynamic directive argument was not found. ' +
     'Note that dynamic directive argument cannot contain spaces.',
+  [ErrorCodes.X_MISSING_DYNAMIC_DIRECTIVE_MODIFIER_END]:
+    'End bracket for dynamic directive modifier was not found. ' +
+    'Note that dynamic directive modifier cannot contain spaces.',
 
   // transform errors
   [ErrorCodes.X_V_IF_NO_EXPRESSION]: `v-if/v-else-if is missing expression.`,

--- a/packages/compiler-core/src/parse.ts
+++ b/packages/compiler-core/src/parse.ts
@@ -617,6 +617,38 @@ function parseAttribute(
       }
     }
 
+    let modifiers: ExpressionNode[] = []
+
+    if (match[3]) {
+      const rawModifiers = match[3].substr(1).split('.')
+
+      for (let i = 0; i < rawModifiers.length; i++) {
+        let content = rawModifiers[i]
+        let isStatic = true
+
+        if (content.startsWith('[')) {
+          isStatic = false
+
+          if (!content.endsWith(']')) {
+            emitError(
+              context,
+              ErrorCodes.X_MISSING_DYNAMIC_DIRECTIVE_MODIFIER_END
+            )
+          }
+
+          content = content.substr(1, content.length - 2)
+        }
+
+        modifiers.push({
+          type: NodeTypes.SIMPLE_EXPRESSION,
+          content,
+          isStatic,
+          isConstant: isStatic,
+          loc
+        })
+      }
+    }
+
     if (value && value.isQuoted) {
       const valueLoc = value.loc
       valueLoc.start.offset++
@@ -644,7 +676,7 @@ function parseAttribute(
         loc: value.loc
       },
       arg,
-      modifiers: match[3] ? match[3].substr(1).split('.') : [],
+      modifiers,
       loc
     }
   }

--- a/packages/compiler-core/src/transforms/transformExpression.ts
+++ b/packages/compiler-core/src/transforms/transformExpression.ts
@@ -55,6 +55,14 @@ export const transformExpression: NodeTransform = (node, context) => {
         if (arg && !arg.isStatic) {
           dir.arg = processExpression(arg, context)
         }
+
+        for (let i = 0; i < dir.modifiers.length; i++) {
+          const modifier = dir.modifiers[i] as SimpleExpressionNode
+
+          if (!modifier.isStatic) {
+            dir.modifiers[i] = processExpression(modifier, context)
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
Example code:
```vue
<span v-a.[a]></span>
```
This dynamic modifier was processed incorrectly as `"[a]": true`, it should be processed as `[_ctx.a]: true`/`[a]: true`.