### PR TITLE
fix(core): use String to convert primitive types

### DIFF
--- a/packages/runtime-core/src/vnode.ts
+++ b/packages/runtime-core/src/vnode.ts
@@ -336,7 +336,7 @@ export function normalizeVNode<T, U>(child: VNodeChild<T, U>): VNode<T, U> {
     return child.el === null ? child : cloneVNode(child)
   } else {
     // primitive types
-    return createVNode(Text, null, child + '')
+    return createVNode(Text, null, String(child))
   }
 }
 
@@ -352,7 +352,7 @@ export function normalizeChildren(vnode: VNode, children: unknown) {
     children = { default: children }
     type = ShapeFlags.SLOTS_CHILDREN
   } else {
-    children = isString(children) ? children : children + ''
+    children = String(children)
     type = ShapeFlags.TEXT_CHILDREN
   }
   vnode.children = children as NormalizedChildren


### PR DESCRIPTION
It's safer to use `String()` to convert primitive types.

E.g:

```sh
> Symbol() + ''
  Thrown:
  TypeError: Cannot convert a Symbol value to a string
> String(Symbol())
  'Symbol()'
```