### PR TITLE
fix: Check the node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
       "git add"
     ]
   },
+  "engines": { "node": ">=10.0.0" },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.3.9",
     "@rollup/plugin-commonjs": "^11.0.2",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,9 @@
       "git add"
     ]
   },
-  "engines": { "node": ">=10.0.0" },
+  "engines": {
+    "node": ">=10.0.0"
+  },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.3.9",
     "@rollup/plugin-commonjs": "^11.0.2",


### PR DESCRIPTION
fix: #827 
When using yarn to install dependencies, the node version that does not match the requirements will be interrupt.
![Snipaste_2020-03-25_16-28-59](https://user-images.githubusercontent.com/41336612/77516711-d337b200-6eb5-11ea-98c2-6571eff62554.png)
