### PR TITLE
fix: shallowReadonly should keep reactive properties reactive

### DIFF
--- a/packages/reactivity/__tests__/readonly.spec.ts
+++ b/packages/reactivity/__tests__/readonly.spec.ts
@@ -470,5 +470,13 @@ describe('reactivity/readonly', () => {
         `Set operation on key "foo" failed: target is readonly.`
       ).not.toHaveBeenWarned()
     })
+
+    test('should keep reactive properties reactive', () => {
+      const props: any = shallowReadonly({ n: reactive({ foo: 1 }) })
+      unlock()
+      props.n = reactive({ foo: 2 })
+      lock()
+      expect(isReactive(props.n)).toBe(true)
+    })
   })
 })


### PR DESCRIPTION
Currently reassigning value to a reactive property will cause the reactivity becomes invalid. (the proxy wrapper is removed during reassigning)

Reproduce: https://codesandbox.io/s/brave-dawn-cg56l

This change simply keeps the reactive property as is. Not sure if this is the correct way to fix this. 