### PR TITLE
chore: fix comments referencing renamed file

### DIFF
--- a/packages/compiler-core/src/transforms/vBind.ts
+++ b/packages/compiler-core/src/transforms/vBind.ts
@@ -4,7 +4,7 @@ import { createCompilerError, ErrorCodes } from '../errors'
 import { camelize } from '@vue/shared'
 import { CAMELIZE } from '../runtimeHelpers'
 
-// v-bind without arg is handled directly in ./element.ts due to it affecting
+// v-bind without arg is handled directly in ./transformElements.ts due to it affecting
 // codegen for the entire props object. This transform here is only for v-bind
 // *with* args.
 export const transformBind: DirectiveTransform = (dir, node, context) => {

--- a/packages/compiler-core/src/transforms/vOn.ts
+++ b/packages/compiler-core/src/transforms/vOn.ts
@@ -16,7 +16,7 @@ import { isMemberExpression, hasScopeRef } from '../utils'
 const fnExpRE = /^([\w$_]+|\([^)]*?\))\s*=>|^function(?:\s+[\w$]+)?\s*\(/
 
 export interface VOnDirectiveNode extends DirectiveNode {
-  // v-on without arg is handled directly in ./element.ts due to it affecting
+  // v-on without arg is handled directly in ./transformElements.ts due to it affecting
   // codegen for the entire props object. This transform here is only for v-on
   // *with* args.
   arg: ExpressionNode


### PR DESCRIPTION
`transformElements.ts` used to be named `element.ts` and the `vBind` and `vOn` transforms still reference the old name in their comments.