### PR TITLE
fix(inject): allow default value to be `undefined`

### DIFF
--- a/packages/runtime-core/__tests__/apiInject.spec.ts
+++ b/packages/runtime-core/__tests__/apiInject.spec.ts
@@ -284,4 +284,27 @@ describe('api: provide/inject', () => {
     expect(serialize(root)).toBe(`<div><!----></div>`)
     expect(`injection "foo" not found.`).toHaveBeenWarned()
   })
+
+  it('should not warn when default value is undefined', () => {
+    const Provider = {
+      setup() {
+        return () => h(Middle)
+      }
+    }
+
+    const Middle = {
+      render: () => h(Consumer)
+    }
+
+    const Consumer = {
+      setup() {
+        const foo = inject('foo', undefined)
+        return () => foo
+      }
+    }
+
+    const root = nodeOps.createElement('div')
+    render(h(Provider), root)
+    expect(`injection "foo" not found.`).not.toHaveBeenWarned()
+  })
 })

--- a/packages/runtime-core/src/apiInject.ts
+++ b/packages/runtime-core/src/apiInject.ts
@@ -40,7 +40,7 @@ export function inject(
     if (key in provides) {
       // TS doesn't allow symbol as index type
       return provides[key as string]
-    } else if (defaultValue !== undefined) {
+    } else if (arguments.length > 1) {
       return defaultValue
     } else if (__DEV__) {
       warn(`injection "${String(key)}" not found.`)


### PR DESCRIPTION
Check the arguments length instead of the argument being `undefined` to issue the warning

Close #892