### PR TITLE
chore(shared): unified use of startsWith to judge key

### DIFF
--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -24,7 +24,7 @@ export const NOOP = () => {}
  */
 export const NO = () => false
 
-export const isOn = (key: string) => key[0] === 'o' && key[1] === 'n'
+export const isOn = (key: string) => key.startsWith('on')
 
 export const extend = <T extends object, U extends object>(
   a: T,


### PR DESCRIPTION
Unified use of `startsWith` to judge key which has a "on" prefix. This will be easier to read, and make it more uniform.