### PR TITLE
fix(runtime-core): allow classes to be passed as plugins

### DIFF
--- a/packages/runtime-core/__tests__/apiApp.spec.ts
+++ b/packages/runtime-core/__tests__/apiApp.spec.ts
@@ -244,11 +244,18 @@ describe('api: createApp', () => {
     const PluginB: Plugin = {
       install: (app, arg1, arg2) => app.provide('bar', arg1 + arg2)
     }
-    const PluginC: any = undefined
+    class PluginC {
+      someProperty = {}
+      static install() {
+        app.provide('baz', 2)
+      }
+    }
+    const PluginD: any = undefined
 
     const app = createApp()
     app.use(PluginA)
     app.use(PluginB, 1, 1)
+    app.use(PluginC)
 
     const Root = {
       setup() {
@@ -266,7 +273,7 @@ describe('api: createApp', () => {
       `Plugin has already been applied to target app`
     ).toHaveBeenWarnedTimes(1)
 
-    app.use(PluginC)
+    app.use(PluginD)
     expect(
       `A plugin must either be a function or an object with an "install" ` +
         `function.`

--- a/packages/runtime-core/src/apiCreateApp.ts
+++ b/packages/runtime-core/src/apiCreateApp.ts
@@ -56,7 +56,7 @@ export interface AppContext {
 type PluginInstallFunction = (app: App, ...options: any[]) => any
 
 export type Plugin =
-  | PluginInstallFunction
+  | PluginInstallFunction & { install?: PluginInstallFunction }
   | {
       install: PluginInstallFunction
     }
@@ -103,11 +103,7 @@ export function createAppAPI<HostNode, HostElement>(
       use(plugin: Plugin, ...options: any[]) {
         if (installedPlugins.has(plugin)) {
           __DEV__ && warn(`Plugin has already been applied to target app.`)
-        } else if (
-          plugin &&
-          'install' in plugin &&
-          isFunction(plugin.install)
-        ) {
+        } else if (plugin && isFunction(plugin.install)) {
           installedPlugins.add(plugin)
           plugin.install(app, ...options)
         } else if (isFunction(plugin)) {

--- a/packages/runtime-core/src/apiCreateApp.ts
+++ b/packages/runtime-core/src/apiCreateApp.ts
@@ -103,12 +103,16 @@ export function createAppAPI<HostNode, HostElement>(
       use(plugin: Plugin, ...options: any[]) {
         if (installedPlugins.has(plugin)) {
           __DEV__ && warn(`Plugin has already been applied to target app.`)
+        } else if (
+          plugin &&
+          'install' in plugin &&
+          isFunction(plugin.install)
+        ) {
+          installedPlugins.add(plugin)
+          plugin.install(app, ...options)
         } else if (isFunction(plugin)) {
           installedPlugins.add(plugin)
           plugin(app, ...options)
-        } else if (plugin && isFunction(plugin.install)) {
-          installedPlugins.add(plugin)
-          plugin.install(app, ...options)
         } else if (__DEV__) {
           warn(
             `A plugin must either be a function or an object with an "install" ` +


### PR DESCRIPTION
In vue 2.x we could pass a class to `Vue.use()` with a static `install` method as it checked for `PluginObject` first.

https://github.com/vuejs/vue/blob/6fe07ebf5ab3fea1860c59fe7cdd2ec1b760f9b0/src/core/global-api/use.js#L15