### PR TITLE
feat(reactive): expose shallowReactive

### DIFF
--- a/packages/runtime-core/src/apiReactivity.ts
+++ b/packages/runtime-core/src/apiReactivity.ts
@@ -6,6 +6,7 @@ export {
   isReactive,
   readonly,
   isReadonly,
+  shallowReactive,
   toRaw,
   markReadonly,
   markNonReactive,


### PR DESCRIPTION
#689 added `shallowReactive` to fix #674 but it forgot to add it to Vue public API, so it's only available internally.