### PR TITLE
fix(runtime-core): always set invalid vnode type

### DIFF
--- a/packages/runtime-core/src/vnode.ts
+++ b/packages/runtime-core/src/vnode.ts
@@ -209,8 +209,10 @@ export function createVNode(
   patchFlag: number = 0,
   dynamicProps: string[] | null = null
 ): VNode {
-  if (__DEV__ && !type) {
-    warn(`Invalid vnode type when creating vnode: ${type}.`)
+  if (!type) {
+    if (__DEV__) {
+      warn(`Invalid vnode type when creating vnode: ${type}.`)
+    }
     type = Comment
   }
 


### PR DESCRIPTION
Currently, when a component used is not properly registered, we have a warning and the vnode type is set to a Comment type in DEV mode. But in prod mode, we have no default value, making such an application broken and throw a strange error (`can not read _isSuspense of undefined`).

This commit avoids such an error in prod mode (as it is currently the case in Vue 2.x).