### PR TITLE
feat(runtime-core): export `ErrorTypes` to can be used with callWithE…

### DIFF
--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -74,16 +74,14 @@ export { warn } from './warning'
 export {
   handleError,
   callWithErrorHandling,
-  callWithAsyncErrorHandling
+  callWithAsyncErrorHandling,
+  ErrorCodes
 } from './errorHandling'
 export {
   useTransitionState,
   resolveTransitionHooks,
   setTransitionHooks
 } from './components/BaseTransition'
-// export errorTypes to can be used with callWithErrorHandling
-export { LifecycleHooks } from './component'
-export { ErrorCodes } from './errorHandling'
 
 // For compiler generated code
 // should sync with '@vue/compiler-core/src/runtimeConstants.ts'

--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -81,6 +81,9 @@ export {
   resolveTransitionHooks,
   setTransitionHooks
 } from './components/BaseTransition'
+// export errorTypes to can be used with callWithErrorHandling
+export { LifecycleHooks } from './component'
+export { ErrorCodes } from './errorHandling'
 
 // For compiler generated code
 // should sync with '@vue/compiler-core/src/runtimeConstants.ts'


### PR DESCRIPTION
…rrorHandling

fix #833