### PR TITLE
perf(compiler-dom): generate modifiers in a function

### DIFF
--- a/packages/compiler-dom/__tests__/transforms/vOn.spec.ts
+++ b/packages/compiler-dom/__tests__/transforms/vOn.spec.ts
@@ -54,7 +54,7 @@ describe('compiler-dom: transform v-on', () => {
     )
     const [clickProp, keyUpProp] = props
 
-    expect(props.length).toBe(2)
+    expect(props).toHaveLength(2)
     expect(clickProp).toMatchObject({
       type: NodeTypes.JS_PROPERTY,
       value: {

--- a/packages/compiler-dom/__tests__/transforms/vOn.spec.ts
+++ b/packages/compiler-dom/__tests__/transforms/vOn.spec.ts
@@ -45,6 +45,32 @@ describe('compiler-dom: transform v-on', () => {
     })
   })
 
+  it('should support multiple events and modifiers options w/ prefixIdentifiers: true', () => {
+    const { props } = parseWithVOn(
+      `<div @click.stop="test" @keyup.enter="test" />`,
+      {
+        prefixIdentifiers: true
+      }
+    )
+    const [clickProp, keyUpProp] = props
+
+    expect(props.length).toBe(2)
+    expect(clickProp).toMatchObject({
+      type: NodeTypes.JS_PROPERTY,
+      value: {
+        callee: V_ON_WITH_MODIFIERS,
+        arguments: [{ content: '_ctx.test' }, '["stop"]']
+      }
+    })
+    expect(keyUpProp).toMatchObject({
+      type: NodeTypes.JS_PROPERTY,
+      value: {
+        callee: V_ON_WITH_KEYS,
+        arguments: [{ content: '_ctx.test' }, '["enter"]']
+      }
+    })
+  })
+
   it('should support multiple modifiers and event options w/ prefixIdentifiers: true', () => {
     const {
       props: [prop]

--- a/packages/compiler-dom/src/transforms/vOn.ts
+++ b/packages/compiler-dom/src/transforms/vOn.ts
@@ -25,18 +25,18 @@ const isKeyboardEvent = /*#__PURE__*/ makeMap(
 )
 
 const generateModifiers = (modifiers: string[]) => {
-  const modifiersSize = modifiers.length
-
   const keyModifiers = []
   const nonKeyModifiers = []
   const eventOptionModifiers = []
 
-  for (let i = 0; i < modifiersSize; i++) {
+  for (let i = 0; i < modifiers.length; i++) {
     const modifier = modifiers[i]
 
     if (isEventOptionModifier(modifier)) {
+      // eventOptionModifiers: modifiers for addEventListener() options, e.g. .passive & .capture
       eventOptionModifiers.push(modifier)
     } else {
+      // runtimeModifiers: modifiers that needs runtime guards
       if (isNonKeyModifier(modifier)) {
         nonKeyModifiers.push(modifier)
       } else {
@@ -46,7 +46,8 @@ const generateModifiers = (modifiers: string[]) => {
   }
 
   return {
-    runtimeModifiers: [keyModifiers, nonKeyModifiers],
+    keyModifiers,
+    nonKeyModifiers,
     eventOptionModifiers
   }
 }
@@ -57,15 +58,11 @@ export const transformOn: DirectiveTransform = (dir, node, context) => {
     if (!modifiers.length) return baseResult
 
     let { key, value: handlerExp } = baseResult.props[0]
-
-    // eventOptionModifiers: modifiers for addEventListener() options, e.g. .passive & .capture
-    // runtimeModifiers: modifiers that needs runtime guards
-    const { runtimeModifiers, eventOptionModifiers } = generateModifiers(
-      modifiers
-    )
-
-    // built-in modifiers
-    const [keyModifiers, nonKeyModifiers] = runtimeModifiers
+    const {
+      keyModifiers,
+      nonKeyModifiers,
+      eventOptionModifiers
+    } = generateModifiers(modifiers)
 
     if (nonKeyModifiers.length) {
       handlerExp = createCallExpression(context.helper(V_ON_WITH_MODIFIERS), [


### PR DESCRIPTION
Created a function to generate modifiers in just one loop, instead of use filters inside `transformOn`. Also, it was added a test with multiple events with modifiers.