### PR TITLE
feat: add hook to transform h's arguments

### DIFF
--- a/packages/runtime-core/__tests__/h.spec.ts
+++ b/packages/runtime-core/__tests__/h.spec.ts
@@ -1,9 +1,11 @@
-import { h } from '../src/h'
+import { h, transformHArgs, resetTransformHArgs } from '../src/h'
 import { createVNode } from '../src/vnode'
+import { ComponentInternalInstance } from '@vue/runtime-core'
+import { createApp } from '@vue/runtime-dom'
 
 // Since h is a thin layer on top of createVNode, we are only testing its
 // own logic here. Details of vnode creation is tested in vnode.spec.ts.
-describe('renderer: h', () => {
+const testH = () => {
   test('type only', () => {
     expect(h('div')).toMatchObject(createVNode('div'))
   })
@@ -56,5 +58,58 @@ describe('renderer: h', () => {
         foo: slot
       })
     )
+  })
+}
+
+describe('renderer: h', testH)
+describe('renderer: transformHArgs', () => {
+  describe('no-op pass-through', () => {
+    beforeAll(() => {
+      transformHArgs((hArgs: unknown[]) => hArgs)
+    })
+    afterAll(resetTransformHArgs)
+    testH()
+  })
+
+  describe('args is used directly, without merging', () => {
+    beforeAll(() => {
+      transformHArgs(() => ['h1', 'Hello World'])
+    })
+    afterAll(resetTransformHArgs)
+    test('nodes become an h1 with text inside', () => {
+      expect(h('div')).toMatchObject(createVNode('h1', null, 'Hello World'))
+    })
+
+    test('resetting transformHArgs turns things back to normal', () => {
+      expect(h('div')).toMatchObject(createVNode('h1', null, 'Hello World'))
+
+      resetTransformHArgs()
+
+      expect(h('div')).toMatchObject(createVNode('div'))
+    })
+  })
+
+  test('receives component instance as the 2nd arg', () => {
+    transformHArgs((_: unknown[], instance: ComponentInternalInstance) => {
+      return ['h1', instance.type.name] // <h1>{{ name }}</h1>
+    })
+
+    const vm = createApp({
+      name: 'Root Component', // this will be the name of the component in the h1
+      render() {
+        return h({
+          // this code will never execute,
+          // because it is overridden by the transformHArgs method
+          render() {
+            return h('h2', 'Stub Text')
+          }
+        })
+      }
+    })
+
+    // we need to mount everything so that the instance passed to transformHArgs isn't null
+    vm.mount('body')
+
+    expect(document.body.outerHTML).toContain('<h1>Root Component</h1>')
   })
 })

--- a/packages/runtime-core/__tests__/h.spec.ts
+++ b/packages/runtime-core/__tests__/h.spec.ts
@@ -62,12 +62,15 @@ const testH = () => {
 }
 
 describe('renderer: h', testH)
+
 describe('renderer: transformHArgs', () => {
   describe('no-op pass-through', () => {
     beforeAll(() => {
       transformHArgs((hArgs: unknown[]) => hArgs)
     })
+ 
     afterAll(resetTransformHArgs)
+ 
     testH()
   })
 
@@ -75,16 +78,16 @@ describe('renderer: transformHArgs', () => {
     beforeAll(() => {
       transformHArgs(() => ['h1', 'Hello World'])
     })
+ 
     afterAll(resetTransformHArgs)
+ 
     test('nodes become an h1 with text inside', () => {
       expect(h('div')).toMatchObject(createVNode('h1', null, 'Hello World'))
     })
 
     test('resetting transformHArgs turns things back to normal', () => {
       expect(h('div')).toMatchObject(createVNode('h1', null, 'Hello World'))
-
       resetTransformHArgs()
-
       expect(h('div')).toMatchObject(createVNode('div'))
     })
   })
@@ -95,7 +98,8 @@ describe('renderer: transformHArgs', () => {
     })
 
     const vm = createApp({
-      name: 'Root Component', // this will be the name of the component in the h1
+      // this will be the name of the component in the h1
+      name: 'Root Component',
       render() {
         return h({
           // this code will never execute,
@@ -107,7 +111,8 @@ describe('renderer: transformHArgs', () => {
       }
     })
 
-    // we need to mount everything so that the instance passed to transformHArgs isn't null
+    // we need to mount everything so that the instance passed to
+    // transformHArgs isn't null
     vm.mount('body')
 
     expect(document.body.outerHTML).toContain('<h1>Root Component</h1>')


### PR DESCRIPTION
### Context
In Vue Test Utils (VTU) we provide two core features: “Shallow Mount” and “Stubs”. 

Both `shallowMount` and `stubs` enable the user to short circuit rendering a component tree. You can opt into this feature on any mount command (using stubs) or `shallowMount` command (stubs everything).

This PR adds the necessary functions to enable Vue Test Utils to implement shallowMount and stubs for Vue 3.

### Implementation Details
**Existing shallowMount functionality in VTU w/ Vue 2**
`shallowMount` is implemented by overwriting `$createElement` in a `beforeCreate` hook and conditionally choosing to apply the real `$createElement`. In VTU we are able to support shallowMounting parent components that use the `h` function directly.

**Implementing shallowMount in Vue 3**
Identical implementation using `beforeCreate` hook is not possible because `h` is not modifiable for a parent component instance like it was in Vue 2.

### Proposed API
Conditionally overload `h`’s functionality when its parent context wants to stub the component. Do this by using a transformer function to mutate the arguments passed into `h`.

1. This function is called `transformHArgs` and it returns an array of arguments to be applied to all `h` functions.
2. Add the ability to reset `transformHArgs` with a reset function.

**Example Usage**
Statically override all calls to `h` to return an `h1` tag (this isn't useful, but it demonstrates the API)

```js
import { transformHArgs, h } from '@vue/runtime-core/src/h'
transformHArgs(() => ['h1', 'Hello World'])
h('div', 'Hello') // renders a vnode equivalent to <h1>Hello World</h1>
```

Conditionally modify what is rendered
```js
import { transformHArgs, h } from '@vue/runtime-core/src/h'
transformHArgs((hArgs, instance) => {
    // if the component is in the "stubs" list for Vue Test Utils
    //     return [`stub-${instance.type.name}`]
    // return hArgs // Passthrough to the real h function
})

h({ name: 'my-component' , template: '<span/>' }) // renders <stub-my-component/> if it is found in the "stubbed list"
```

**Questions**
* Should this API be exported from `@vue/runtime-core`?
* Thoughts on how to avoid querying document.body in the test for the ComponentInternalInstance? Do we have an element reference available on the `vm` still?