### PR TITLE
feat(server-renderer): compile templates on-the-fly

### DIFF
--- a/packages/server-renderer/__tests__/renderToString.spec.ts
+++ b/packages/server-renderer/__tests__/renderToString.spec.ts
@@ -6,9 +6,11 @@ import {
   resolveComponent,
   ComponentOptions
 } from 'vue'
-import { escapeHtml } from '@vue/shared'
+import { escapeHtml, mockWarn } from '@vue/shared'
 import { renderToString, renderComponent } from '../src/renderToString'
 import { ssrRenderSlot } from '../src/helpers/ssrRenderSlot'
+
+mockWarn()
 
 describe('ssr: renderToString', () => {
   test('should apply app context', async () => {
@@ -56,17 +58,29 @@ describe('ssr: renderToString', () => {
       ).toBe(`<div>hello</div>`)
     })
 
-    test('template components', async () => {
-      expect(
-        await renderToString(
-          createApp({
-            data() {
-              return { msg: 'hello' }
-            },
-            template: `<div>{{ msg }}</div>`
-          })
-        )
-      ).toBe(`<div>hello</div>`)
+    describe('template components', () => {
+      test('render', async () => {
+        expect(
+          await renderToString(
+            createApp({
+              data() {
+                return { msg: 'hello' }
+              },
+              template: `<div>{{ msg }}</div>`
+            })
+          )
+        ).toBe(`<div>hello</div>`)
+      })
+
+      test('handle compiler errors', async () => {
+        await renderToString(createApp({ template: `<` }))
+
+        expect(
+          '[Vue warn]: Template compilation error: Unexpected EOF in tag.\n' +
+            '1  |  <\n' +
+            '   |   ^'
+        ).toHaveBeenWarned()
+      })
     })
 
     test('nested vnode components', async () => {

--- a/packages/server-renderer/__tests__/renderToString.spec.ts
+++ b/packages/server-renderer/__tests__/renderToString.spec.ts
@@ -282,18 +282,7 @@ describe('ssr: renderToString', () => {
     test('nested components with template slots', async () => {
       const Child = {
         props: ['msg'],
-        ssrRender(ctx: any, push: any, parent: any) {
-          push(`<div class="child">`)
-          ssrRenderSlot(
-            ctx.$slots,
-            'default',
-            { msg: 'from slot' },
-            null,
-            push,
-            parent
-          )
-          push(`</div>`)
-        }
+        template: `<div class="child"><slot msg="from slot"></slot></div>`
       }
 
       const app = createApp({
@@ -304,6 +293,32 @@ describe('ssr: renderToString', () => {
       expect(await renderToString(app)).toBe(
         `<div>parent<div class="child">` +
           `<!----><span>from slot</span><!---->` +
+          `</div></div>`
+      )
+    })
+
+    test('nested render fn components with template slots', async () => {
+      const Child = {
+        props: ['msg'],
+        render(this: any) {
+          return h(
+            'div',
+            {
+              class: 'child'
+            },
+            this.$slots.default({ msg: 'from slot' })
+          )
+        }
+      }
+
+      const app = createApp({
+        template: `<div>parent<Child v-slot="{ msg }"><span>{{ msg }}</span></Child></div>`
+      })
+      app.component('Child', Child)
+
+      expect(await renderToString(app)).toBe(
+        `<div>parent<div class="child">` +
+          `<span>from slot</span>` +
           `</div></div>`
       )
     })

--- a/packages/server-renderer/package.json
+++ b/packages/server-renderer/package.json
@@ -28,5 +28,8 @@
   "homepage": "https://github.com/vuejs/vue/tree/dev/packages/server-renderer#readme",
   "peerDependencies": {
     "vue": "3.0.0-alpha.4"
+  },
+  "dependencies": {
+    "@vue/compiler-ssr": "3.0.0-alpha.4"
   }
 }

--- a/packages/server-renderer/src/renderToString.ts
+++ b/packages/server-renderer/src/renderToString.ts
@@ -143,7 +143,7 @@ function renderComponentSubTree(
     } else if (comp.render) {
       renderVNode(push, renderComponentRoot(instance), instance)
     } else {
-      // TODO on the fly template compilation support
+      //  TODO on the fly template compilation support
       throw new Error(
         `Component ${
           comp.name ? `${comp.name} ` : ``

--- a/packages/server-renderer/src/renderToString.ts
+++ b/packages/server-renderer/src/renderToString.ts
@@ -158,7 +158,7 @@ function renderComponentSubTree(
       throw new Error(
         `Component ${
           comp.name ? `${comp.name} ` : ``
-        } doesn't provide template or render function.`
+        } is missing template or render function.`
       )
     }
   }


### PR DESCRIPTION
I've got some questions about this:
1. Should compiler be removable (`server-renderer` built w/o compiler, just as in Vue client renderer)?
2. Should I rewrite existing SSR tests with templates to simplify them (except, of course, `render`/`ssrRender` ones)?