### PR TITLE
refactor(runtime-core): remove unnecessary tracing check

### DIFF
--- a/packages/runtime-core/src/component.ts
+++ b/packages/runtime-core/src/component.ts
@@ -452,7 +452,7 @@ function finishComponentSetup(
       Component.render = compile(Component.template, {
         isCustomElement: instance.appContext.config.isCustomElement || NO
       })
-      if (__DEV__ && instance.appContext.config.performance) {
+      if (__DEV__) {
         endMeasure(instance, `compile`)
       }
       // mark the function as runtime compiled


### PR DESCRIPTION
The check for `config.performance` is already done inside `endMeasure` and is not done anywhere else `endMeasure` is called.