### PR TITLE
refactor: run iteration effect first

### DIFF
--- a/packages/reactivity/__tests__/effect.spec.ts
+++ b/packages/reactivity/__tests__/effect.spec.ts
@@ -191,6 +191,22 @@ describe('reactivity/effect', () => {
     expect(dummy).toBe('Hello')
   })
 
+  it('should run iteration effect first', () => {
+    let dummy, runner: any
+    const list = reactive(['Hello'])
+    effect(() => {
+      if (runner) {
+        stop(runner)
+      }
+      list.length
+    })
+    runner = effect(() => (dummy = list[0]))
+
+    expect(dummy).toBe('Hello')
+    list.pop()
+    expect(dummy).toBe('Hello')
+  })
+
   it('should observe enumeration', () => {
     let dummy = 0
     const numbers = reactive<Record<string, number>>({ num1: 3 })

--- a/packages/reactivity/src/effect.ts
+++ b/packages/reactivity/src/effect.ts
@@ -170,18 +170,21 @@ export function trigger(
       addRunners(effects, computedRunners, dep)
     })
   } else {
-    // schedule runs for SET | ADD | DELETE
-    if (key !== void 0) {
-      addRunners(effects, computedRunners, depsMap.get(key))
-    }
-    // also run for iteration key on ADD | DELETE
+    // run for iteration key on ADD | DELETE
+    // it must be run first so that user have a chance to stop ADD | DELETE effects
     if (type === TriggerOpTypes.ADD || type === TriggerOpTypes.DELETE) {
       const iterationKey = isArray(target) ? 'length' : ITERATE_KEY
       addRunners(effects, computedRunners, depsMap.get(iterationKey))
     }
+    // schedule runs for SET | ADD | DELETE
+    if (key !== void 0) {
+      addRunners(effects, computedRunners, depsMap.get(key))
+    }
   }
   const run = (effect: ReactiveEffect) => {
-    scheduleRun(effect, target, type, key, extraInfo)
+    if (effect.active) {
+      scheduleRun(effect, target, type, key, extraInfo)
+    }
   }
   // Important: computed effects must be run first so that computed getters
   // can be invalidated before any normal effects that depend on them are run.

--- a/packages/runtime-core/__tests__/apiWatch.spec.ts
+++ b/packages/runtime-core/__tests__/apiWatch.spec.ts
@@ -140,6 +140,28 @@ describe('api: watch', () => {
     expect(dummy).toBe(0)
   })
 
+  it('skip watcher when it stopped (basic)', async () => {
+    const state = reactive({ count: 0 })
+    let dummy
+    const stop = watch(() => {
+      dummy = state.count
+    })
+    stop()
+    await nextTick()
+    expect(dummy).toBeUndefined()
+  })
+
+  it('skip watcher when it stopped (with source)', async () => {
+    const count = ref(0)
+    let dummy
+    const stop = watch(count, count => {
+      dummy = count
+    })
+    stop()
+    await nextTick()
+    expect(dummy).toBeUndefined()
+  })
+
   it('cleanup registration (basic)', async () => {
     const state = reactive({ count: 0 })
     const cleanup = jest.fn()

--- a/packages/runtime-core/src/apiWatch.ts
+++ b/packages/runtime-core/src/apiWatch.ts
@@ -121,7 +121,7 @@ function doWatch(
   } else {
     // no cb -> simple effect
     getter = () => {
-      if (instance && instance.isUnmounted) {
+      if ((instance && instance.isUnmounted) || !runner.active) {
         return
       }
       if (cleanup) {
@@ -151,7 +151,7 @@ function doWatch(
   let oldValue = isArray(source) ? [] : undefined
   const applyCb = cb
     ? () => {
-        if (instance && instance.isUnmounted) {
+        if ((instance && instance.isUnmounted) || !runner.active) {
           return
         }
         const newValue = runner()


### PR DESCRIPTION
## What I'm trying to do
Run iteration effects before ADD | DELETE effects

## Why
I'm trying to bring Composition API to MiniProgram, so I need watch reactivity data source and sync it to MiniProgram. Part of the code like this:
```ts
const stoppers = new Set<StopHandle>()
const watchObjectField = (obj: Record<string, unknown>): void => {
  Object.keys(obj).forEach(name => {
    stoppers.add(
      watch(
        () => obj[name],
        () => {
          // I have to write this condition, otherwise it will set `undefined` to
          // MiniProgram, when the field is deleted. It's useless, and it will cause
          // warning in MiniProgram. I can't stop this watcher because it run before
          // iteration watcher. If iteration watcher run first, then this condition
          // is no longer needed. Array have same problem.
          if (name in obj) {
            // sync object field
            // ...
          }
        },
        { lazy: true }
      )
    )
  })
}

watch(
  () => Object.keys(value),
  (_, __, onCleanup) => {
    // sync whole object
    // ...
    watchObjectField(value as Record<string, unknown>)
    onCleanup(() => {
      stoppers.forEach(stopper => stopper())
      stoppers.clear()
    })
  },
  { lazy: true }
)
watchObjectField(value as Record<string, unknown>)
```
And I think this is a general use case.

## Risk
I'm not sure is there anything rely on the current order, I didn't find any, and all tests passed. But you know best.

## Question
Is the `instance && instance.isUnmounted` condition in `apiWatch.ts` still needed?