### PR TITLE
perf(compiler-core): use indexOf instead of startsWith

### DIFF
--- a/packages/compiler-core/src/parse.ts
+++ b/packages/compiler-core/src/parse.ts
@@ -939,7 +939,7 @@ function last<T>(xs: T[]): T | undefined {
 }
 
 function startsWith(source: string, searchString: string): boolean {
-  return source.startsWith(searchString)
+  return source.indexOf(searchString) === 0
 }
 
 function advanceBy(context: ParserContext, numberOfCharacters: number): void {

--- a/packages/compiler-core/src/transforms/transformElement.ts
+++ b/packages/compiler-core/src/transforms/transformElement.ts
@@ -425,8 +425,8 @@ function dedupeProperties(properties: Property[]): Property[] {
       if (
         name === 'style' ||
         name === 'class' ||
-        name.startsWith('on') ||
-        name.startsWith('vnode')
+        name.indexOf('on') === 0 ||
+        name.indexOf('vnode') === 0
       ) {
         mergeAsArray(existing, prop)
       }


### PR DESCRIPTION
string.indexOf() is much faster than the string.startsWith() function

https://jsperf.com/startswithnative
