### PR TITLE
fix(runtime-core): empty boolean props

### DIFF
--- a/packages/runtime-core/__tests__/component.spec.ts
+++ b/packages/runtime-core/__tests__/component.spec.ts
@@ -14,7 +14,34 @@ describe('renderer: component', () => {
 
   test.todo('componentProxy')
 
-  test.todo('componentProps')
+  describe('componentProps', () => {
+    test.todo('should work')
+
+    test('should convert empty booleans to true', () => {
+      let b1: any, b2: any, b3: any
+
+      const Comp = defineComponent({
+        props: {
+          b1: Boolean,
+          b2: [Boolean, String],
+          b3: [String, Boolean]
+        },
+        setup(props) {
+          ;({ b1, b2, b3 } = props)
+          return () => ''
+        }
+      })
+
+      render(
+        h(Comp, <any>{ b1: '', b2: '', b3: '' }),
+        nodeOps.createElement('div')
+      )
+
+      expect(b1).toBe(true)
+      expect(b2).toBe(true)
+      expect(b3).toBe('')
+    })
+  })
 
   describe('slots', () => {
     test('should respect $stable flag', async () => {

--- a/packages/runtime-core/src/componentProps.ts
+++ b/packages/runtime-core/src/componentProps.ts
@@ -260,7 +260,8 @@ function normalizePropsOptions(
           const booleanIndex = getTypeIndex(Boolean, prop.type)
           const stringIndex = getTypeIndex(String, prop.type)
           prop[BooleanFlags.shouldCast] = booleanIndex > -1
-          prop[BooleanFlags.shouldCastTrue] = booleanIndex < stringIndex
+          prop[BooleanFlags.shouldCastTrue] =
+            stringIndex < 0 || booleanIndex < stringIndex
           // if the prop needs boolean casting or default value
           if (booleanIndex > -1 || hasOwn(prop, 'default')) {
             needCastKeys.push(normalizedKey)
@@ -297,7 +298,7 @@ function getTypeIndex(
         return i
       }
     }
-  } else if (isObject(expectedTypes)) {
+  } else if (isFunction(expectedTypes)) {
     return isSameType(expectedTypes, type) ? 0 : -1
   }
   return -1


### PR DESCRIPTION
If you define the following property:
`props: { active: Boolean }`
And then use it without a value:
`<Component active>`
Then it is not set to `true` but to `''`.

There are in fact 2 different bugs in source code preventing this from working, check the changes.

There were no tests for props (just a TODO), I added one test for this specific fix.

Fixes #843