### PR TITLE
fix(componentRenderUtils): a wrong judge in shouldUpdateComponent (#677)

### DIFF
--- a/packages/runtime-core/src/componentRenderUtils.ts
+++ b/packages/runtime-core/src/componentRenderUtils.ts
@@ -64,6 +64,13 @@ export function renderComponentRoot(
       result = normalizeVNode(
         instance.render!.call(proxyToUse, proxyToUse, renderCache)
       )
+      // root node should inherit class/style in component tag and patch
+      if (vnode.patchFlag & PatchFlags.CLASS) {
+        result.patchFlag |= PatchFlags.CLASS
+      }
+      if (vnode.patchFlag & PatchFlags.STYLE) {
+        result.patchFlag |= PatchFlags.STYLE
+      }
     } else {
       // functional
       const render = Component as FunctionalComponent

--- a/packages/runtime-core/src/componentRenderUtils.ts
+++ b/packages/runtime-core/src/componentRenderUtils.ts
@@ -183,7 +183,7 @@ export function shouldUpdateComponent(
       return hasPropsChanged(prevProps!, nextProps!)
     } else {
       if (patchFlag & PatchFlags.CLASS) {
-        return prevProps!.class === nextProps!.class
+        return prevProps!.class !== nextProps!.class
       }
       if (patchFlag & PatchFlags.STYLE) {
         return hasPropsChanged(prevProps!.style, nextProps!.style)


### PR DESCRIPTION
This PR is to fix [#677](https://github.com/vuejs/vue-next/issues/677), #677 can be more simple, the bug still exit without ````<transition-group>````, there are two problems cause it.
I had resolved one, now #677 can patch text correctly.
About the color(class) patch error, I had found the reason. But I still have some confussion, I don't know what is the best way to fix it：In vue-next, a Component can have multi root element, so how to deal with class or style, all to inherit？
(I am not good at English.≥.≤)