### PR TITLE
feat(isRuntimeCompileBuild): use buildOption to determine runtime com…

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -13,6 +13,7 @@
   ],
   "buildOptions": {
     "name": "Vue",
+    "isRuntimeCompileBuild": true,
     "formats": [
       "esm-bundler",
       "esm-bundler-runtime",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -82,7 +82,7 @@ function createConfig(format, output, plugins = []) {
   const isRawESMBuild = format === 'esm'
   const isNodeBuild = format === 'cjs'
   const isBundlerESMBuild = /esm-bundler/.test(format)
-  const isRuntimeCompileBuild = /vue\./.test(output.file)
+  const isRuntimeCompileBuild = packageOptions.isRuntimeCompileBuild
 
   if (isGlobalBuild) {
     output.name = packageOptions.name


### PR DESCRIPTION
…pile build

This makes it possible to create a separate package that uses runtime compilation.