### PR TITLE
fix(h function): wrapped when reserve argument children

### DIFF
--- a/packages/runtime-core/src/h.ts
+++ b/packages/runtime-core/src/h.ts
@@ -153,8 +153,10 @@ export function h(type: any, propsOrChildren?: any, children?: any): VNode {
       return createVNode(type, null, propsOrChildren)
     }
   } else {
-    if (isVNode(children)) {
-      children = [children]
+    if (arguments.length > 3) {
+      let kids = []
+      for (let i = 2; i < arguments.length; i++) kids.push(arguments[i])
+      return createVNode(type, propsOrChildren, kids)
     }
     return createVNode(type, propsOrChildren, children)
   }


### PR DESCRIPTION
Hey, here I try to explain this case.
When I use JSX, it doesn't put children in the array by default, but passes them down as arguments.
For example:
```jsx
<div>
    <span/>
    <p/>
</div>
```
The compilation result is
```js
h('div', {}, h('span'), h('p'))
```
`span` and `p` is passed as third and fourth here, but not wrapped in an array.

I don't know if it's important. Maybe Vue team doesn't care, because there may be Vue loader to control compilation in the future.

But almost all the h function of the frameworks will be traversed twice.
