### PR TITLE
chore: fix grid composition example

### DIFF
--- a/packages/vue/examples/composition/grid.html
+++ b/packages/vue/examples/composition/grid.html
@@ -26,7 +26,7 @@
 </script>
 <!-- DemoGrid component script -->
 <script>
-const { reactive, computed, toRefs } = Vue
+const { reactive, computed } = Vue
 
 const capitalize = str => str.charAt(0).toUpperCase() + str.slice(1)
 


### PR DESCRIPTION
I was going to submit a PR fixing the grid composition example, but @yyx990803 already did in commit 27a72bd8f150be956a7931b64590cf3867bb4803 .

It introduced a useless import though.
Or we can use `toRefs`and get rid of `state`, what do you prefer?