### PR TITLE
test(e2e): enhance and fix test of svg example

### DIFF
--- a/packages/vue/examples/__tests__/e2eUtils.ts
+++ b/packages/vue/examples/__tests__/e2eUtils.ts
@@ -73,8 +73,8 @@ export function setupPuppeteer() {
   async function setValue(selector: string, value: string) {
     await page.$eval(
       selector,
-      (node: HTMLInputElement, value) => {
-        node.value = value
+      (node, value) => {
+        (node as HTMLInputElement).value = value
         node.dispatchEvent(new Event('input'))
       },
       value

--- a/packages/vue/examples/__tests__/e2eUtils.ts
+++ b/packages/vue/examples/__tests__/e2eUtils.ts
@@ -71,6 +71,17 @@ export function setupPuppeteer() {
   }
 
   async function setValue(selector: string, value: string) {
+    await page.$eval(
+      selector,
+      (node: HTMLInputElement, value) => {
+        node.value = value
+        node.dispatchEvent(new Event('input'))
+      },
+      value
+    )
+  }
+
+  async function typeValue(selector: string, value: string) {
     const el = (await page.$(selector))!
     await el.evaluate((node: HTMLInputElement) => (node.value = ''))
     await el.type(value)
@@ -103,6 +114,7 @@ export function setupPuppeteer() {
     isChecked,
     isFocused,
     setValue,
+    typeValue,
     enterValue,
     clearValue
   }

--- a/packages/vue/examples/__tests__/grid.spec.ts
+++ b/packages/vue/examples/__tests__/grid.spec.ts
@@ -7,7 +7,7 @@ interface TableData {
 }
 
 describe('e2e: grid', () => {
-  const { page, click, text, count, setValue, clearValue } = setupPuppeteer()
+  const { page, click, text, count, typeValue, clearValue } = setupPuppeteer()
   const columns = ['name', 'power'] as const
 
   async function assertTable(data: TableData[]) {
@@ -88,18 +88,18 @@ describe('e2e: grid', () => {
       { name: 'Jet Li', power: 8000 }
     ])
 
-    await setValue('input[name="query"]', 'j')
+    await typeValue('input[name="query"]', 'j')
     await assertTable([
       { name: 'Jackie Chan', power: 7000 },
       { name: 'Jet Li', power: 8000 }
     ])
 
-    await setValue('input[name="query"]', 'infinity')
+    await typeValue('input[name="query"]', 'infinity')
     await assertTable([{ name: 'Chuck Norris', power: Infinity }])
 
     await clearValue('input[name="query"]')
     expect(await count('p')).toBe(0)
-    await setValue('input[name="query"]', 'stringthatdoesnotexistanywhere')
+    await typeValue('input[name="query"]', 'stringthatdoesnotexistanywhere')
     expect(await count('p')).toBe(1)
   }
 

--- a/packages/vue/examples/__tests__/svg.spec.ts
+++ b/packages/vue/examples/__tests__/svg.spec.ts
@@ -64,10 +64,7 @@ describe('e2e: svg', () => {
     const statsValue = await page().evaluate(() => {
       return globalStats.map(stat => +stat.value)
     })
-    expect(statsValue.length).toBe(expected.length)
-    for (let i = 0; i < expected.length; i++) {
-      expect(statsValue[i]).toBe(expected[i])
-    }
+    expect(statsValue).toEqual(expected)
   }
 
   function nthRange(n: number) {

--- a/packages/vue/examples/__tests__/svg.spec.ts
+++ b/packages/vue/examples/__tests__/svg.spec.ts
@@ -39,7 +39,7 @@ describe('e2e: svg', () => {
   }
 
   // assert the position of each label is correct
-  async function assertLabel(total: number) {
+  async function assertLabels(total: number) {
     const positions = await page().evaluate(
       total => {
         return globalStats.map((stat, i) => {
@@ -86,8 +86,13 @@ describe('e2e: svg', () => {
     expect(await count('button')).toBe(7)
     expect(await count('input[type="range"]')).toBe(6)
     await assertPolygon(6)
-    await assertLabel(6)
+    await assertLabels(6)
     await assertStats([100, 100, 100, 100, 100, 100])
+
+    await setValue(nthRange(1), '10')
+    await assertPolygon(6)
+    await assertLabels(6)
+    await assertStats([10, 100, 100, 100, 100, 100])
 
     await click('button.remove')
     expect(await count('text')).toBe(5)
@@ -95,7 +100,7 @@ describe('e2e: svg', () => {
     expect(await count('button')).toBe(6)
     expect(await count('input[type="range"]')).toBe(5)
     await assertPolygon(5)
-    await assertLabel(5)
+    await assertLabels(5)
     await assertStats([100, 100, 100, 100, 100])
 
     await typeValue('input[name="newlabel"]', 'foo')
@@ -105,23 +110,33 @@ describe('e2e: svg', () => {
     expect(await count('button')).toBe(7)
     expect(await count('input[type="range"]')).toBe(6)
     await assertPolygon(6)
-    await assertLabel(6)
+    await assertLabels(6)
     await assertStats([100, 100, 100, 100, 100, 100])
 
     await setValue(nthRange(1), '10')
     await assertPolygon(6)
-    await assertLabel(6)
+    await assertLabels(6)
     await assertStats([10, 100, 100, 100, 100, 100])
 
     await setValue(nthRange(2), '20')
     await assertPolygon(6)
-    await assertLabel(6)
+    await assertLabels(6)
     await assertStats([10, 20, 100, 100, 100, 100])
 
     await setValue(nthRange(6), '60')
     await assertPolygon(6)
-    await assertLabel(6)
+    await assertLabels(6)
     await assertStats([10, 20, 100, 100, 100, 60])
+
+    await click('button.remove')
+    await assertPolygon(5)
+    await assertLabels(5)
+    await assertStats([20, 100, 100, 100, 60])
+
+    await setValue(nthRange(1), '10')
+    await assertPolygon(5)
+    await assertLabels(5)
+    await assertStats([10, 100, 100, 100, 60])
   }
 
   test('classic', async () => {

--- a/packages/vue/examples/__tests__/svg.spec.ts
+++ b/packages/vue/examples/__tests__/svg.spec.ts
@@ -52,10 +52,9 @@ describe('e2e: svg', () => {
     for (let i = 0; i < total; i++) {
       const textPosition = await page().$eval(
         `text:nth-child(${i + 3})`,
-        node => [node.attributes[0].value, node.attributes[1].value]
+        node => [+node.attributes[0].value, +node.attributes[1].value]
       )
-      expect(+textPosition[0]).toBe(positions[i][0])
-      expect(+textPosition[1]).toBe(positions[i][1])
+      expect(textPosition).toEqual(positions[i])
     }
   }
 


### PR DESCRIPTION
**Currently the failing test is expected**

I found a bug that is probably caused by `v-model`. I tried but I could't fix it so I add test to cover this issue (the new `assertStats` part). Therefore the test of this PR should fail now. I can rebase and push after it's fixed.

To reproduce the issue:

1. Open the svg example
2. Remove the first range control A
3. Drag other ranges, they are now broken

For now it can be fixed by adding `key`, but in Vue 2.0 `key` is not required. (If it is required in Vue 3.0, I can help with fixing the example in this PR)
I also add the `assertLabels` which can catch the issue of #552 for regression.

*The same SVG example in Vue 2.0 passes all the newly added tests.*

Changes:

- Rename `setValue` to more accurate `typeValue`
- Add `setValue` which will set value and dispatch `input` event
- Add `assertLabels` test
- Fix the broken `assertStats`. It didn't assert anything, sorry for my stupid mistake...
- Rename `assertStats` to `assertPolygon` because there is a new `assertStats`
