### PR TITLE
perf(compiler-core): removal of loop over ancestors from isEnd()

### DIFF
--- a/packages/compiler-core/src/parse.ts
+++ b/packages/compiler-core/src/parse.ts
@@ -995,11 +995,11 @@ function isEnd(
   switch (mode) {
     case TextModes.DATA:
       if (startsWith(s, '</')) {
-        //TODO: probably bad performance
-        for (let i = ancestors.length - 1; i >= 0; --i) {
-          if (startsWithEndTagOpen(s, ancestors[i].tag)) {
-            return true
-          }
+        if (
+          ancestors.length &&
+          startsWithEndTagOpen(s, ancestors[ancestors.length - 1].tag)
+        ) {
+          return true
         }
       }
       break


### PR DESCRIPTION
In all the cases it's going to be only last tag to be checked among the ancestors array.