### PR TITLE
fix(types): fix VNodeTypes unique symbols

### DIFF
--- a/packages/runtime-core/src/suspense.ts
+++ b/packages/runtime-core/src/suspense.ts
@@ -4,7 +4,7 @@ import { isFunction } from '@vue/shared'
 import { ComponentInternalInstance } from './component'
 import { Slots } from './componentSlots'
 
-export const SuspenseSymbol = __DEV__ ? Symbol('Suspense key') : Symbol()
+export const SuspenseSymbol = Symbol(__DEV__ ? 'Suspense key' : undefined)
 
 export interface SuspenseBoundary<
   HostNode = any,

--- a/packages/runtime-core/src/vnode.ts
+++ b/packages/runtime-core/src/vnode.ts
@@ -18,11 +18,11 @@ import { isReactive } from '@vue/reactivity'
 import { AppContext } from './apiApp'
 import { SuspenseBoundary } from './suspense'
 
-export const Fragment = __DEV__ ? Symbol('Fragment') : Symbol()
-export const Portal = __DEV__ ? Symbol('Portal') : Symbol()
-export const Suspense = __DEV__ ? Symbol('Suspense') : Symbol()
-export const Text = __DEV__ ? Symbol('Text') : Symbol()
-export const Comment = __DEV__ ? Symbol('Comment') : Symbol()
+export const Fragment = Symbol(__DEV__ ? 'Fragment' : undefined)
+export const Portal = Symbol(__DEV__ ? 'Portal' : undefined)
+export const Suspense = Symbol(__DEV__ ? 'Suspense' : undefined)
+export const Text = Symbol(__DEV__ ? 'Text' : undefined)
+export const Comment = Symbol(__DEV__ ? 'Comment' : undefined)
 
 export type VNodeTypes =
   | string


### PR DESCRIPTION
TS thought `VNodeTypes = string | Component | symbol` due to ternary. Now `VNodeTypes` is correct:
`VNodeTypes = string | Component | typeof Fragment | typeof Portal | typeof Text | typeof Comment | typeof Suspense`
I fixed `SuspenseSymbol` too.
Wrong `Portal` type:
![image](https://user-images.githubusercontent.com/19504461/67619191-1f949e00-f801-11e9-8f00-fc92b67386a5.png)

Fixed one:
![image](https://user-images.githubusercontent.com/19504461/67619188-15729f80-f801-11e9-9f95-3575f79a0372.png)
