### PR TITLE
types(reactivity): fix corner case on UnwrapRef

### DIFF
--- a/packages/reactivity/src/ref.ts
+++ b/packages/reactivity/src/ref.ts
@@ -85,6 +85,11 @@ function toProxyRef<T extends object, K extends keyof T>(
 
 type UnwrapArray<T> = { [P in keyof T]: UnwrapRef<T[P]> }
 
+// corner case when use narrows type
+// Ex. type RelativePath = string & { __brand: unknown }
+// RelativePath extends object -> true
+type BaseTypes = string | number | boolean
+
 // Recursively unwraps nested value bindings.
 export type UnwrapRef<T> = {
   cRef: T extends ComputedRef<infer V> ? UnwrapRef<V> : T
@@ -97,6 +102,6 @@ export type UnwrapRef<T> = {
     ? 'ref'
     : T extends Array<any>
       ? 'array'
-      : T extends Function | CollectionTypes
+      : T extends Function | CollectionTypes | BaseTypes
         ? 'ref' // bail out on types that shouldn't be unwrapped
         : T extends object ? 'object' : 'ref']

--- a/test-dts/defineComponent.test-d.tsx
+++ b/test-dts/defineComponent.test-d.tsx
@@ -12,6 +12,8 @@ describe('with object props', () => {
     ddd: string[]
   }
 
+  type GT = string & { __brand: unknown }
+
   const MyComponent = defineComponent({
     props: {
       a: Number,
@@ -57,6 +59,9 @@ describe('with object props', () => {
         c: ref(1),
         d: {
           e: ref('hi')
+        },
+        f: {
+          g: ref('hello' as GT)
         }
       }
     },
@@ -88,6 +93,7 @@ describe('with object props', () => {
       // assert setup context unwrapping
       expectType<number>(this.c)
       expectType<string>(this.d.e)
+      expectType<GT>(this.f.g)
 
       // setup context properties should be mutable
       this.c = 2


### PR DESCRIPTION
We need special string or number types sometime.
Ex. RelativePath, AbsolutePath
```typescript
type AbsolutePath = string & { __brand: unknown }
function readFile (path: AbsolutePath) {
  // do some thing
}
function getAbsolutePath (path: string) {
  if (path.startWith('file://')) return path as AbsolutePath
}
```

I use it for safe use translation keys,
but code is broken when pass UnwrapRef on vetur template interpolation.