### PR TITLE
fix(TransitionGroup): ignore comment node when warn (fix#869)

### DIFF
--- a/packages/runtime-dom/src/components/TransitionGroup.ts
+++ b/packages/runtime-dom/src/components/TransitionGroup.ts
@@ -9,6 +9,7 @@ import {
 } from './Transition'
 import {
   Fragment,
+  Comment,
   VNode,
   warn,
   resolveTransitionHooks,
@@ -108,7 +109,7 @@ const TransitionGroupImpl = {
             child,
             resolveTransitionHooks(child, cssTransitionProps, state, instance)
           )
-        } else if (__DEV__) {
+        } else if (__DEV__ && child.type !== Comment) {
           warn(`<TransitionGroup> children must be keyed.`)
         }
       }


### PR DESCRIPTION
fix #869 