### PR TITLE
test(e2e): add e2e test for markdown example

### DIFF
--- a/packages/vue/examples/__tests__/e2eUtils.ts
+++ b/packages/vue/examples/__tests__/e2eUtils.ts
@@ -33,16 +33,16 @@ export function setupPuppeteer() {
     return await page.$eval(selector, (node: HTMLInputElement) => node.value)
   }
 
+  async function html(selector: string) {
+    return await page.$eval(selector, node => node.innerHTML)
+  }
+
   async function classList(selector: string) {
     return await page.$eval(selector, (node: any) => [...node.classList])
   }
 
   async function children(selector: string) {
     return await page.$eval(selector, (node: any) => [...node.children])
-  }
-
-  async function html(selector: string) {
-    return await page.$eval(selector, node => node.innerHTML)
   }
 
   async function isVisible(selector: string) {

--- a/packages/vue/examples/__tests__/e2eUtils.ts
+++ b/packages/vue/examples/__tests__/e2eUtils.ts
@@ -30,7 +30,7 @@ export function setupPuppeteer() {
   }
 
   async function value(selector: string) {
-    return await page.$eval(selector, (node: any) => node.value)
+    return await page.$eval(selector, (node: HTMLInputElement) => node.value)
   }
 
   async function classList(selector: string) {
@@ -53,7 +53,7 @@ export function setupPuppeteer() {
   }
 
   async function isChecked(selector: string) {
-    return await page.$eval(selector, (node: any) => node.checked)
+    return await page.$eval(selector, (node: HTMLInputElement) => node.checked)
   }
 
   async function isFocused(selector: string) {
@@ -62,13 +62,16 @@ export function setupPuppeteer() {
 
   async function enterValue(selector: string, value: string) {
     const el = (await page.$(selector))!
-    await el.evaluate((node: any) => (node.value = ''))
+    await el.evaluate((node: HTMLInputElement) => (node.value = ''))
     await el.type(value)
     await el.press('Enter')
   }
 
   async function clearValue(selector: string) {
-    return await page.$eval(selector, (node: any) => (node.value = ''))
+    return await page.$eval(
+      selector,
+      (node: HTMLInputElement) => (node.value = '')
+    )
   }
 
   return {

--- a/packages/vue/examples/__tests__/e2eUtils.ts
+++ b/packages/vue/examples/__tests__/e2eUtils.ts
@@ -41,6 +41,10 @@ export function setupPuppeteer() {
     return await page.$eval(selector, (node: any) => [...node.children])
   }
 
+  async function html(selector: string) {
+    return await page.$eval(selector, node => node.innerHTML)
+  }
+
   async function isVisible(selector: string) {
     const display = await page.$eval(selector, (node: HTMLElement) => {
       return window.getComputedStyle(node).display
@@ -73,6 +77,7 @@ export function setupPuppeteer() {
     count,
     text,
     value,
+    html,
     classList,
     children,
     isVisible,

--- a/packages/vue/examples/__tests__/markdown.spec.ts
+++ b/packages/vue/examples/__tests__/markdown.spec.ts
@@ -1,0 +1,36 @@
+import path from 'path'
+import { setupPuppeteer } from './e2eUtils'
+
+describe('e2e: markdown', () => {
+  const { page, isVisible, value, html } = setupPuppeteer()
+
+  async function testMarkdown(apiType: 'classic' | 'composition') {
+    const baseUrl = `file://${path.resolve(
+      __dirname,
+      `../${apiType}/markdown.html`
+    )}`
+
+    await page().goto(baseUrl)
+    expect(await isVisible('#editor')).toBe(true)
+    expect(await value('textarea')).toBe('# hello')
+    expect(await html('#editor div')).toBe('<h1 id="hello">hello</h1>\n')
+
+    await page().type('textarea', '\n## foo\n\n- bar\n- baz')
+    // assert the output is not updated yet because of debounce
+    expect(await html('#editor div')).toBe('<h1 id="hello">hello</h1>\n')
+    await page().waitFor(500)
+    expect(await html('#editor div')).toBe(
+      '<h1 id="hello">hello</h1>\n' +
+        '<h2 id="foo">foo</h2>\n' +
+        '<ul>\n<li>bar</li>\n<li>baz</li>\n</ul>\n'
+    )
+  }
+
+  test('classic', async () => {
+    await testMarkdown('classic')
+  })
+
+  test('composition', async () => {
+    await testMarkdown('composition')
+  })
+})


### PR DESCRIPTION
Add test for markdown example, and use `HTMLInputElement` instead of `any` for the utils that expected to be used on input elements.