### PR TITLE
fix(transition): props should be declared by generic

### DIFF
--- a/packages/runtime-dom/src/components/Transition.ts
+++ b/packages/runtime-dom/src/components/Transition.ts
@@ -32,8 +32,8 @@ export interface TransitionProps extends BaseTransitionProps {
 
 // DOM Transition is a higher-order-component based on the platform-agnostic
 // base Transition component, with DOM-specific logic.
-export const Transition: FunctionalComponent = (
-  props: TransitionProps,
+export const Transition: FunctionalComponent<TransitionProps> = (
+  props,
   { slots }
 ) => h(BaseTransition, resolveTransitionProps(props), slots)
 


### PR DESCRIPTION
Current build results:
```ts
// runtime-dom/dist/runtime-dom.d.ts
export declare const Transition: FunctionalComponent;
```


Expected results(after fix):
```ts
// runtime-dom/dist/runtime-dom.d.ts
export declare const Transition: FunctionalComponent<TransitionProps>;
```