### PR TITLE
fix: e2e tests timeout error

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   preset: 'ts-jest',
+  setupFilesAfterEnv: ['./jest.setup.js'],
   globals: {
     __DEV__: true,
     __TEST__: true,

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,4 @@
+/* global jest */
+if (!process.env.SKIP_E2E) {
+  jest.setTimeout(30000)
+}


### PR DESCRIPTION
When I ran tests, I found some errors about e2e test timeout. E.g:

```
Timeout - Async callback was not invoked within the 5000ms timeout specified by jest.setTimeout.Error: 
```