### PR TITLE
fix(build): play nice with rollup

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -3,7 +3,7 @@
   "version": "3.0.0-alpha.0",
   "description": "vue",
   "main": "index.js",
-  "module": "dist/vue.runtime.esm-bundler.js",
+  "module": "dist/vue.esm.js",
   "types": "dist/vue.d.ts",
   "unpkg": "dist/vue.global.js",
   "files": [


### PR DESCRIPTION
I'm almost sure that current `"module": "dist/vue.runtime.esm-bundler.js",` is here on purpose.
But in order to use `vue@next` with `rollup` I had to make this change (see PR changed files).

How should one use Vue 3 today?

It works well when used as ES module like this

```js
import { createApp } from 'https://unpkg.com/vue@3.0.0-alpha.0/dist/vue.esm.prod.js'
```

but if one wants to use a module like `pinia@next` that relies on `vue@next` I'm not sure what the correct approach is.