### PR TITLE
fix(runtime-core): convert to an Error instance for ErrorCapturedHook

### DIFF
--- a/packages/runtime-core/src/errorHandling.ts
+++ b/packages/runtime-core/src/errorHandling.ts
@@ -93,10 +93,12 @@ export function callWithAsyncErrorHandling(
 }
 
 export function handleError(
-  err: Error,
+  argError: any,
   instance: ComponentInternalInstance | null,
   type: ErrorTypes
 ) {
+  const err = toError(argError)
+
   const contextVNode = instance ? instance.vnode : null
   if (instance) {
     let cur = instance.parent
@@ -151,4 +153,12 @@ function logError(err: Error, type: ErrorTypes, contextVNode: VNode | null) {
   } else {
     throw err
   }
+}
+
+export const toError = (val: any): Error => {
+  if (val instanceof Error) {
+    return val
+  }
+
+  return new Error(String(val))
 }


### PR DESCRIPTION
When a non `Error` is thrown in async setup functions, the error passed to `ErrorCapturedHook` is not `Error`.
 (e:g `onErrorCaptured`)

```ts
// Child
defineComponent({
  async setup() {
    throw 'Something went wrong'
  }
})

// Parent
defineComponent({
  setup() {
    onErrorCaptured(err => {
      console.log(err) //  This is string, not Error instance.
    })
  }
})
```

Therefore, we convert the passed value to Error.