### PR TITLE
fix(runtime-core): renderList with default value when source is undefined

### DIFF
--- a/packages/runtime-core/__tests__/helpers/renderList.spec.ts
+++ b/packages/runtime-core/__tests__/helpers/renderList.spec.ts
@@ -42,7 +42,7 @@ describe('renderList', () => {
     ).toEqual(['node 0: 1', 'node 1: 2', 'node 2: 3'])
   })
 
-  it('should return empty array when data is undefined', () => {
+  it('should return empty array when source is undefined', () => {
     expect(
       renderList(undefined, (item, index) => `node ${index}: ${item}`)
     ).toEqual([])

--- a/packages/runtime-core/__tests__/helpers/renderList.spec.ts
+++ b/packages/runtime-core/__tests__/helpers/renderList.spec.ts
@@ -41,4 +41,10 @@ describe('renderList', () => {
       renderList(iterable(), (item, index) => `node ${index}: ${item}`)
     ).toEqual(['node 0: 1', 'node 1: 2', 'node 2: 3'])
   })
+
+  it('should return empty array when data is undefined', () => {
+    expect(
+      renderList(undefined, (item, index) => `node ${index}: ${item}`)
+    ).toEqual([])
+  })
 })

--- a/packages/runtime-core/src/helpers/renderList.ts
+++ b/packages/runtime-core/src/helpers/renderList.ts
@@ -34,7 +34,7 @@ export function renderList(
     }
   } else {
     if (__DEV__) {
-      warn(`Invalid v-for property. Did you typed it correctly?`, source)
+      warn(`Invalid v-for property. Did you typed it correctly?`)
     }
     ret = []
   }

--- a/packages/runtime-core/src/helpers/renderList.ts
+++ b/packages/runtime-core/src/helpers/renderList.ts
@@ -1,5 +1,6 @@
 import { VNodeChild } from '../vnode'
 import { isArray, isString, isObject } from '@vue/shared'
+import { warn } from '../warning'
 
 export function renderList(
   source: unknown,
@@ -9,7 +10,7 @@ export function renderList(
     index?: number
   ) => VNodeChild
 ): VNodeChild[] {
-  let ret: VNodeChild[] = []
+  let ret: VNodeChild[]
   if (isArray(source) || isString(source)) {
     ret = new Array(source.length)
     for (let i = 0, l = source.length; i < l; i++) {
@@ -31,6 +32,11 @@ export function renderList(
         ret[i] = renderItem(source[key], key, i)
       }
     }
+  } else {
+    if (__DEV__) {
+      warn(`Invalid v-for property. Did you typed it correctly?`, source)
+    }
+    ret = []
   }
   return ret
 }

--- a/packages/runtime-core/src/helpers/renderList.ts
+++ b/packages/runtime-core/src/helpers/renderList.ts
@@ -9,7 +9,7 @@ export function renderList(
     index?: number
   ) => VNodeChild
 ): VNodeChild[] {
-  let ret: VNodeChild[]
+  let ret: VNodeChild[] = []
   if (isArray(source) || isString(source)) {
     ret = new Array(source.length)
     for (let i = 0, l = source.length; i < l; i++) {
@@ -32,5 +32,5 @@ export function renderList(
       }
     }
   }
-  return ret!
+  return ret
 }

--- a/packages/runtime-core/src/helpers/renderList.ts
+++ b/packages/runtime-core/src/helpers/renderList.ts
@@ -1,6 +1,5 @@
 import { VNodeChild } from '../vnode'
 import { isArray, isString, isObject } from '@vue/shared'
-import { warn } from '../warning'
 
 export function renderList(
   source: unknown,

--- a/packages/runtime-core/src/helpers/renderList.ts
+++ b/packages/runtime-core/src/helpers/renderList.ts
@@ -33,9 +33,6 @@ export function renderList(
       }
     }
   } else {
-    if (__DEV__) {
-      warn(`Invalid v-for property. Did you typed it correctly?`)
-    }
     ret = []
   }
   return ret


### PR DESCRIPTION
When made a `v-for` with an undefined value, without a default value, will throw an error:

<details><summary>Show error</summary>

![image](https://user-images.githubusercontent.com/32134586/69596960-2589c480-0fe3-11ea-9f43-603afca3bf4b.png)

</details>

