### PR TITLE
fix(runtime-core): Update error type to unknown

### DIFF
--- a/packages/runtime-core/__tests__/components/Suspense.spec.ts
+++ b/packages/runtime-core/__tests__/components/Suspense.spec.ts
@@ -536,15 +536,18 @@ describe('Suspense', () => {
 
     const Comp = {
       setup() {
-        const error = ref<Error | null>(null)
-        onErrorCaptured(e => {
-          error.value = e
+        const errorMessage = ref<string | null>(null)
+        onErrorCaptured(err => {
+          errorMessage.value =
+            err instanceof Error
+              ? err.message
+              : `A non-Error value thrown: ${err}`
           return true
         })
 
         return () =>
-          error.value
-            ? h('div', error.value.message)
+          errorMessage.value
+            ? h('div', errorMessage.value)
             : h(Suspense, null, {
                 default: h(Async),
                 fallback: h('div', 'fallback')

--- a/packages/runtime-core/src/apiCreateApp.ts
+++ b/packages/runtime-core/src/apiCreateApp.ts
@@ -41,7 +41,7 @@ export interface AppConfig {
   readonly isNativeTag?: (tag: string) => boolean
   isCustomElement?: (tag: string) => boolean
   errorHandler?: (
-    err: Error,
+    err: unknown,
     instance: ComponentPublicInstance | null,
     info: string
   ) => void

--- a/packages/runtime-core/src/apiLifecycle.ts
+++ b/packages/runtime-core/src/apiLifecycle.ts
@@ -85,7 +85,7 @@ export const onRenderTracked = createHook<DebuggerHook>(
 )
 
 export type ErrorCapturedHook = (
-  err: Error,
+  err: unknown,
   instance: ComponentPublicInstance | null,
   info: string
 ) => boolean | void

--- a/packages/runtime-core/src/errorHandling.ts
+++ b/packages/runtime-core/src/errorHandling.ts
@@ -78,7 +78,7 @@ export function callWithAsyncErrorHandling(
   if (isFunction(fn)) {
     const res = callWithErrorHandling(fn, instance, type, args)
     if (res != null && !res._isVue && isPromise(res)) {
-      res.catch((err: Error) => {
+      res.catch(err => {
         handleError(err, instance, type)
       })
     }
@@ -93,7 +93,7 @@ export function callWithAsyncErrorHandling(
 }
 
 export function handleError(
-  err: Error,
+  err: unknown,
   instance: ComponentInternalInstance | null,
   type: ErrorTypes
 ) {
@@ -136,7 +136,7 @@ export function setErrorRecovery(value: boolean) {
   forceRecover = value
 }
 
-function logError(err: Error, type: ErrorTypes, contextVNode: VNode | null) {
+function logError(err: unknown, type: ErrorTypes, contextVNode: VNode | null) {
   // default behavior is crash in prod & test, recover in dev.
   if (__DEV__ && (forceRecover || !__TEST__)) {
     const info = ErrorTypeStrings[type]


### PR DESCRIPTION
The type of error passed to `onErrorCaptured` should be any, because JavaScript can throw anything other than `Error`.
React does not convert the thrown value to `Error`, and passes it to componentDidCatch as it is.