### PR TITLE
test: increase jest testTimeout setting

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -31,5 +31,6 @@ module.exports = {
     ? // ignore example tests on netlify builds since they don't contribute
       // to coverage and can cause netlify builds to fail
       ['/node_modules/', '/examples/__tests__']
-    : ['/node_modules/']
+    : ['/node_modules/'],
+  testTimeout: 30 * 1000
 }


### PR DESCRIPTION
Increase jest testTimeout setting to avoid random test failure due to timeout
on slow cpus.