### PR TITLE
test(dts): props is not read-only

### DIFF
--- a/packages/runtime-core/src/apiCreateComponent.ts
+++ b/packages/runtime-core/src/apiCreateComponent.ts
@@ -14,16 +14,19 @@ import { VNodeProps } from './vnode'
 // overload 1: direct setup function
 // (uses user defined props interface)
 export function createComponent<Props, RawBindings = object>(
-  setup: (props: Props, ctx: SetupContext) => RawBindings | RenderFunction
+  setup: (
+    props: Readonly<Props>,
+    ctx: SetupContext
+  ) => RawBindings | RenderFunction
 ): {
   new (): ComponentPublicInstance<
-    Props,
+    Readonly<Props>,
     RawBindings,
     {},
     {},
     {},
     // public props
-    VNodeProps & Props
+    VNodeProps & Readonly<Props>
   >
 }
 
@@ -37,15 +40,15 @@ export function createComponent<
   C extends ComputedOptions = {},
   M extends MethodOptions = {}
 >(
-  options: ComponentOptionsWithoutProps<Props, RawBindings, D, C, M>
+  options: ComponentOptionsWithoutProps<Readonly<Props>, RawBindings, D, C, M>
 ): {
   new (): ComponentPublicInstance<
-    Props,
+    Readonly<Props>,
     RawBindings,
     D,
     C,
     M,
-    VNodeProps & Props
+    VNodeProps & Readonly<Props>
   >
 }
 

--- a/test-dts/createComponent.test-d.tsx
+++ b/test-dts/createComponent.test-d.tsx
@@ -12,7 +12,10 @@ describe('with object props', () => {
     ccc?: string[] | undefined
     ddd: string[]
   }
-
+  createComponent<ExpectedProps>(props => () => {
+    // props should be readonly
+    expectError((props.a = 1))
+  })
   const MyComponent = createComponent({
     props: {
       a: Number,


### PR DESCRIPTION
when ComponentOptionsWithoutProps , props is not readonly.

  createComponent<ExpectedProps.> (props => () => {
    // props should be readonly
    expectError((props.a = 1))
  })