### PR TITLE
Mark VTU as alpha

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ In addition, the current implementation requires native ES2015+ in the runtime e
 | vue-class-component | Alpha [[Github][vcc-code]] [[npm][vcc-npm]] |
 | vue-cli             | Experimental support via [vue-cli-plugin-vue-next][cli] |
 | eslint-plugin-vue   | Alpha [[Github][epv-code]] [[npm][epv-npm]] |
-| vue-test-utils      | Pre-alpha [[Github][vtu-code]] [[npm][vtu-npm]] |
+| vue-test-utils      | Alpha [[Github][vtu-code]] [[npm][vtu-npm]] |
 | vue-devtools        | WIP |
 | jsx                 | WIP |
 


### PR DESCRIPTION
Hi! 

We actually release the first public alpha for Vue Test Utils: 

https://www.npmjs.com/package/@vue/test-utils/v/2.0.0-alpha.1
https://github.com/vuejs/vue-test-utils-next/releases/tag/2.0.0-alpha.1

stay safe! 👋 