### PR TITLE
fix(types): export missing types from runtime-core

### DIFF
--- a/.ls-lint.yml
+++ b/.ls-lint.yml
@@ -1,5 +1,5 @@
 ls:
-  packages/**/{src,__tests__}:
+  packages/*/{src,__tests__}:
     .js: kebab-case
     .ts: camelCase | PascalCase
     .d.ts: camelCase

--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -189,6 +189,8 @@ export {
 export { ComponentPublicInstance } from './componentProxy'
 export {
   Renderer,
+  RendererNode,
+  RendererElement,
   HydrationRenderer,
   RendererOptions,
   RootRenderFunction


### PR DESCRIPTION
These types were not being exported but they are necessary for applications to bundle: https://circleci.com/gh/vuejs/vue-router-next/531

There are more types that are marked as _forgotten export_ by API Extractor but I changed only those

I also change ls-lint because it was checking files inside `dist` folders