### PR TITLE
fix(runtime-core/watch): set initial oldValue  param of cb as undefined

### DIFF
--- a/packages/runtime-core/__tests__/apiWatch.spec.ts
+++ b/packages/runtime-core/__tests__/apiWatch.spec.ts
@@ -391,7 +391,26 @@ describe('api: watch', () => {
     await nextTick()
     expect(spy).toHaveBeenCalledTimes(3)
   })
+  it('immediate: set undefined as oldValue param in cb at first run ', () => {
+    let dummy
+    watch(
+      [],
+      (newValue, oldValue) => {
+        dummy = [newValue, oldValue]
+      },
+      { immediate: true }
+    )
+    expect(dummy).toEqual([[], undefined])
 
+    watch(
+      ref(0),
+      (newValue, oldValue) => {
+        dummy = [newValue, oldValue]
+      },
+      { immediate: true }
+    )
+    expect(dummy).toEqual([0, undefined])
+  })
   it('warn immediate option when using effect', async () => {
     const count = ref(0)
     let dummy

--- a/packages/runtime-core/src/apiWatch.ts
+++ b/packages/runtime-core/src/apiWatch.ts
@@ -79,9 +79,6 @@ export function watchEffect(
   return doWatch(effect, null, options)
 }
 
-// initial value for watchers to trigger on undefined initial values
-const INITIAL_WATCHER_VALUE = {}
-
 // overload #1: single source + cb
 export function watch<T, Immediate extends Readonly<boolean> = false>(
   source: WatchSource<T>,
@@ -201,7 +198,9 @@ function doWatch(
     return NOOP
   }
 
-  let oldValue = isArray(source) ? [] : INITIAL_WATCHER_VALUE
+  // initial value for watchers to trigger on undefined initial values
+  const INITIAL_WATCHER_VALUE = {}
+  let oldValue = INITIAL_WATCHER_VALUE
   const applyCb = cb
     ? () => {
         if (instance && instance.isUnmounted) {


### PR DESCRIPTION
`watch([], cb, {immediate: true})` set `undefined` as oldValue param
in cb in first run. Keeps same behavior with 2.x

You can inspect different output in console:
v2.6.11:  https://codepen.io/djy/pen/NWqpJMp
v3.0.0-alpha.7: https://codepen.io/djy/pen/MWwpxXQ?editors=0011