### PR TITLE
fix(runtime-core): components options should accept components define…

### DIFF
--- a/packages/runtime-core/src/apiOptions.ts
+++ b/packages/runtime-core/src/apiOptions.ts
@@ -63,7 +63,10 @@ export interface ComponentOptionsBase<
   // Luckily `render()` doesn't need any arguments nor does it care about return
   // type.
   render?: Function
-  components?: Record<string, Component>
+  components?: Record<
+    string,
+    Component | { new (): ComponentPublicInstance<any, any, any, any, any> }
+  >
   directives?: Record<string, Directive>
   inheritAttrs?: boolean
 

--- a/test-dts/defineComponent.test-d.tsx
+++ b/test-dts/defineComponent.test-d.tsx
@@ -259,3 +259,11 @@ describe('compatibility w/ createApp', () => {
   })
   createApp().mount(comp3, '#hello')
 })
+
+describe('defineComponent', () => {
+  test('should accept components defined with defineComponent')
+  const comp = defineComponent({})
+  defineComponent({
+    components: { comp }
+  })
+})


### PR DESCRIPTION
…d with defineComponent

Currently, when using TypeScript, a component defined with `defineComponent` can not be used in the `components` options:

```typescript
const comp = defineComponent({})
defineComponent({
  components: { comp }
})
```

This example was throwing with:

```
The last overload gave the following error.
    Type { comp: new () => ComponentPublicInstance<unknown, unknown, unknown, {}, {}, VNodeProps>; } is not assignable to type Record<string, Component>.
      Property comp is incompatible with index signature.
```

This commit fixes the issue, and adds a simple repro in the dts tests.