### PR TITLE
bug: _createTextVNode is not defined

### DIFF
--- a/packages/vue/examples/todomvc-composition.html
+++ b/packages/vue/examples/todomvc-composition.html
@@ -50,6 +50,8 @@
       </button>
     </footer>
   </section>
+  <Child/>
+
 </div>
 
 <script>
@@ -89,8 +91,20 @@ const filters = {
 function pluralize (n) {
   return n === 1 ? 'item' : 'items'
 }
+//当dom层级达到三级， _createTextVNode is not defined
+const Child = {
+  template:`
+  <div>
+    <div>
+      <div>111</div>
+      11
+    </div>
+  </div>
+  `
+}
 
 const App = {
+  components:{Child},
   setup () {
     const state = reactive({
       todos: todoStorage.fetch(),


### PR DESCRIPTION
`Uncaught ReferenceError: _createTextVNode is not defined
    at eval (eval at compileToFunction (vue.global.js:10790), <anonymous>:5:3)
    at compileToFunction (vue.global.js:10790)
    at finishComponentSetup (vue.global.js:9878)
    at setupStatefulComponent (vue.global.js:9846)
    at mountComponent (vue.global.js:8358)
    at processComponent (vue.global.js:8297)
    at patch (vue.global.js:8022)
    at mountChildren (vue.global.js:8096)
    at processFragment (vue.global.js:8228)
    at patch (vue.global.js:8012)`