### PR TITLE
tests: Add check if the child array gets unwrap

### DIFF
--- a/packages/reactivity/__tests__/ref.spec.ts
+++ b/packages/reactivity/__tests__/ref.spec.ts
@@ -61,6 +61,14 @@ describe('reactivity/ref', () => {
     expect(dummy1).toBe(3)
     expect(dummy2).toBe(3)
     expect(dummy3).toBe(3)
+    obj.b.c++
+    expect(dummy1).toBe(4)
+    expect(dummy2).toBe(4)
+    expect(dummy3).toBe(4)
+    obj.b.d[0]++
+    expect(dummy1).toBe(5)
+    expect(dummy2).toBe(5)
+    expect(dummy3).toBe(5)
   })
 
   it('should unwrap nested ref in types', () => {

--- a/packages/reactivity/src/ref.ts
+++ b/packages/reactivity/src/ref.ts
@@ -82,8 +82,10 @@ type UnwrapRefPropValue<T> = T extends Array<infer V>
         ? T
         : T extends object ? { [K in keyof T]: UnwrapRefPropValue<T[K]> } : T
 
-export type UnwrapRef<T> = T extends object
-  ? T extends Ref<infer V>
-    ? { [K in keyof V]: UnwrapRefPropValue<V[K]> }
-    : { [K in keyof T]: UnwrapRefPropValue<T[K]> }
-  : T
+export type UnwrapRef<T> = T extends Function | CollectionTypes
+  ? T
+  : T extends object
+    ? T extends Ref<infer V>
+      ? { [K in keyof V]: UnwrapRefPropValue<V[K]> }
+      : { [K in keyof T]: UnwrapRefPropValue<T[K]> }
+    : T

--- a/packages/reactivity/src/ref.ts
+++ b/packages/reactivity/src/ref.ts
@@ -82,6 +82,8 @@ type UnwrapRefPropValue<T> = T extends Array<infer V>
         ? T
         : T extends object ? { [K in keyof T]: UnwrapRefPropValue<T[K]> } : T
 
-export type UnwrapRef<T> = T extends Ref<infer V>
-  ? { [K in keyof V]: UnwrapRefPropValue<V[K]> }
-  : { [K in keyof T]: UnwrapRefPropValue<T[K]> }
+export type UnwrapRef<T> = T extends object
+  ? T extends Ref<infer V>
+    ? { [K in keyof V]: UnwrapRefPropValue<V[K]> }
+    : { [K in keyof T]: UnwrapRefPropValue<T[K]> }
+  : T

--- a/packages/reactivity/src/ref.ts
+++ b/packages/reactivity/src/ref.ts
@@ -72,18 +72,16 @@ function toProxyRef<T extends object, K extends keyof T>(
   }
 }
 
-// Recursively unwraps nested value bindings.
-export type UnwrapRef<T> = {
-  cRef: T extends ComputedRef<infer V> ? UnwrapRef<V> : T
-  ref: T extends Ref<infer V> ? UnwrapRef<V> : T
-  array: T extends Array<infer V> ? Array<UnwrapRef<V>> : T
-  object: { [K in keyof T]: UnwrapRef<T[K]> }
-}[T extends ComputedRef<any>
-  ? 'cRef'
-  : T extends Ref
-    ? 'ref'
-    : T extends Array<any>
-      ? 'array'
+type UnwrapRefPropValue<T> = T extends Array<infer V>
+  ? Array<UnwrapRef<V>>
+  : T extends ComputedRef<infer V>
+    ? UnwrapRef<V>
+    : T extends Ref<infer V>
+      ? UnwrapRef<V>
       : T extends Function | CollectionTypes
-        ? 'ref' // bail out on types that shouldn't be unwrapped
-        : T extends object ? 'object' : 'ref']
+        ? T
+        : T extends object ? { [K in keyof T]: UnwrapRefPropValue<T[K]> } : T
+
+export type UnwrapRef<T> = T extends Ref<infer V>
+  ? { [K in keyof V]: UnwrapRefPropValue<V[K]> }
+  : { [K in keyof T]: UnwrapRefPropValue<T[K]> }


### PR DESCRIPTION
Check if the types of the return reactive unwraps correctly, since `dummy`s are of type undefined 