### PR TITLE
chore: expose ExtractPropTypes

### DIFF
--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -207,7 +207,8 @@ export {
   Prop,
   PropType,
   ComponentPropsOptions,
-  ComponentObjectPropsOptions
+  ComponentObjectPropsOptions,
+  ExtractPropTypes
 } from './componentProps'
 export {
   Directive,


### PR DESCRIPTION
In an attempt to add some typesafety to `@vue/test-utils` I ended up with a PR that can check that `mount(defineComponent({ props: { a: string } }), { props: { a: 2 } })` does not compile.

To achieve the same without `defineComponent`, it looks like we'll need `ExtractPropTypes` to be public. See https://github.com/vuejs/vue-test-utils-next/pull/74 for more context.

Would it be possible?