### PR TITLE
refactor(runtime-dom): avoid unnecessary checks in patchDOMProp

### DIFF
--- a/packages/runtime-dom/src/modules/props.ts
+++ b/packages/runtime-dom/src/modules/props.ts
@@ -12,11 +12,15 @@ export function patchDOMProp(
 ) {
   if ((key === 'innerHTML' || key === 'textContent') && prevChildren != null) {
     unmountChildren(prevChildren, parentComponent, parentSuspense)
+    el[key] = value == null ? '' : value
+    return
   }
   if (key === 'value' && el.tagName !== 'PROGRESS') {
     // store value as _value as well since
     // non-string values will be stringified.
     el._value = value
+    el.value = value == null ? '' : value
+    return
   }
   if (value === '' && typeof el[key] === 'boolean') {
     // e.g. <select multiple> compiles to { multiple: '' }


### PR DESCRIPTION
While implementing #449 I noticed that `patchDOMProp` is currently doing several checks where only one should be enough.
This commit adds some early returns to slightly speed up the overall function in some cases.