### PR TITLE
chore: add @types/node as an explicit dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@rollup/plugin-node-resolve": "^7.1.1",
     "@rollup/plugin-replace": "^2.2.1",
     "@types/jest": "^25.1.4",
+    "@types/node": "12.12.35",
     "@types/puppeteer": "^2.0.0",
     "brotli": "^1.3.2",
     "chalk": "^2.4.2",

--- a/packages/compiler-sfc/src/templateTransformAssetUrl.ts
+++ b/packages/compiler-sfc/src/templateTransformAssetUrl.ts
@@ -69,8 +69,8 @@ export const transformAssetUrl: NodeTransform = (
 }
 
 function getImportsExpressionExp(
-  path: string | undefined,
-  hash: string | undefined,
+  path: string | null,
+  hash: string | null,
   loc: SourceLocation,
   context: TransformContext
 ): ExpressionNode {

--- a/packages/template-explorer/src/index.ts
+++ b/packages/template-explorer/src/index.ts
@@ -97,7 +97,7 @@ window.init = () => {
     }
   }
 
-  const sharedEditorOptions: m.editor.IEditorConstructionOptions = {
+  const sharedEditorOptions: m.editor.IStandaloneEditorConstructionOptions = {
     theme: 'vs-dark',
     fontSize: 14,
     wordWrap: 'on',

--- a/yarn.lock
+++ b/yarn.lock
@@ -843,6 +843,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.13.tgz#ccebcdb990bd6139cd16e84c39dc2fb1023ca90c"
   integrity sha512-pMCcqU2zT4TjqYFrWtYHKal7Sl30Ims6ulZ4UFXxI4xbtQqK/qqKwkDoBFCfooRqqmRu9vY3xaJRwxSh673aYg==
 
+"@types/node@12.12.35":
+  version "12.12.35"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.12.35.tgz#1e61b226c14380f4384f70cfe49a65c2c553ad2b"
+  integrity sha512-ASYsaKecA7TUsDrqIGPNk3JeEox0z/0XR/WsJJ8BIX/9+SkMSImQXKWfU/yBrSyc7ZSE/NPqLu36Nur0miCFfQ==
+
 "@types/prettier@^1.19.0":
   version "1.19.1"
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-1.19.1.tgz#33509849f8e679e4add158959fdb086440e9553f"


### PR DESCRIPTION
As `tsconfig.json` references it, it should be listed in the dependencies.
It currently uses an older version: this commit also bumps to the latest v12 version, and fixes a typing issue (and an unrelated one in template-explorer).