### PR TITLE
feat(runtime-core): add special property to get class component options

### DIFF
--- a/packages/runtime-core/__tests__/vnode.spec.ts
+++ b/packages/runtime-core/__tests__/vnode.spec.ts
@@ -46,6 +46,15 @@ describe('vnode', () => {
     }
   })
 
+  test('create with class component', () => {
+    class Component {
+      $props: any
+      static __vueClassComponentOptions = { template: '<div />' }
+    }
+    const vnode = createVNode(Component)
+    expect(vnode.type).toEqual(Component.__vueClassComponentOptions)
+  })
+
   describe('class normalization', () => {
     test('string', () => {
       const vnode = createVNode('p', { class: 'foo baz' })

--- a/packages/runtime-core/__tests__/vnode.spec.ts
+++ b/packages/runtime-core/__tests__/vnode.spec.ts
@@ -49,10 +49,10 @@ describe('vnode', () => {
   test('create with class component', () => {
     class Component {
       $props: any
-      static __vueClassComponentOptions = { template: '<div />' }
+      static __vccOpts = { template: '<div />' }
     }
     const vnode = createVNode(Component)
-    expect(vnode.type).toEqual(Component.__vueClassComponentOptions)
+    expect(vnode.type).toEqual(Component.__vccOpts)
   })
 
   describe('class normalization', () => {

--- a/packages/runtime-core/src/component.ts
+++ b/packages/runtime-core/src/component.ts
@@ -58,13 +58,18 @@ export interface FunctionalComponent<P = {}> extends SFCInternalOptions {
   displayName?: string
 }
 
+export interface ClassComponent {
+  new (...args: any[]): ComponentPublicInstance<any, any, any, any, any>
+  __vueClassComponentOptions: ComponentOptions
+}
+
 export type Component = ComponentOptions | FunctionalComponent
 
 // A type used in public APIs where a component type is expected.
 // The constructor type is an artificial type returned by defineComponent().
 export type PublicAPIComponent =
   | Component
-  | { new (): ComponentPublicInstance<any, any, any, any, any> }
+  | { new (...args: any[]): ComponentPublicInstance<any, any, any, any, any> }
 
 export { ComponentOptions }
 

--- a/packages/runtime-core/src/component.ts
+++ b/packages/runtime-core/src/component.ts
@@ -60,7 +60,7 @@ export interface FunctionalComponent<P = {}> extends SFCInternalOptions {
 
 export interface ClassComponent {
   new (...args: any[]): ComponentPublicInstance<any, any, any, any, any>
-  __vueClassComponentOptions: ComponentOptions
+  __vccOpts: ComponentOptions
 }
 
 export type Component = ComponentOptions | FunctionalComponent

--- a/packages/runtime-core/src/h.ts
+++ b/packages/runtime-core/src/h.ts
@@ -130,7 +130,7 @@ export function h<O>(
   children?: RawChildren | RawSlots
 ): VNode
 
-// fake constructor type returned by `defineComponent`
+// fake constructor type returned by `defineComponent` or class component
 export function h(type: Constructor, children?: RawChildren): VNode
 export function h<P>(
   type: Constructor<P>,

--- a/packages/runtime-core/src/vnode.ts
+++ b/packages/runtime-core/src/vnode.ts
@@ -216,8 +216,8 @@ export function createVNode(
   }
 
   // class component normalization.
-  if (isFunction(type) && '__vueClassComponentOptions' in type) {
-    type = type.__vueClassComponentOptions
+  if (isFunction(type) && '__vccOpts' in type) {
+    type = type.__vccOpts
   }
 
   // class & style normalization.

--- a/packages/runtime-core/src/vnode.ts
+++ b/packages/runtime-core/src/vnode.ts
@@ -14,7 +14,8 @@ import {
   ComponentInternalInstance,
   Data,
   SetupProxySymbol,
-  Component
+  Component,
+  ClassComponent
 } from './component'
 import { RawSlots } from './componentSlots'
 import { isReactive, Ref } from '@vue/reactivity'
@@ -162,7 +163,7 @@ export function setBlockTracking(value: number) {
 // A block root keeps track of dynamic nodes within the block in the
 // `dynamicChildren` array.
 export function createBlock(
-  type: VNodeTypes,
+  type: VNodeTypes | ClassComponent,
   props?: { [key: string]: any } | null,
   children?: any,
   patchFlag?: number,
@@ -203,7 +204,7 @@ export function isSameVNodeType(n1: VNode, n2: VNode): boolean {
 }
 
 export function createVNode(
-  type: VNodeTypes,
+  type: VNodeTypes | ClassComponent,
   props: (Data & VNodeProps) | null = null,
   children: unknown = null,
   patchFlag: number = 0,
@@ -212,6 +213,11 @@ export function createVNode(
   if (__DEV__ && !type) {
     warn(`Invalid vnode type when creating vnode: ${type}.`)
     type = Comment
+  }
+
+  // class component normalization.
+  if (isFunction(type) && '__vueClassComponentOptions' in type) {
+    type = type.__vueClassComponentOptions
   }
 
   // class & style normalization.


### PR DESCRIPTION
This PR adds a special property `__vueClassComponentOptions` to process class style component. 

If a component passed to `createVNode` is a `function` and having `__vueClassComponentOptions` property, it gets the actual component options from that property. To decouple with vue-class-component as possible, Vue core only knows where the options object of class component is stored. vue-class-component should convert the class to a component options object.

Vue v3 + vue-class-component is already working with this change. The brief idea of the implementation looks like below:

```ts
// Providing Vue base constructor from vue-class-component
export class Vue<Props = unknown> implements ComponentPublicInstance<{}, {}, {}, {}, {}, Props> {
  // Define a getter to convert the class to options object
  static get __vueClassComponentOptions() {
    // converting logic here...
  }
}

// ------

// Usage
class App extends Vue<{ name: string }> {
  greeting = 'Hello, ' + this.$props.name
}
```