### PR TITLE
fix(runtime-core): make watchEffect ignore deep option

### DIFF
--- a/packages/runtime-core/__tests__/apiWatch.spec.ts
+++ b/packages/runtime-core/__tests__/apiWatch.spec.ts
@@ -410,6 +410,24 @@ describe('api: watch', () => {
     expect(dummy).toBe(1)
   })
 
+  it('warn and not respect deep option when using effect', async () => {
+    const arr = ref([1, [2]])
+    let spy = jest.fn()
+    watchEffect(
+      () => {
+        spy()
+        return arr
+      },
+      // @ts-ignore
+      { deep: true }
+    )
+    expect(spy).toHaveBeenCalledTimes(1)
+    ;(arr.value[1] as Array<number>)[0] = 3
+    await nextTick()
+    expect(spy).toHaveBeenCalledTimes(1)
+    expect(`"deep" option is only respected`).toHaveBeenWarned()
+  })
+
   it('onTrack', async () => {
     const events: DebuggerEvent[] = []
     let dummy

--- a/packages/runtime-core/src/apiWatch.ts
+++ b/packages/runtime-core/src/apiWatch.ts
@@ -139,13 +139,13 @@ function doWatch(
     if (immediate !== undefined) {
       warn(
         `watch() "immediate" option is only respected when using the ` +
-          `watch(source, callback) signature.`
+          `watch(source, callback, options?) signature.`
       )
     }
     if (deep !== undefined) {
       warn(
         `watch() "deep" option is only respected when using the ` +
-          `watch(source, callback) signature.`
+          `watch(source, callback, options?) signature.`
       )
     }
   }
@@ -186,7 +186,7 @@ function doWatch(
     }
   }
 
-  if (deep) {
+  if (cb && deep) {
     const baseGetter = getter
     getter = () => traverse(baseGetter())
   }


### PR DESCRIPTION
Make watchEffect  behavior not affected by deep option when the callback function returns a nested Reactive or Ref.