### PR TITLE
types: improve isRef typing

### DIFF
--- a/packages/reactivity/src/ref.ts
+++ b/packages/reactivity/src/ref.ts
@@ -23,6 +23,7 @@ export interface Ref<T = any> {
 const convert = <T extends unknown>(val: T): T =>
   isObject(val) ? reactive(val) : val
 
+export function isRef<T>(r: Ref<T> | T): r is Ref<T>
 export function isRef(r: any): r is Ref {
   return r ? r._isRef === true : false
 }


### PR DESCRIPTION
Allow inferring the T value if the condition `isRef` is true

```ts
export function unwrap<T>(o: T | Ref<T>): T {
  return isRef(o) ? o.value : o;
}
```

EDIT: because `.value` is `UnwrapRef<T>` and `T` !== `UnwrapRef<T>` you need to cast `o.value as T` to make it work.

but this works perfectly when we have typed argument:  

```ts
interface MyObject {
  a: 1,
  other: 'string'
}

function returnOther(o: MyObject| Ref<MyObject>): string {
  return isRef(o) ? o.value.other : o.other
}
```
