### PR TITLE
chore: debug jest in vscode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -19,7 +19,10 @@
         "NODE_ENV": "development"
       },
       "console": "integratedTerminal",
-      "sourceMaps": true
+      "sourceMaps": true,
+      "windows": {
+        "program": "${workspaceFolder}/node_modules/jest/bin/jest",
+      }
     }
   ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,7 +8,7 @@
       "name": "Jest",
       "type": "node",
       "request": "launch",
-      "program": "${workspaceFolder}/scripts/jest.js",
+      "program": "${workspaceFolder}/node_modules/jest/.bin/jest",
       "stopOnEntry": false,
       "args": ["${fileBasename}", "--runInBand", "--detectOpenHandles"],
       "cwd": "${workspaceFolder}",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,7 +8,7 @@
       "name": "Jest",
       "type": "node",
       "request": "launch",
-      "program": "${workspaceFolder}/node_modules/jest/.bin/jest",
+      "program": "${workspaceFolder}/node_modules/.bin/jest",
       "stopOnEntry": false,
       "args": ["${fileBasename}", "--runInBand", "--detectOpenHandles"],
       "cwd": "${workspaceFolder}",

--- a/scripts/jest.js
+++ b/scripts/jest.js
@@ -1,7 +1,0 @@
-/**
- * This file is the entry for debug single test file in vscode
- *
- * Not using node_modules/.bin/jest due to cross platform issues, see
- * https://github.com/microsoft/vscode-recipes/issues/107
- */
-require('jest').run(process.argv)


### PR DESCRIPTION
ref #360 

I can't match file in original way, and https://github.com/microsoft/vscode-recipes/pull/108 added a workaround configuration for windows users. [doc here](https://github.com/microsoft/vscode-recipes/blob/master/debugging-jest-tests/README.md#configure-packagejson-file-for-your-test-framework). I work fine in the config, but i didn't test other systems.
