### PR TITLE
feat(compiler-core): remove repeat key

### DIFF
--- a/packages/compiler-core/__tests__/transforms/__snapshots__/vIf.spec.ts.snap
+++ b/packages/compiler-core/__tests__/transforms/__snapshots__/vIf.spec.ts.snap
@@ -105,3 +105,17 @@ return function render() {
   }
 }"
 `;
+
+exports[`compiler: v-if codegen v-if with key 1`] = `
+"const _Vue = Vue
+
+return function render() {
+  with (this) {
+    const { openBlock: _openBlock, createVNode: _createVNode, createBlock: _createBlock, createCommentVNode: _createCommentVNode } = _Vue
+    
+    return (_openBlock(), ok
+      ? _createBlock(\\"div\\", { key: \\"some-key\\" })
+      : _createCommentVNode(\\"v-if\\", true))
+  }
+}"
+`;

--- a/packages/compiler-core/__tests__/transforms/vIf.spec.ts
+++ b/packages/compiler-core/__tests__/transforms/vIf.spec.ts
@@ -530,6 +530,20 @@ describe('compiler: v-if', () => {
       )
     })
 
+    test('v-if with key', () => {
+      const {
+        root,
+        node: { codegenNode }
+      } = parseWithIfTransform(`<div v-if="ok" key="some-key"/>`)
+      const branch1 = (codegenNode.expressions[1] as ConditionalExpression)
+        .consequent as CallExpression
+      expect(branch1.arguments).toMatchObject([
+        `"div"`,
+        createObjectMatcher({ key: 'some-key' })
+      ])
+      expect(generate(root).code).toMatchSnapshot()
+    })
+
     test.todo('with comments')
   })
 })

--- a/packages/compiler-core/src/utils.ts
+++ b/packages/compiler-core/src/utils.ts
@@ -253,7 +253,14 @@ export function injectProp(
     }
     propsWithInjection = props
   } else if (props.type === NodeTypes.JS_OBJECT_EXPRESSION) {
-    props.properties.unshift(prop)
+    let isRepeated = false
+    if (prop.key.type === NodeTypes.SIMPLE_EXPRESSION) {
+      const propKeyName = prop.key.content
+      isRepeated = props.properties.some(p => p.key.type === NodeTypes.SIMPLE_EXPRESSION && p.key.content === propKeyName)
+    }
+    if (!isRepeated) {
+      props.properties.unshift(prop)
+    }
     propsWithInjection = props
   } else {
     // single v-bind with expression, return a merged replacement

--- a/packages/compiler-core/src/utils.ts
+++ b/packages/compiler-core/src/utils.ts
@@ -253,12 +253,16 @@ export function injectProp(
     }
     propsWithInjection = props
   } else if (props.type === NodeTypes.JS_OBJECT_EXPRESSION) {
-    let isRepeated = false
+    let alreadyExists = false
+    // check existing key to avoid overriding user provided keys
     if (prop.key.type === NodeTypes.SIMPLE_EXPRESSION) {
       const propKeyName = prop.key.content
-      isRepeated = props.properties.some(p => p.key.type === NodeTypes.SIMPLE_EXPRESSION && p.key.content === propKeyName)
+      alreadyExists = props.properties.some(p => (
+        p.key.type === NodeTypes.SIMPLE_EXPRESSION &&
+        p.key.content === propKeyName
+      ))
     }
-    if (!isRepeated) {
+    if (!alreadyExists) {
       props.properties.unshift(prop)
     }
     propsWithInjection = props


### PR DESCRIPTION
Remove the repeat `key` in v-if when you set `key` property directly.

Template:
```html
<div>
  <div v-if="xxx" key="2"></div>
</div>
```
Before:
```js
import { openBlock, createVNode, createBlock, createCommentVNode } from "vue"

export function render() {
  const _ctx = this
  return (openBlock(), createBlock("div", null, [
    (openBlock(), (_ctx.xxx)
      ? createBlock("div", {
          // this key is redundant
          key: 0,
          key: "2"
        })
      : createCommentVNode("v-if", true))
  ]))
}
```
After:
```js
import { openBlock, createVNode, createBlock, createCommentVNode } from "vue"

export function render() {
  const _ctx = this
  return (openBlock(), createBlock("div", null, [
    (openBlock(), (_ctx.xxx)
      ? createBlock("div", { key: "2" })
      : createCommentVNode("v-if", true))
  ]))
}
```