### PR TITLE
feat(scheduler): prevent from maximum recursive updates

### DIFF
--- a/packages/runtime-core/src/scheduler.ts
+++ b/packages/runtime-core/src/scheduler.ts
@@ -37,51 +37,60 @@ function queueFlush() {
 
 const dedupe = (cbs: Function[]): Function[] => [...new Set(cbs)]
 
-export function flushPostFlushCbs() {
+export function flushPostFlushCbs(seen?: CountMap) {
   if (postFlushCbs.length) {
     const cbs = dedupe(postFlushCbs)
     postFlushCbs.length = 0
+    if (__DEV__) {
+      seen = seen || new Map()
+    }
     for (let i = 0; i < cbs.length; i++) {
+      if (__DEV__) {
+        checkRecursiveUpdates(seen!, cbs[i])
+      }
       cbs[i]()
     }
   }
 }
 
 const RECURSION_LIMIT = 100
-type JobCountMap = Map<Function, number>
+type CountMap = Map<Function, number>
 
-function flushJobs(seenJobs?: JobCountMap) {
+function checkRecursiveUpdates(seen: CountMap, fn: Function) {
+  if (!seen.has(fn)) {
+    seen.set(fn, 1)
+  } else {
+    const count = seen.get(fn)!
+    if (count > RECURSION_LIMIT) {
+      throw new Error(
+        'Maximum recursive updates exceeded. ' +
+          "You may have code that is mutating state in your component's " +
+          'render function or updated hook or watcher source function.'
+      )
+    } else {
+      seen.set(fn, count + 1)
+    }
+  }
+}
+
+function flushJobs(seen?: CountMap) {
   isFlushPending = false
   isFlushing = true
   let job
   if (__DEV__) {
-    seenJobs = seenJobs || new Map()
+    seen = seen || new Map()
   }
   while ((job = queue.shift())) {
     if (__DEV__) {
-      const seen = seenJobs!
-      if (!seen.has(job)) {
-        seen.set(job, 1)
-      } else {
-        const count = seen.get(job)!
-        if (count > RECURSION_LIMIT) {
-          throw new Error(
-            'Maximum recursive updates exceeded. ' +
-              "You may have code that is mutating state in your component's " +
-              'render function or updated hook.'
-          )
-        } else {
-          seen.set(job, count + 1)
-        }
-      }
+      checkRecursiveUpdates(seen!, job)
     }
     callWithErrorHandling(job, null, ErrorCodes.SCHEDULER)
   }
-  flushPostFlushCbs()
+  flushPostFlushCbs(seen)
   isFlushing = false
   // some postFlushCb queued jobs!
   // keep flushing until it drains.
   if (queue.length || postFlushCbs.length) {
-    flushJobs(seenJobs)
+    flushJobs(seen)
   }
 }


### PR DESCRIPTION
The demo is as follows:

```js
  const state = reactive({ count: 0 })
  let dummy
  watch(() => {
    dummy = state.count
    state.count++
  })
```
`flushPostFlushCbs` dost not check maximum recursive updates, the code above will cause a maximum call exceed