### PR TITLE
chore: remove jsx.d.ts from package.files

### DIFF
--- a/packages/runtime-core/package.json
+++ b/packages/runtime-core/package.json
@@ -6,8 +6,7 @@
   "module": "dist/runtime-core.esm-bundler.js",
   "files": [
     "index.js",
-    "dist",
-    "jsx.d.ts"
+    "dist"
   ],
   "types": "dist/runtime-core.d.ts",
   "sideEffects": false,


### PR DESCRIPTION
jsx.d.ts has been deleted in this commit 66ecd8b47f7d4ecb70fd380048fb8dc576be33c5.