### PR TITLE
test(reactivity): extracted repeated code into a function 

### DIFF
--- a/packages/reactivity/__tests__/ref.spec.ts
+++ b/packages/reactivity/__tests__/ref.spec.ts
@@ -42,33 +42,27 @@ describe('reactivity/ref', () => {
         d: [a]
       }
     })
-    let dummy1
-    let dummy2
-    let dummy3
+    let dummy1: number
+    let dummy2: number
+    let dummy3: number
     effect(() => {
       dummy1 = obj.a
       dummy2 = obj.b.c
       dummy3 = obj.b.d[0]
     })
-    expect(dummy1).toBe(1)
-    expect(dummy2).toBe(1)
-    expect(dummy3).toBe(1)
+
+    const checkDummiesEqualTo = (val: any) =>
+      [dummy1, dummy2, dummy3].forEach(dummy => expect(dummy).toBe(val))
+
+    checkDummiesEqualTo(1)
     a.value++
-    expect(dummy1).toBe(2)
-    expect(dummy2).toBe(2)
-    expect(dummy3).toBe(2)
+    checkDummiesEqualTo(2)
     obj.a++
-    expect(dummy1).toBe(3)
-    expect(dummy2).toBe(3)
-    expect(dummy3).toBe(3)
+    checkDummiesEqualTo(3)
     obj.b.c++
-    expect(dummy1).toBe(4)
-    expect(dummy2).toBe(4)
-    expect(dummy3).toBe(4)
+    checkDummiesEqualTo(4)
     obj.b.d[0]++
-    expect(dummy1).toBe(5)
-    expect(dummy2).toBe(5)
-    expect(dummy3).toBe(5)
+    checkDummiesEqualTo(5)
   })
 
   it('should unwrap nested ref in types', () => {

--- a/packages/reactivity/__tests__/ref.spec.ts
+++ b/packages/reactivity/__tests__/ref.spec.ts
@@ -42,27 +42,29 @@ describe('reactivity/ref', () => {
         d: [a]
       }
     })
+ 
     let dummy1: number
     let dummy2: number
     let dummy3: number
+
     effect(() => {
       dummy1 = obj.a
       dummy2 = obj.b.c
       dummy3 = obj.b.d[0]
     })
 
-    const checkDummiesEqualTo = (val: any) =>
+    const assertDummiesEqualTo = (val: any) =>
       [dummy1, dummy2, dummy3].forEach(dummy => expect(dummy).toBe(val))
 
-    checkDummiesEqualTo(1)
+    assertDummiesEqualTo(1)
     a.value++
-    checkDummiesEqualTo(2)
+    assertDummiesEqualTo(2)
     obj.a++
-    checkDummiesEqualTo(3)
+    assertDummiesEqualTo(3)
     obj.b.c++
-    checkDummiesEqualTo(4)
+    assertDummiesEqualTo(4)
     obj.b.d[0]++
-    checkDummiesEqualTo(5)
+    assertDummiesEqualTo(5)
   })
 
   it('should unwrap nested ref in types', () => {


### PR DESCRIPTION
I've extracted repeated code into a function. I believe it makes the code more concise and pleasant to the eye of the reader.  No logic has changed. 