### PR TITLE
fix: spelling is wrong ('with'=>'width')

### DIFF
--- a/packages/runtime-core/__tests__/vnode.spec.ts
+++ b/packages/runtime-core/__tests__/vnode.spec.ts
@@ -182,10 +182,10 @@ describe('vnode', () => {
         style: [
           {
             color: 'blue',
-            with: '200px'
+            width: '200px'
           },
           {
-            with: '300px',
+            width: '300px',
             height: '300px',
             fontSize: 30
           }
@@ -194,7 +194,7 @@ describe('vnode', () => {
       expect(mergeProps(props1, props2)).toMatchObject({
         style: {
           color: 'blue',
-          with: '300px',
+          width: '300px',
           height: '300px',
           fontSize: 30
         }

--- a/packages/template-explorer/src/index.ts
+++ b/packages/template-explorer/src/index.ts
@@ -32,7 +32,7 @@ window.init = () => {
         filename: 'template.vue',
         ...compilerOptions,
         sourceMap: true,
-        onError: (err: CompilerError) => {
+        onError: err => {
           errors.push(err)
         }
       })

--- a/packages/template-explorer/src/index.ts
+++ b/packages/template-explorer/src/index.ts
@@ -32,7 +32,7 @@ window.init = () => {
         filename: 'template.vue',
         ...compilerOptions,
         sourceMap: true,
-        onError: err => {
+        onError: (err: CompilerError) => {
           errors.push(err)
         }
       })


### PR DESCRIPTION
spelling is wrong ('with'=>'width')