### PR TITLE
feat(reactivity): public contract for ref, reactive (fix vuejs/rfcs#129)

### DIFF
--- a/packages/reactivity/__tests__/reactive.spec.ts
+++ b/packages/reactivity/__tests__/reactive.spec.ts
@@ -4,6 +4,7 @@ import {
   isReactive,
   toRaw,
   markNonReactive,
+  markReactive,
   shallowReactive
 } from '../src/reactive'
 import { mockWarn } from '@vue/shared'
@@ -153,6 +154,17 @@ describe('reactivity/reactive', () => {
     })
     expect(isReactive(obj.foo)).toBe(true)
     expect(isReactive(obj.bar)).toBe(false)
+  })
+
+  test('markReactive', () => {
+    const raw = { a: 1, b: 2 }
+    const proxy = new Proxy(raw, {})
+    const myReactive = markReactive(proxy, raw)
+
+    expect(myReactive).toBe(proxy)
+    expect(isReactive(myReactive)).toBe(true)
+    expect(toRaw(myReactive)).toBe(raw)
+    expect(reactive(myReactive)).toBe(myReactive)
   })
 
   describe('shallowReactive', () => {

--- a/packages/reactivity/__tests__/ref.spec.ts
+++ b/packages/reactivity/__tests__/ref.spec.ts
@@ -3,6 +3,7 @@ import {
   effect,
   reactive,
   isRef,
+  markRef,
   toRefs,
   Ref,
   isReactive
@@ -166,6 +167,17 @@ describe('reactivity/ref', () => {
     expect(isRef(1)).toBe(false)
     // an object that looks like a ref isn't necessarily a ref
     expect(isRef({ value: 0 })).toBe(false)
+  })
+
+  test('markRef', () => {
+    const raw = { value: 4 }
+    const myRef = markRef(raw)
+
+    expect(myRef).toBe(raw)
+    expect(myRef.value).toBe(4)
+    expect(isRef(myRef)).toBe(true)
+    expect(unref(myRef)).toBe(4)
+    expect(ref(myRef).value).toBe(4)
   })
 
   test('toRefs', () => {

--- a/packages/reactivity/src/index.ts
+++ b/packages/reactivity/src/index.ts
@@ -1,4 +1,13 @@
-export { ref, unref, shallowRef, isRef, toRefs, Ref, UnwrapRef } from './ref'
+export {
+  ref,
+  unref,
+  shallowRef,
+  isRef,
+  markRef,
+  toRefs,
+  Ref,
+  UnwrapRef
+} from './ref'
 export {
   reactive,
   isReactive,
@@ -8,7 +17,8 @@ export {
   shallowReadonly,
   toRaw,
   markReadonly,
-  markNonReactive
+  markNonReactive,
+  markReactive
 } from './reactive'
 export {
   computed,

--- a/packages/reactivity/src/reactive.ts
+++ b/packages/reactivity/src/reactive.ts
@@ -164,3 +164,12 @@ export function markNonReactive<T>(value: T): T {
   nonReactiveValues.add(value)
   return value
 }
+
+export function markReactive<T>(react: T, raw: object) {
+  if (__DEV__ && rawToReactive.has(raw)) {
+    console.warn('Raw value is already registered with a reactive wrapper', raw)
+  }
+  reactiveToRaw.set(react, raw)
+  rawToReactive.set(raw, react)
+  return react
+}

--- a/packages/reactivity/src/ref.ts
+++ b/packages/reactivity/src/ref.ts
@@ -40,6 +40,11 @@ export function shallowRef(value?: unknown) {
   return createRef(value, true)
 }
 
+export function markRef<T>(r: { value: T }) {
+  ;(r as any)._isRef = true
+  return r as Ref<T>
+}
+
 function createRef(value: unknown, shallow = false) {
   if (isRef(value)) {
     return value


### PR DESCRIPTION
This PR adds two new public functions: `markRef` and `markReactive`.
They are meant for advanced users or library authors and are only exported by `@vue/reactivity`, not `vue` itself.

The use-case here is to allow libraries to provide alternative, specialized implementations of the `ref` (observable value) and `reactive` (observable object) concepts.

### Example use cases
One could want to create a ref that debounces its notifications:
```ts
function debouncedRef<T>(delay: number, value?: T) {
  let timeout = 0
  return markRef({
    get value() {
      track(this, TrackOpTypes.GET, 'value')
      return value
    },
    set value(v: T) {
      value = v
      clearTimeout(timeout)
      timeout = setTimeout(() => trigger(this, TriggerOpTypes.SET, 'value'), delay)
    }
  })
}
```

On the reactive side, one could want to create:
- an implementation based on getter/setters rather than proxies (e.g. to work with classes using private fields); 
- an optimized reactive array that doesn't watch changes individually but as a whole;
- "fake" reactive objects that do limited functionality, e.g. `hideRefs({ a: ref(4) })` that only automatically unwrap refs.

### Alternatives
It is possible to mark alternative implementations with `markNonReactive` but it doesn't integrate as well with Vue and some scenarios are broken.

For example, you can't make a `Ref<T>` in Typescript because the interface uses a private symbol to prevent that. This can only be worked around with `<any>` casts.

On the `reactive` side, some operations use `toRaw` (notably the template `ref` feature, e.g. `<Component ref='x'>`) and this is not exposed publicly so there is no way to tap into it.

### RFC
Closes vuejs/rfcs#129