### PR TITLE
fix(transformElement): build suspense slots

### DIFF
--- a/packages/compiler-core/src/transforms/transformElement.ts
+++ b/packages/compiler-core/src/transforms/transformElement.ts
@@ -120,7 +120,7 @@ export const transformElement: NodeTransform = (node, context) => {
       if (!hasProps) {
         args.push(`null`)
       }
-      if (isComponent) {
+      if (isComponent || node.tagType === ElementTypes.SUSPENSE) {
         const { slots, hasDynamicSlots } = buildSlots(node, context)
         args.push(slots)
         if (hasDynamicSlots) {


### PR DESCRIPTION
This code:
```vue
<suspense>
  <template #default><div>default</div></template>
  <template #fallback><div>fallback</div></template>
</suspense>
```
was compiled with errors, now it builds slots OK.
UPD: what's about validation of Suspense slots?