### PR TITLE
fix(compiler): only transform relative asset URLs

### DIFF
--- a/packages/compiler-sfc/__tests__/__snapshots__/templateTransformAssetUrl.spec.ts.snap
+++ b/packages/compiler-sfc/__tests__/__snapshots__/templateTransformAssetUrl.spec.ts.snap
@@ -33,7 +33,9 @@ export function render() {
   return (openBlock(), createBlock(Fragment, null, [
     createVNode(\\"img\\", { src: _imports_0 }),
     createVNode(\\"img\\", { src: _imports_1 }),
-    createVNode(\\"img\\", { src: _imports_1 })
+    createVNode(\\"img\\", { src: _imports_1 }),
+    createVNode(\\"img\\", { src: \\"http://example.com/fixtures/logo.png\\" }),
+    createVNode(\\"img\\", { src: \\"/fixtures/logo.png\\" })
   ], 64 /* STABLE_FRAGMENT */))
 }"
 `;

--- a/packages/compiler-sfc/__tests__/__snapshots__/templateTransformSrcset.spec.ts.snap
+++ b/packages/compiler-sfc/__tests__/__snapshots__/templateTransformSrcset.spec.ts.snap
@@ -12,9 +12,7 @@ const _hoisted_4 = _imports_0 + ', ' + _imports_0 + '2x'
 const _hoisted_5 = _imports_0 + '2x, ' + _imports_0
 const _hoisted_6 = _imports_0 + '2x, ' + _imports_0 + '3x'
 const _hoisted_7 = _imports_0 + ', ' + _imports_0 + '2x, ' + _imports_0 + '3x'
-const _hoisted_8 = \\"/logo.png\\" + ', ' + \\"/logo.png\\" + '2x'
-const _hoisted_9 = \\"https://example.com/logo.png\\" + ', ' + \\"https://example.com/logo.png\\" + '2x'
-const _hoisted_10 = \\"/logo.png\\" + ', ' + _imports_0 + '2x'
+const _hoisted_8 = \\"/logo.png\\" + ', ' + _imports_0 + '2x'
 
 export function render() {
   const _ctx = this
@@ -49,15 +47,15 @@ export function render() {
     }),
     createVNode(\\"img\\", {
       src: \\"/logo.png\\",
-      srcset: _hoisted_8
+      srcset: \\"/logo.png, /logo.png 2x\\"
     }),
     createVNode(\\"img\\", {
       src: \\"https://example.com/logo.png\\",
-      srcset: _hoisted_9
+      srcset: \\"https://example.com/logo.png, https://example.com/logo.png 2x\\"
     }),
     createVNode(\\"img\\", {
       src: \\"/logo.png\\",
-      srcset: _hoisted_10
+      srcset: _hoisted_8
     })
   ], 64 /* STABLE_FRAGMENT */))
 }"

--- a/packages/compiler-sfc/__tests__/__snapshots__/templateTransformSrcset.spec.ts.snap
+++ b/packages/compiler-sfc/__tests__/__snapshots__/templateTransformSrcset.spec.ts.snap
@@ -12,6 +12,9 @@ const _hoisted_4 = _imports_0 + ', ' + _imports_0 + '2x'
 const _hoisted_5 = _imports_0 + '2x, ' + _imports_0
 const _hoisted_6 = _imports_0 + '2x, ' + _imports_0 + '3x'
 const _hoisted_7 = _imports_0 + ', ' + _imports_0 + '2x, ' + _imports_0 + '3x'
+const _hoisted_8 = \\"/logo.png\\" + ', ' + \\"/logo.png\\" + '2x'
+const _hoisted_9 = \\"https://example.com/logo.png\\" + ', ' + \\"https://example.com/logo.png\\" + '2x'
+const _hoisted_10 = \\"/logo.png\\" + ', ' + _imports_0 + '2x'
 
 export function render() {
   const _ctx = this
@@ -43,6 +46,18 @@ export function render() {
     createVNode(\\"img\\", {
       src: \\"./logo.png\\",
       srcset: _hoisted_7
+    }),
+    createVNode(\\"img\\", {
+      src: \\"/logo.png\\",
+      srcset: _hoisted_8
+    }),
+    createVNode(\\"img\\", {
+      src: \\"https://example.com/logo.png\\",
+      srcset: _hoisted_9
+    }),
+    createVNode(\\"img\\", {
+      src: \\"/logo.png\\",
+      srcset: _hoisted_10
     })
   ], 64 /* STABLE_FRAGMENT */))
 }"

--- a/packages/compiler-sfc/__tests__/compileTemplate.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileTemplate.spec.ts
@@ -50,7 +50,7 @@ test('warn missing preprocessor', () => {
 })
 
 test('transform asset url options', () => {
-  const input = { source: `<foo bar="baz"/>`, filename: 'example.vue' }
+  const input = { source: `<foo bar="~baz"/>`, filename: 'example.vue' }
   // Object option
   const { code: code1 } = compileTemplate({
     ...input,

--- a/packages/compiler-sfc/__tests__/templateTransformAssetUrl.spec.ts
+++ b/packages/compiler-sfc/__tests__/templateTransformAssetUrl.spec.ts
@@ -20,6 +20,8 @@ describe('compiler sfc: transform asset url', () => {
 			<img src="./logo.png"/>
 			<img src="~fixtures/logo.png"/>
 			<img src="~/fixtures/logo.png"/>
+			<img src="http://example.com/fixtures/logo.png"/>
+			<img src="/fixtures/logo.png"/>
 		`)
 
     expect(result.code).toMatchSnapshot()

--- a/packages/compiler-sfc/__tests__/templateTransformSrcset.spec.ts
+++ b/packages/compiler-sfc/__tests__/templateTransformSrcset.spec.ts
@@ -24,6 +24,9 @@ describe('compiler sfc: transform srcset', () => {
 			<img src="./logo.png" srcset="./logo.png 2x, ./logo.png"/>
 			<img src="./logo.png" srcset="./logo.png 2x, ./logo.png 3x"/>
 			<img src="./logo.png" srcset="./logo.png, ./logo.png 2x, ./logo.png 3x"/>
+			<img src="/logo.png" srcset="/logo.png, /logo.png 2x"/>
+			<img src="https://example.com/logo.png" srcset="https://example.com/logo.png, https://example.com/logo.png 2x"/>
+			<img src="/logo.png" srcset="/logo.png, ./logo.png 2x"/>
 		`)
 
     expect(result.code).toMatchSnapshot()

--- a/packages/compiler-sfc/src/templateTransformAssetUrl.ts
+++ b/packages/compiler-sfc/src/templateTransformAssetUrl.ts
@@ -46,23 +46,14 @@ export const transformAssetUrl: NodeTransform = (
             if (attr.type !== NodeTypes.ATTRIBUTE) return
             if (attr.name !== item) return
             if (!attr.value) return
-            let exp: ExpressionNode
-            if (isRelativeUrl(attr.value.content)) {
-              const url = parseUrl(attr.value.content)
-              exp = getImportsExpressionExp(
-                url.path,
-                url.hash,
-                attr.loc,
-                context
-              )
-            } else {
-              exp = createSimpleExpression(
-                `"${attr.value.content}"`,
-                false,
-                attr.loc,
-                true
-              )
-            }
+            if (!isRelativeUrl(attr.value.content)) return
+            const url = parseUrl(attr.value.content)
+            const exp = getImportsExpressionExp(
+              url.path,
+              url.hash,
+              attr.loc,
+              context
+            )
             node.props[index] = {
               type: NodeTypes.DIRECTIVE,
               name: 'bind',

--- a/packages/compiler-sfc/src/templateTransformSrcset.ts
+++ b/packages/compiler-sfc/src/templateTransformSrcset.ts
@@ -5,7 +5,7 @@ import {
   NodeTypes,
   SimpleExpressionNode
 } from '@vue/compiler-core'
-import { parseUrl } from './templateUtils'
+import { isRelativeUrl, parseUrl } from './templateUtils'
 
 const srcsetTags = ['img', 'source']
 
@@ -38,29 +38,39 @@ export const transformSrcset: NodeTransform = (node, context) => {
 
           const compoundExpression = createCompoundExpression([], attr.loc)
           imageCandidates.forEach(({ url, descriptor }, index) => {
-            const { path } = parseUrl(url)
-            let exp: SimpleExpressionNode
-            if (path) {
-              const importsArray = Array.from(context.imports)
-              const existingImportsIndex = importsArray.findIndex(
-                i => i.path === path
-              )
-              if (existingImportsIndex > -1) {
-                exp = createSimpleExpression(
-                  `_imports_${existingImportsIndex}`,
-                  false,
-                  attr.loc,
-                  true
+            if (isRelativeUrl(url)) {
+              const { path } = parseUrl(url)
+              let exp: SimpleExpressionNode
+              if (path) {
+                const importsArray = Array.from(context.imports)
+                const existingImportsIndex = importsArray.findIndex(
+                  i => i.path === path
                 )
-              } else {
-                exp = createSimpleExpression(
-                  `_imports_${importsArray.length}`,
-                  false,
-                  attr.loc,
-                  true
-                )
-                context.imports.add({ exp, path })
+                if (existingImportsIndex > -1) {
+                  exp = createSimpleExpression(
+                    `_imports_${existingImportsIndex}`,
+                    false,
+                    attr.loc,
+                    true
+                  )
+                } else {
+                  exp = createSimpleExpression(
+                    `_imports_${importsArray.length}`,
+                    false,
+                    attr.loc,
+                    true
+                  )
+                  context.imports.add({ exp, path })
+                }
+                compoundExpression.children.push(exp)
               }
+            } else {
+              const exp = createSimpleExpression(
+                `"${url}"`,
+                false,
+                attr.loc,
+                true
+              )
               compoundExpression.children.push(exp)
             }
             const isNotLast = imageCandidates.length - 1 > index

--- a/packages/compiler-sfc/src/templateTransformSrcset.ts
+++ b/packages/compiler-sfc/src/templateTransformSrcset.ts
@@ -36,6 +36,9 @@ export const transformSrcset: NodeTransform = (node, context) => {
             return { url, descriptor }
           })
 
+          // When srcset does not contain any relative URLs, skip transforming
+          if (!imageCandidates.some(({ url }) => isRelativeUrl(url))) return
+
           const compoundExpression = createCompoundExpression([], attr.loc)
           imageCandidates.forEach(({ url, descriptor }, index) => {
             if (isRelativeUrl(url)) {

--- a/packages/compiler-sfc/src/templateUtils.ts
+++ b/packages/compiler-sfc/src/templateUtils.ts
@@ -1,15 +1,18 @@
 import { UrlWithStringQuery, parse as uriParse } from 'url'
 import { isString } from '@vue/shared'
 
+export function isRelativeUrl(url: string): boolean {
+  const firstChar = url.charAt(0)
+  return firstChar === '.' || firstChar === '~' || firstChar === '@'
+}
+
 // We need an extra transform context API for injecting arbitrary import
 // statements.
 export function parseUrl(url: string): UrlWithStringQuery {
   const firstChar = url.charAt(0)
-  if (firstChar === '.' || firstChar === '~' || firstChar === '@') {
-    if (firstChar === '~') {
-      const secondChar = url.charAt(1)
-      url = url.slice(secondChar === '/' ? 2 : 1)
-    }
+  if (firstChar === '~') {
+    const secondChar = url.charAt(1)
+    url = url.slice(secondChar === '/' ? 2 : 1)
   }
   return parseUriParts(url)
 }


### PR DESCRIPTION
Issue first reported in `vue-loader`: https://github.com/vuejs/vue-loader/issues/1632

Absolute asset URLs, such as those that start with a forward-slash `/` or are even `http(s)://` URLs are currently interpreted as relative URLs and their path is transformed into an `import` expression by the SFC compiler.

This PR adds a utility method `isRelativeUrl` and uses it to differentiate between URLs that need to be imported and thus transformed, and those that do not.

I can also imagine other names for the helper method, such as `requiresTransform`.

_I only started looking into the source yesterday, so if the solution presented in this PR does not match with how you would solve this, feel free to give pointers and close this._