### PR TITLE
fix(watch): fire callback when original value is undefined

### DIFF
--- a/packages/runtime-core/__tests__/apiWatch.spec.ts
+++ b/packages/runtime-core/__tests__/apiWatch.spec.ts
@@ -439,4 +439,13 @@ describe('api: watch', () => {
       oldValue: 2
     })
   })
+
+  // #683
+  it('watching undefined', async () => {
+    let dummy = null
+    const r = ref(undefined)
+    watch(r, v => (dummy = v))
+    await nextTick()
+    expect(dummy).toBe(undefined)
+  })
 })

--- a/packages/runtime-core/src/apiWatch.ts
+++ b/packages/runtime-core/src/apiWatch.ts
@@ -153,7 +153,8 @@ function doWatch(
     }
   }
 
-  let oldValue = isArray(source) ? [] : undefined
+  const watchDefaultSymbol = (Symbol('watchDefault') as unknown) as undefined // Unique symbol for default, see #683
+  let oldValue = isArray(source) ? [] : watchDefaultSymbol
   const applyCb = cb
     ? () => {
         if (instance && instance.isUnmounted) {
@@ -161,6 +162,9 @@ function doWatch(
         }
         const newValue = runner()
         if (deep || hasChanged(newValue, oldValue)) {
+          if (oldValue === watchDefaultSymbol) {
+            oldValue = undefined
+          }
           // cleanup before running cb again
           if (cleanup) {
             cleanup()


### PR DESCRIPTION
Fixes #683. Created a symbol for default value, so it's unique and will cause callback run even if original value is `undefined`. If it's bad solution, I've got another fix idea so PR can be updated.