### PR TITLE
perf(reactivity): better computed tracking

### DIFF
--- a/packages/reactivity/src/computed.ts
+++ b/packages/reactivity/src/computed.ts
@@ -1,4 +1,5 @@
-import { effect, ReactiveEffect, activeEffect } from './effect'
+import { effect, ReactiveEffect, trigger, track } from './effect'
+import { TriggerOpTypes, TrackOpTypes } from './operations'
 import { Ref, UnwrapRef } from './ref'
 import { isFunction, NOOP } from '@vue/shared'
 
@@ -42,16 +43,20 @@ export function computed<T>(
 
   let dirty = true
   let value: T
+  let computed: ComputedRef<T>
 
   const runner = effect(getter, {
     lazy: true,
     // mark effect as computed so that it gets priority during trigger
     computed: true,
     scheduler: () => {
-      dirty = true
+      if (!dirty) {
+        dirty = true
+        trigger(computed, TriggerOpTypes.SET, 'value')
+      }
     }
   })
-  return {
+  computed = {
     _isRef: true,
     // expose effect so computed can be stopped
     effect: runner,
@@ -60,27 +65,12 @@ export function computed<T>(
         value = runner()
         dirty = false
       }
-      // When computed effects are accessed in a parent effect, the parent
-      // should track all the dependencies the computed property has tracked.
-      // This should also apply for chained computed properties.
-      trackChildRun(runner)
+      track(computed, TrackOpTypes.GET, 'value')
       return value
     },
     set value(newValue: T) {
       setter(newValue)
     }
   } as any
-}
-
-function trackChildRun(childRunner: ReactiveEffect) {
-  if (activeEffect === undefined) {
-    return
-  }
-  for (let i = 0; i < childRunner.deps.length; i++) {
-    const dep = childRunner.deps[i]
-    if (!dep.has(activeEffect)) {
-      dep.add(activeEffect)
-      activeEffect.deps.push(dep)
-    }
-  }
+  return computed
 }


### PR DESCRIPTION
I made `computed` use `track` and `trigger` directly.

Why?
- **Code is shorter and simpler**. `trackChildRun` depended on `activeEffect` and was basically a copy of tracking internals. The new code is straightforward to understand: it simply calls `track` when value is read.
- **Debugging is more clear**. If you look at dependencies during debugging, you'll see the computed, rather than what's cached behind.
- **It's more efficient**. If the getter depends on hundreds of values (typical use case: computed filters or summarizes an array), those 100+ dependencies will be registered on the computed effect, but then transitively copied as dependencies of any effect that reads the computed. With `N` dependencies and `M` readers, before PR we had `N*(M+1)` entries, after PR `N+M`.
Not only does it save space, it also saves time if many dependencies change at once. If `N` dependencies change at once, the number function calls is the same as the entries above (after PR, `computed` only calls `trigger` once, rather than having a notification for every dependency that changes).