### PR TITLE
fix(watch): memory leak

### DIFF
--- a/packages/runtime-core/src/apiReactivity.ts
+++ b/packages/runtime-core/src/apiReactivity.ts
@@ -33,16 +33,14 @@ import {
 
 import { currentInstance } from './component'
 
-type RemoveRecord = () => void
-
 // record effects created during a component's setup() so that they can be
 // stopped when the component unmounts
-export function recordEffect(effect: ReactiveEffect): RemoveRecord | void {
+export function recordEffect(effect: ReactiveEffect): (() => void) | void {
   if (currentInstance) {
     const effects = currentInstance.effects || (currentInstance.effects = [])
     effects.push(effect)
     return () => {
-      const index = effects.findIndex(_effect => _effect === effect)
+      const index = effects.indexOf(effect)
       if (index !== -1) {
         effects.splice(index, 1)
       }

--- a/packages/runtime-core/src/apiReactivity.ts
+++ b/packages/runtime-core/src/apiReactivity.ts
@@ -35,7 +35,7 @@ import { currentInstance } from './component'
 
 // record effects created during a component's setup() so that they can be
 // stopped when the component unmounts
-export function recordEffect(effect: ReactiveEffect): (() => void) | void {
+export function recordEffect(effect: ReactiveEffect) {
   if (currentInstance) {
     ;(currentInstance.effects || (currentInstance.effects = [])).push(effect)
   }

--- a/packages/runtime-core/src/apiReactivity.ts
+++ b/packages/runtime-core/src/apiReactivity.ts
@@ -33,11 +33,20 @@ import {
 
 import { currentInstance } from './component'
 
+type RemoveRecord = () => void
+
 // record effects created during a component's setup() so that they can be
 // stopped when the component unmounts
-export function recordEffect(effect: ReactiveEffect) {
+export function recordEffect(effect: ReactiveEffect): RemoveRecord | void {
   if (currentInstance) {
-    ;(currentInstance.effects || (currentInstance.effects = [])).push(effect)
+    const effects = currentInstance.effects || (currentInstance.effects = [])
+    effects.push(effect)
+    return () => {
+      const index = effects.findIndex(_effect => _effect === effect)
+      if (index !== -1) {
+        effects.splice(index, 1)
+      }
+    }
   }
 }
 

--- a/packages/runtime-core/src/apiReactivity.ts
+++ b/packages/runtime-core/src/apiReactivity.ts
@@ -37,14 +37,7 @@ import { currentInstance } from './component'
 // stopped when the component unmounts
 export function recordEffect(effect: ReactiveEffect): (() => void) | void {
   if (currentInstance) {
-    const effects = currentInstance.effects || (currentInstance.effects = [])
-    effects.push(effect)
-    return () => {
-      const index = effects.indexOf(effect)
-      if (index !== -1) {
-        effects.splice(index, 1)
-      }
-    }
+    ;(currentInstance.effects || (currentInstance.effects = [])).push(effect)
   }
 }
 

--- a/packages/runtime-core/src/apiWatch.ts
+++ b/packages/runtime-core/src/apiWatch.ts
@@ -214,11 +214,15 @@ function doWatch(
     }
   }
 
-  const removeRecord = recordEffect(runner)
+  recordEffect(runner)
   return () => {
     stop(runner)
-    if (removeRecord) {
-      removeRecord()
+    if (instance) {
+      const effects = instance.effects!
+      const index = effects.indexOf(runner)
+      if (index > -1) {
+        effects.splice(index, 1)
+      }
     }
   }
 }

--- a/packages/runtime-core/src/apiWatch.ts
+++ b/packages/runtime-core/src/apiWatch.ts
@@ -214,9 +214,12 @@ function doWatch(
     }
   }
 
-  recordEffect(runner)
+  const removeRecord = recordEffect(runner)
   return () => {
     stop(runner)
+    if (removeRecord) {
+      removeRecord()
+    }
   }
 }
 


### PR DESCRIPTION
I think `computed` have same problem, but unless expose a stop api, I don't think there is an easy way to fix it.