### PR TITLE
fix(reactivity): Remove confusing 'dep' and 'deps' naming conventions…

### DIFF
--- a/packages/reactivity/src/computed.ts
+++ b/packages/reactivity/src/computed.ts
@@ -76,11 +76,11 @@ function trackChildRun(childRunner: ReactiveEffect) {
   if (activeEffect === undefined) {
     return
   }
-  for (let i = 0; i < childRunner.deps.length; i++) {
-    const dep = childRunner.deps[i]
-    if (!dep.has(activeEffect)) {
-      dep.add(activeEffect)
-      activeEffect.deps.push(dep)
+  for (let i = 0; i < childRunner.effects.length; i++) {
+    const effect = childRunner.effects[i]
+    if (!effect.has(activeEffect)) {
+      effect.add(activeEffect)
+      activeEffect.effects.push(effect)
     }
   }
 }


### PR DESCRIPTION
… in favor of 'effect' and 'effects'

As I was teaching reactivity with Vue 3, I noticed how ["dep" here](https://github.com/vuejs/vue-next/blob/master/packages/reactivity/src/effect.ts#L136) is used to mean "effects." It got quite confusing.  

When you realize that a "dependancy" (dep) and an "effect" are used to mean the same thing, you start to wonder why.  

In this pull request I've removed all old traces of "dep" or "deps" in favor of "effect" and "effects"

Previously:

![Vue 3 Reactivity-1](https://user-images.githubusercontent.com/2618/72467102-3fa47f80-37a8-11ea-9c8a-3a0b53718978.jpg)

Now with this pull request:

![Vue 3 Reactivity](https://user-images.githubusercontent.com/2618/72467010-11bf3b00-37a8-11ea-9382-44892e2d68fc.jpg)
