### PR TITLE
types(runtime-core): Adds type signature for renderList helper

### DIFF
--- a/packages/runtime-core/src/helpers/renderList.ts
+++ b/packages/runtime-core/src/helpers/renderList.ts
@@ -1,13 +1,44 @@
 import { VNodeChild } from '../vnode'
 import { isArray, isString, isObject } from '@vue/shared'
 
+// v-for string
 export function renderList(
-  source: unknown,
-  renderItem: (
-    value: unknown,
-    key: string | number,
-    index?: number
+  source: string,
+  renderItem: (value: string, index: number) => VNodeChild
+): VNodeChild[]
+
+// v-for number
+export function renderList(
+  source: number,
+  renderItem: (value: number, index: number) => VNodeChild
+): VNodeChild[]
+
+// v-for array
+export function renderList<T>(
+  source: T[],
+  renderItem: (value: T, index: number) => VNodeChild
+): VNodeChild[]
+
+// v-for iterable
+export function renderList<T>(
+  source: Iterable<T>,
+  renderItem: (value: T, index: number) => VNodeChild
+): VNodeChild[]
+
+// v-for object
+export function renderList<T>(
+  source: T,
+  renderItem: <K extends keyof T>(
+    value: T[K],
+    key: K,
+    index: number
   ) => VNodeChild
+): VNodeChild[]
+
+// actual implementation
+export function renderList(
+  source: any,
+  renderItem: (...args: any[]) => VNodeChild
 ): VNodeChild[] {
   let ret: VNodeChild[]
   if (isArray(source) || isString(source)) {


### PR DESCRIPTION
Similar to `h()`, `renderList()` would be used to provide type check and completion in IDE toolings. For proper type inference, correct types for `renderList()` are required.
