### PR TITLE
types: correct api types

### DIFF
--- a/packages/runtime-core/src/apiOptions.ts
+++ b/packages/runtime-core/src/apiOptions.ts
@@ -51,7 +51,7 @@ export interface ComponentOptionsBase<
   M extends MethodOptions
 > extends LegacyOptions<Props, RawBindings, D, C, M>, SFCInternalOptions {
   setup?: (
-    this: null,
+    this: void,
     props: Props,
     ctx: SetupContext
   ) => RawBindings | RenderFunction | void
@@ -82,7 +82,7 @@ export type ComponentOptionsWithoutProps<
   D = {},
   C extends ComputedOptions = {},
   M extends MethodOptions = {}
-> = ComponentOptionsBase<Props, RawBindings, D, C, M> & {
+> = ComponentOptionsBase<Readonly<Props>, RawBindings, D, C, M> & {
   props?: undefined
 } & ThisType<ComponentPublicInstance<{}, RawBindings, D, C, M, Readonly<Props>>>
 


### PR DESCRIPTION
`this` is `undefined` in runtime, `null` may cause misunderstanding, and TS think `this` is `void`.

https://www.typescriptlang.org/play/index.html?ssl=1&ssc=21&pln=1&pc=30#code/GYVwdgxgLglg9mABFApgZygCigCxmgLkXABMVgYwUSBKRAbwF8AoZ1DTGoA