### PR TITLE
types(reactivity): improve toRefs type

### DIFF
--- a/packages/reactivity/src/reactive.ts
+++ b/packages/reactivity/src/reactive.ts
@@ -42,7 +42,7 @@ const canObserve = (value: any): boolean => {
 }
 
 // only unwrap nested ref
-type UnwrapNestedRefs<T> = T extends Ref ? T : UnwrapRef<T>
+export type UnwrapNestedRefs<T> = T extends Ref ? T : UnwrapRef<T>
 
 export function reactive<T extends object>(target: T): UnwrapNestedRefs<T>
 export function reactive(target: object) {

--- a/packages/reactivity/src/ref.ts
+++ b/packages/reactivity/src/ref.ts
@@ -1,7 +1,7 @@
 import { track, trigger } from './effect'
 import { OperationTypes } from './operations'
 import { isObject } from '@vue/shared'
-import { reactive } from './reactive'
+import { reactive, UnwrapNestedRefs } from './reactive'
 import { ComputedRef } from './computed'
 import { CollectionTypes } from './collectionHandlers'
 
@@ -39,7 +39,7 @@ export function isRef(r: any): r is Ref {
 }
 
 export function toRefs<T extends object>(
-  object: T
+  object: UnwrapNestedRefs<T>
 ): { [K in keyof T]: Ref<T[K]> } {
   const ret: any = {}
   for (const key in object) {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/26789139/68013296-7b5e9b80-fcc7-11e9-80ac-f398dec2c7da.png) 
I think the parameter type passed to the toRefs function should be UnwrapNestedRefs instead of object.