### PR TITLE
fix(compiler-sfc): always use offset for template block sourcemaps

### DIFF
--- a/packages/compiler-sfc/src/parse.ts
+++ b/packages/compiler-sfc/src/parse.ts
@@ -147,7 +147,7 @@ export function parse(
           source,
           block.content,
           sourceRoot,
-          pad ? 0 : block.loc.start.line - 1
+          !pad || block.type === 'template' ? block.loc.start.line - 1 : 0
         )
       }
     }


### PR DESCRIPTION
Template blocks are never padded hence they need offset for generating correct source map.