### PR TITLE
test(reactivity): add tests for object with symbols

### DIFF
--- a/packages/reactivity/__tests__/ref.spec.ts
+++ b/packages/reactivity/__tests__/ref.spec.ts
@@ -139,6 +139,21 @@ describe('reactivity/ref', () => {
     expect(tupleRef.value[4].value).toBe(1)
   })
 
+  it('should keep symbols', () => {
+    const customSymbol = Symbol()
+    const obj = {
+      [Symbol.asyncIterator]: { a: 1 },
+      [Symbol.unscopables]: { b: '1' },
+      [customSymbol]: { c: [1, 2, 3] }
+    }
+
+    const objRef = ref(obj)
+
+    expect(objRef.value[Symbol.asyncIterator]).toBe(obj[Symbol.asyncIterator])
+    expect(objRef.value[Symbol.unscopables]).toBe(obj[Symbol.unscopables])
+    expect(objRef.value[customSymbol]).toStrictEqual(obj[customSymbol])
+  })
+
   test('unref', () => {
     expect(unref(1)).toBe(1)
     expect(unref(ref(1))).toBe(1)

--- a/test-dts/ref.test-d.ts
+++ b/test-dts/ref.test-d.ts
@@ -57,3 +57,20 @@ function bailType(arg: HTMLElement | Ref<HTMLElement>) {
 }
 const el = document.createElement('DIV')
 bailType(el)
+
+function withSymbol() {
+  const customSymbol = Symbol()
+  const obj = {
+    [Symbol.asyncIterator]: { a: 1 },
+    [Symbol.unscopables]: { b: '1' },
+    [customSymbol]: { c: [1, 2, 3] }
+  }
+
+  const objRef = ref(obj)
+
+  expectType<{ a: number }>(objRef.value[Symbol.asyncIterator])
+  expectType<{ b: string }>(objRef.value[Symbol.unscopables])
+  expectType<{ c: Array<number> }>(objRef.value[customSymbol])
+}
+
+withSymbol()


### PR DESCRIPTION
This add tests for symbols and dts tests.

This is a follow up to the https://github.com/vuejs/vue-next/pull/579

Question, when using a custom symbol it seems you can't do `toBe`
```ts
 expect(objRef.value[customSymbol]).toBe(obj[customSymbol]) // fails
 expect(objRef.value[customSymbol]).toStrictEqual(obj[customSymbol])
```

Do we change the object to reactive for symbol properties?