### PR TITLE
types(reactivity): ref type may be undefined without initial value

### DIFF
--- a/packages/reactivity/src/ref.ts
+++ b/packages/reactivity/src/ref.ts
@@ -30,7 +30,7 @@ export function isRef(r: any): r is Ref {
 
 export function ref<T extends Ref>(value: T): T
 export function ref<T>(value: T): Ref<T>
-export function ref<T = any>(): Ref<T>
+export function ref<T = any>(): Ref<T | undefined>
 export function ref(value?: unknown) {
   if (isRef(value)) {
     return value


### PR DESCRIPTION
```ts
// before
ref<string>() // string

// after
ref<string>() // string | undefined
```