### PR TITLE
test(apiApp): add test for app.use

### DIFF
--- a/packages/runtime-core/__tests__/apiApp.spec.ts
+++ b/packages/runtime-core/__tests__/apiApp.spec.ts
@@ -246,7 +246,13 @@ describe('api: createApp', () => {
     }
 
     const app = createApp()
-    app.use(PluginA)
+    app.use(PluginA).use(PluginA) // call repeatedly
+
+    expect(
+      `App already provides property with key "foo". ` +
+        `It will be overwritten with the new value.`
+    ).toHaveBeenWarnedTimes(1)
+
     app.use(PluginB)
 
     const Root = {


### PR DESCRIPTION
It seems that `app.use()` in `Vue 3.x` does not store plugin in cache, It is different from `Vue 2.x`, I do not know why, so I add a test for this case to explicitly notify the users