### PR TITLE
feat(transition): Added functions to remove repeat and removed unnecessary type

### DIFF
--- a/packages/runtime-dom/src/components/CSSTransition.ts
+++ b/packages/runtime-dom/src/components/CSSTransition.ts
@@ -297,6 +297,6 @@ function getTimeout(delays: string[], durations: string[]): number {
 // numbers in a locale-dependent way, using a comma instead of a dot.
 // If comma is not replaced with a dot, the input will be rounded down
 // (i.e. acting as a floor function) causing unexpected behaviors
-function toMs(s: string) {
+function toMs(s: string): number {
   return Number(s.slice(0, -1).replace(',', '.')) * 1000
 }

--- a/packages/runtime-dom/src/components/CSSTransition.ts
+++ b/packages/runtime-dom/src/components/CSSTransition.ts
@@ -289,7 +289,6 @@ function getTimeout(delays: string[], durations: string[]): number {
   while (delays.length < durations.length) {
     delays = delays.concat(delays)
   }
-
   return Math.max(...durations.map((d, i) => toMs(d) + toMs(delays[i])))
 }
 

--- a/packages/runtime-dom/src/components/CSSTransition.ts
+++ b/packages/runtime-dom/src/components/CSSTransition.ts
@@ -281,6 +281,6 @@ function getTimeout(delays: string[], durations: string[]): number {
 // numbers in a locale-dependent way, using a comma instead of a dot.
 // If comma is not replaced with a dot, the input will be rounded down
 // (i.e. acting as a floor function) causing unexpected behaviors
-function toMs(s: string): number {
+function toMs(s: string) {
   return Number(s.slice(0, -1).replace(',', '.')) * 1000
 }

--- a/packages/runtime-dom/src/components/CSSTransition.ts
+++ b/packages/runtime-dom/src/components/CSSTransition.ts
@@ -265,15 +265,31 @@ function getTransitionInfo(
   }
 }
 
+function getMaximumNumber<T>(
+  array: T[],
+  valueCallback: (value: T, index: number) => number,
+  intialMaximumNumber = -Infinity
+) {
+  let maximum = intialMaximumNumber
+
+  for (let i = 0; i < array.length; i++) {
+    const current = valueCallback(array[i], i)
+
+    if (current > maximum) {
+      maximum = current
+    }
+  }
+
+  return maximum
+}
+
 function getTimeout(delays: string[], durations: string[]): number {
   while (delays.length < durations.length) {
     delays = delays.concat(delays)
   }
-  return Math.max.apply(
-    null,
-    durations.map((d, i) => {
-      return toMs(d) + toMs(delays[i])
-    })
+  return getMaximumNumber(
+    durations,
+    (duration, i) => toMs(duration) + toMs(delays[i])
   )
 }
 

--- a/packages/runtime-dom/src/components/CSSTransition.ts
+++ b/packages/runtime-dom/src/components/CSSTransition.ts
@@ -215,14 +215,17 @@ function getTransitionInfo(
   expectedType?: CSSTransitionProps['type']
 ): CSSTransitionInfo {
   const styles: any = window.getComputedStyle(el)
+
+  function getStyleProperties(propertyName: string): string[] {
+    return (styles[propertyName] || '').split(', ')
+  }
+
   // JSDOM may return undefined for transition properties
-  const transitionDelays = (styles[TRANSITION + 'Delay'] || '').split(', ')
-  const transitionDurations = (styles[TRANSITION + 'Duration'] || '').split(
-    ', '
-  )
+  const transitionDelays = getStyleProperties(TRANSITION + 'Delay')
+  const transitionDurations = getStyleProperties(TRANSITION + 'Duration')
   const transitionTimeout = getTimeout(transitionDelays, transitionDurations)
-  const animationDelays = (styles[ANIMATION + 'Delay'] || '').split(', ')
-  const animationDurations = (styles[ANIMATION + 'Duration'] || '').split(', ')
+  const animationDelays = getStyleProperties(ANIMATION + 'Delay')
+  const animationDurations = getStyleProperties(ANIMATION + 'Duration')
   const animationTimeout = getTimeout(animationDelays, animationDurations)
 
   let type: CSSTransitionInfo['type'] = null

--- a/packages/runtime-dom/src/components/CSSTransition.ts
+++ b/packages/runtime-dom/src/components/CSSTransition.ts
@@ -287,32 +287,12 @@ function getTransitionInfo(
   }
 }
 
-function getMaximumNumber<T>(
-  array: T[],
-  valueCallback: (value: T, index: number) => number,
-  intialMaximumNumber = -Infinity
-) {
-  let maximum = intialMaximumNumber
-
-  for (let i = 0; i < array.length; i++) {
-    const current = valueCallback(array[i], i)
-
-    if (current > maximum) {
-      maximum = current
-    }
-  }
-
-  return maximum
-}
-
 function getTimeout(delays: string[], durations: string[]): number {
   while (delays.length < durations.length) {
     delays = delays.concat(delays)
   }
-  return getMaximumNumber(
-    durations,
-    (duration, i) => toMs(duration) + toMs(delays[i])
-  )
+
+  return Math.max(...durations.map((d, i) => toMs(d) + toMs(delays[i])))
 }
 
 // Old versions of Chromium (below 61.0.3163.100) formats floating pointer

--- a/packages/runtime-dom/src/components/CSSTransition.ts
+++ b/packages/runtime-dom/src/components/CSSTransition.ts
@@ -238,9 +238,7 @@ function getTransitionInfo(
 ): CSSTransitionInfo {
   const styles: any = window.getComputedStyle(el)
 
-  function getStyleProperties(propertyName: string): string[] {
-    return (styles[propertyName] || '').split(', ')
-  }
+  const getStyleProperties = (key: string) => (styles[key] || '').split(', ')
 
   // JSDOM may return undefined for transition properties
   const transitionDelays = getStyleProperties(TRANSITION + 'Delay')

--- a/packages/runtime-dom/src/components/CSSTransition.ts
+++ b/packages/runtime-dom/src/components/CSSTransition.ts
@@ -237,10 +237,8 @@ function getTransitionInfo(
   expectedType?: CSSTransitionProps['type']
 ): CSSTransitionInfo {
   const styles: any = window.getComputedStyle(el)
-
-  const getStyleProperties = (key: string) => (styles[key] || '').split(', ')
-
   // JSDOM may return undefined for transition properties
+  const getStyleProperties = (key: string) => (styles[key] || '').split(', ')
   const transitionDelays = getStyleProperties(TRANSITION + 'Delay')
   const transitionDurations = getStyleProperties(TRANSITION + 'Duration')
   const transitionTimeout = getTimeout(transitionDelays, transitionDurations)


### PR DESCRIPTION
- It was added a function to remove repeatable code
- Changed use `for` instead of `Math.max` with `map`  for a better performance
- Removed unnecessary type from `toMs` function