### PR TITLE
perf(renderComponentRoot): optimize component's props patch

### DIFF
--- a/packages/runtime-core/src/componentRenderUtils.ts
+++ b/packages/runtime-core/src/componentRenderUtils.ts
@@ -77,7 +77,7 @@ export function renderComponentRoot(
           : render(props, null as any /* we know it doesn't need it */)
       )
     }
-
+    debugger
     // attr merging
     let fallthroughAttrs
     if (
@@ -114,7 +114,7 @@ export function renderComponentRoot(
               PatchFlags.PROPS)
           if (inheritFlag) {
             result.patchFlag |= inheritFlag
-          } else {
+          } else if (vnode.dynamicProps === null) {
             result.patchFlag |= PatchFlags.FULL_PROPS
           }
         }


### PR DESCRIPTION
It‘s unnecessary to patch full props always in component root