### PR TITLE
fix(runtime-core): should work fallthrough with inheritAttrs: true

### DIFF
--- a/packages/runtime-core/__tests__/rendererAttrsFallthrough.spec.ts
+++ b/packages/runtime-core/__tests__/rendererAttrsFallthrough.spec.ts
@@ -227,6 +227,27 @@ describe('attribute fallthrough', () => {
     expect(node.hasAttribute('foo')).toBe(false)
   })
 
+  it('should fallthrough with inheritAttrs: true and no declared props', () => {
+    const Parent = {
+      render() {
+        return h(Child, { class: 'parent' })
+      }
+    }
+
+    const Child = defineComponent({
+      inheritAttrs: true,
+      render() {
+        return h('div')
+      }
+    })
+
+    const root = document.createElement('div')
+    document.body.appendChild(root)
+    render(h(Parent), root)
+
+    expect(root.innerHTML).toMatch(`<div class="parent"></div>`)
+  })
+
   it('should not fallthrough with inheritAttrs: false', () => {
     const Parent = {
       render() {

--- a/packages/runtime-core/src/componentRenderUtils.ts
+++ b/packages/runtime-core/src/componentRenderUtils.ts
@@ -80,8 +80,8 @@ export function renderComponentRoot(
 
     // attr merging
     if (
-      Component.props != null &&
-      Component.inheritAttrs !== false &&
+      (Component.inheritAttrs ||
+        (Component.props != null && Component.inheritAttrs !== false)) &&
       attrs !== EMPTY_OBJ &&
       Object.keys(attrs).length
     ) {


### PR DESCRIPTION
I suggest that the attrs fallthrough should work with `inheritAttrs: true` even when props has not declared.

related #749 