### PR TITLE
fix(types): export missing type from compiler-core

### DIFF
--- a/packages/compiler-core/src/index.ts
+++ b/packages/compiler-core/src/index.ts
@@ -48,6 +48,6 @@ export {
   trackVForSlotScopes,
   trackSlotScopes
 } from './transforms/vSlot'
-export { resolveComponentType, buildProps } from './transforms/transformElement'
+export { transformElement, resolveComponentType, buildProps } from './transforms/transformElement'
 export { processSlotOutlet } from './transforms/transformSlotOutlet'
 export { generateCodeFrame } from '@vue/shared'


### PR DESCRIPTION
`transformElement` is not currently exported, but it's required for our custom renderer's tests similar to what's used in `compiler-dom` transform tests:
https://github.com/vuejs/vue-next/blob/b7b0d16b1cc076a80ab51388f8f861d14e6fe8a0/packages/compiler-dom/__tests__/transforms/transformStyle.spec.ts#L10

If it makes sense, I can update [all the imports](https://github.com/vuejs/vue-next/search?p=3&q=transformElement&unscoped_q=transformElement) to use the new export.