### PR TITLE
types(reactivity): add support for tuples

### DIFF
--- a/packages/reactivity/__tests__/ref.spec.ts
+++ b/packages/reactivity/__tests__/ref.spec.ts
@@ -1,4 +1,4 @@
-import { ref, effect, reactive, isRef, toRefs } from '../src/index'
+import { ref, effect, reactive, isRef, toRefs, Ref } from '../src/index'
 import { computed } from '@vue/runtime-dom'
 
 describe('reactivity/ref', () => {
@@ -105,6 +105,27 @@ describe('reactivity/ref', () => {
       // and not contain any Ref type
       value.has('foo')
     }
+  })
+
+  it('should keep tuple types', () => {
+    const tuple: [number, string, { a: number }, () => number, Ref<number>] = [
+      0,
+      '1',
+      { a: 1 },
+      () => 0,
+      ref(0)
+    ]
+    const tupleRef = ref(tuple)
+
+    tupleRef.value[0]++
+    expect(tupleRef.value[0]).toBe(1)
+    tupleRef.value[1].concat('1')
+    expect(tupleRef.value[1]).toBe('11')
+    tupleRef.value[2].a++
+    expect(tupleRef.value[2].a).toBe(2)
+    expect(tupleRef.value[3]()).toBe(2)
+    tupleRef.value[4]++
+    expect(tupleRef.value[4]).toBe(1)
   })
 
   test('isRef', () => {

--- a/packages/reactivity/__tests__/ref.spec.ts
+++ b/packages/reactivity/__tests__/ref.spec.ts
@@ -119,11 +119,11 @@ describe('reactivity/ref', () => {
 
     tupleRef.value[0]++
     expect(tupleRef.value[0]).toBe(1)
-    tupleRef.value[1].concat('1')
+    tupleRef.value[1] += '1'
     expect(tupleRef.value[1]).toBe('11')
     tupleRef.value[2].a++
     expect(tupleRef.value[2].a).toBe(2)
-    expect(tupleRef.value[3]()).toBe(2)
+    expect(tupleRef.value[3]()).toBe(0)
     tupleRef.value[4]++
     expect(tupleRef.value[4]).toBe(1)
   })

--- a/packages/reactivity/src/ref.ts
+++ b/packages/reactivity/src/ref.ts
@@ -72,15 +72,19 @@ function toProxyRef<T extends object, K extends keyof T>(
   }
 }
 
-type UnwrapArray<T> = {
-  [P in keyof T]: UnwrapRef<T[P]>;
-} & { length: number; }
+type UnwrapArray<T> = { [P in keyof T]: UnwrapRef<T[P]> } & { length: number }
+
+type IsTuple<T> = T extends (infer V)[]
+  ? T extends { 0: V } ? true : T extends { length: 0 } ? true : false
+  : never
 
 // Recursively unwraps nested value bindings.
 export type UnwrapRef<T> = {
   cRef: T extends ComputedRef<infer V> ? UnwrapRef<V> : T
   ref: T extends Ref<infer V> ? UnwrapRef<V> : T
-  array: T extends Array<any> ? UnwrapArray<T> : T
+  array: T extends Array<infer V>
+    ? IsTuple<V> extends false ? Array<UnwrapRef<V>> : UnwrapArray<T>
+    : T
   object: { [K in keyof T]: UnwrapRef<T[K]> }
 }[T extends ComputedRef<any>
   ? 'cRef'

--- a/packages/reactivity/src/ref.ts
+++ b/packages/reactivity/src/ref.ts
@@ -72,11 +72,15 @@ function toProxyRef<T extends object, K extends keyof T>(
   }
 }
 
+type UnwrapArray<T> = {
+  [P in keyof T]: UnwrapRef<T[P]>;
+} & { length: number; }
+
 // Recursively unwraps nested value bindings.
 export type UnwrapRef<T> = {
   cRef: T extends ComputedRef<infer V> ? UnwrapRef<V> : T
   ref: T extends Ref<infer V> ? UnwrapRef<V> : T
-  array: T extends Array<infer V> ? Array<UnwrapRef<V>> : T
+  array: T extends Array<any> ? UnwrapArray<T> : T
   object: { [K in keyof T]: UnwrapRef<T[K]> }
 }[T extends ComputedRef<any>
   ? 'cRef'

--- a/packages/reactivity/src/ref.ts
+++ b/packages/reactivity/src/ref.ts
@@ -72,19 +72,13 @@ function toProxyRef<T extends object, K extends keyof T>(
   }
 }
 
-type UnwrapArray<T> = { [P in keyof T]: UnwrapRef<T[P]> } & { length: number }
-
-type IsTuple<T> = T extends (infer V)[]
-  ? T extends { 0: V } ? true : T extends { length: 0 } ? true : false
-  : never
+type UnwrapArray<T> = { [P in keyof T]: UnwrapRef<T[P]> }
 
 // Recursively unwraps nested value bindings.
 export type UnwrapRef<T> = {
   cRef: T extends ComputedRef<infer V> ? UnwrapRef<V> : T
   ref: T extends Ref<infer V> ? UnwrapRef<V> : T
-  array: T extends Array<infer V>
-    ? IsTuple<V> extends false ? Array<UnwrapRef<V>> : UnwrapArray<T>
-    : T
+  array: T extends Array<infer V> ? Array<UnwrapRef<V>> & UnwrapArray<T> : T
   object: { [K in keyof T]: UnwrapRef<T[K]> }
 }[T extends ComputedRef<any>
   ? 'cRef'


### PR DESCRIPTION
Allows to keep the tuple types when unwrapping 

https://www.typescriptlang.org/docs/handbook/basic-types.html#tuple

```ts
const tuple = ref<string,number(["hello", 10]).value
tuple[0].concat('world') // valid
tuple[1]++ // valid

tuple[0]++ // invalid because is string
```