### PR TITLE
Remove 'this' annotation from 'get' accessor

### DIFF
--- a/packages/reactivity/src/collectionHandlers.ts
+++ b/packages/reactivity/src/collectionHandlers.ts
@@ -176,8 +176,8 @@ const mutableInstrumentations: Record<string, Function> = {
   get(this: MapTypes, key: unknown) {
     return get(this, key, toReactive)
   },
-  get size(this: IterableCollections) {
-    return size(this)
+  get size() {
+    return size(this as unknown as IterableCollections)
   },
   has,
   add,


### PR DESCRIPTION
The next version of Typescript disallows 'this' parameter annotations on accessors, which causes vue-next to fail to compile.

This PR removes the annotation and adds a cast instead.

Fixes #800