### PR TITLE
Fix error reporting URL to point to vue-next

### DIFF
--- a/packages/runtime-core/src/errorHandling.ts
+++ b/packages/runtime-core/src/errorHandling.ts
@@ -49,7 +49,7 @@ export const ErrorTypeStrings: Record<number | string, string> = {
   [ErrorCodes.FUNCTION_REF]: 'ref function',
   [ErrorCodes.SCHEDULER]:
     'scheduler flush. This is likely a Vue internals bug. ' +
-    'Please open an issue at https://new-issue.vuejs.org/?repo=vuejs/vue'
+    'Please open an issue at https://new-issue.vuejs.org/?repo=vuejs/vue-next'
 }
 
 export type ErrorTypes = LifecycleHooks | ErrorCodes


### PR DESCRIPTION
I'm am testing Vue3 with a non-trivial app and am getting internals errors, and I noticed that the URL to the error reporting page points to Vue2 bug reporting, instead of vue-next.