### PR TITLE
fix(reactivity): remove Symbol.observable

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@rollup/plugin-node-resolve": "^7.1.1",
     "@rollup/plugin-replace": "^2.2.1",
     "@types/jest": "^25.1.4",
+    "@types/node": "12.12.35",
     "@types/puppeteer": "^2.0.0",
     "brotli": "^1.3.2",
     "chalk": "^2.4.2",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@rollup/plugin-node-resolve": "^7.1.1",
     "@rollup/plugin-replace": "^2.2.1",
     "@types/jest": "^25.1.4",
-    "@types/node": "12.12.35",
+    "@types/node": "13.11.1",
     "@types/puppeteer": "^2.0.0",
     "brotli": "^1.3.2",
     "chalk": "^2.4.2",

--- a/packages/compiler-sfc/src/templateTransformAssetUrl.ts
+++ b/packages/compiler-sfc/src/templateTransformAssetUrl.ts
@@ -69,8 +69,8 @@ export const transformAssetUrl: NodeTransform = (
 }
 
 function getImportsExpressionExp(
-  path: string | undefined,
-  hash: string | undefined,
+  path: string | null,
+  hash: string | null,
   loc: SourceLocation,
   context: TransformContext
 ): ExpressionNode {

--- a/packages/reactivity/src/ref.ts
+++ b/packages/reactivity/src/ref.ts
@@ -151,9 +151,6 @@ type SymbolExtract<T> = (T extends { [Symbol.asyncIterator]: infer V }
   (T extends { [Symbol.iterator]: infer V } ? { [Symbol.iterator]: V } : {}) &
   (T extends { [Symbol.match]: infer V } ? { [Symbol.match]: V } : {}) &
   (T extends { [Symbol.matchAll]: infer V } ? { [Symbol.matchAll]: V } : {}) &
-  (T extends { [Symbol.observable]: infer V }
-    ? { [Symbol.observable]: V }
-    : {}) &
   (T extends { [Symbol.replace]: infer V } ? { [Symbol.replace]: V } : {}) &
   (T extends { [Symbol.search]: infer V } ? { [Symbol.search]: V } : {}) &
   (T extends { [Symbol.species]: infer V } ? { [Symbol.species]: V } : {}) &

--- a/packages/template-explorer/src/index.ts
+++ b/packages/template-explorer/src/index.ts
@@ -97,7 +97,7 @@ window.init = () => {
     }
   }
 
-  const sharedEditorOptions: m.editor.IEditorConstructionOptions = {
+  const sharedEditorOptions: m.editor.IStandaloneEditorConstructionOptions = {
     theme: 'vs-dark',
     fontSize: 14,
     wordWrap: 'on',

--- a/yarn.lock
+++ b/yarn.lock
@@ -843,6 +843,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.13.tgz#ccebcdb990bd6139cd16e84c39dc2fb1023ca90c"
   integrity sha512-pMCcqU2zT4TjqYFrWtYHKal7Sl30Ims6ulZ4UFXxI4xbtQqK/qqKwkDoBFCfooRqqmRu9vY3xaJRwxSh673aYg==
 
+"@types/node@12.12.35":
+  version "12.12.35"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.12.35.tgz#1e61b226c14380f4384f70cfe49a65c2c553ad2b"
+  integrity sha512-ASYsaKecA7TUsDrqIGPNk3JeEox0z/0XR/WsJJ8BIX/9+SkMSImQXKWfU/yBrSyc7ZSE/NPqLu36Nur0miCFfQ==
+
 "@types/prettier@^1.19.0":
   version "1.19.1"
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-1.19.1.tgz#33509849f8e679e4add158959fdb086440e9553f"

--- a/yarn.lock
+++ b/yarn.lock
@@ -843,10 +843,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.13.tgz#ccebcdb990bd6139cd16e84c39dc2fb1023ca90c"
   integrity sha512-pMCcqU2zT4TjqYFrWtYHKal7Sl30Ims6ulZ4UFXxI4xbtQqK/qqKwkDoBFCfooRqqmRu9vY3xaJRwxSh673aYg==
 
-"@types/node@12.12.35":
-  version "12.12.35"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.12.35.tgz#1e61b226c14380f4384f70cfe49a65c2c553ad2b"
-  integrity sha512-ASYsaKecA7TUsDrqIGPNk3JeEox0z/0XR/WsJJ8BIX/9+SkMSImQXKWfU/yBrSyc7ZSE/NPqLu36Nur0miCFfQ==
+"@types/node@13.11.1":
+  version "13.11.1"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-13.11.1.tgz#49a2a83df9d26daacead30d0ccc8762b128d53c7"
+  integrity sha512-eWQGP3qtxwL8FGneRrC5DwrJLGN4/dH1clNTuLfN81HCrxVtxRjygDTUoZJ5ASlDEeo0ppYFQjQIlXhtXpOn6g==
 
 "@types/prettier@^1.19.0":
   version "1.19.1"


### PR DESCRIPTION
`Symbol.observable` is brought by `@types/node@12` and is not a "well-known" typescript symbol https://www.typescriptlang.org/docs/handbook/symbols.html that can be find in lib.es20xx like the others. It has been removed in `@types/node@v13`.
It means that an application using vue@3.0.0-alpha.13 does not compile unless it explicitely adds `@types/node@v12` as a dependency and `node` in its own tsconfig types.
Otherwise here is the compilation error:

```
ERROR in /Users/ced-pro/Code/ninjasquad/.../node_modules/@vue/reactivity/dist/reactivity.d.ts(134,13):
134:13 Property 'observable' does not exist on type 'SymbolConstructor'.
    132 |     [Symbol.observable]: infer V;
    133 | } ? {
  > 134 |     [Symbol.observable]: V;
        |             ^
    135 | } : {}) & (T extends {
    136 |     [Symbol.replace]: infer V;
    137 | } ? {
```
On top of #967 

The bump to `@types/node@v13` can be removed if you want: it's mainly here to reproduce the issue.