### PR TITLE
chore: fix debounce of markdown example

### DIFF
--- a/packages/vue/examples/composition/markdown.html
+++ b/packages/vue/examples/composition/markdown.html
@@ -14,7 +14,7 @@ const App = {
   setup() {
     const input = ref('# hello')
     const output = computed(() => marked(input.value, { sanitize: true }))
-    const update = _.debounce(e => { input.value = e.target.value })
+    const update = _.debounce(e => { input.value = e.target.value }, 300)
 
     return {
       input,


### PR DESCRIPTION
To make the behavior of classic/composition examples the same.