### PR TITLE
fix(watch): allow to pass {deep: true} on ref primitives

### DIFF
--- a/packages/runtime-core/__tests__/apiWatch.spec.ts
+++ b/packages/runtime-core/__tests__/apiWatch.spec.ts
@@ -69,17 +69,6 @@ describe('api: watch', () => {
     expect(dummy).toMatchObject([1, 0])
   })
 
-  it('watching single source: ref<string>', async () => {
-    const msg = ref<string>()
-    let dummy
-    watch(msg, (current, prevMessage) => {
-      dummy = [current, prevMessage]
-    })
-    msg.value = 'hello'
-    await nextTick()
-    expect(dummy).toMatchObject(['hello', undefined])
-  })
-
   it('watching single source: computed ref', async () => {
     const count = ref(0)
     const plus = computed(() => count.value + 1)

--- a/packages/runtime-core/__tests__/apiWatch.spec.ts
+++ b/packages/runtime-core/__tests__/apiWatch.spec.ts
@@ -69,6 +69,17 @@ describe('api: watch', () => {
     expect(dummy).toMatchObject([1, 0])
   })
 
+  it('watching single source: ref<string>', async () => {
+    const msg = ref<string>()
+    let dummy
+    watch(msg, (current, prevMessage) => {
+      dummy = [current, prevMessage]
+    })
+    msg.value = 'hello'
+    await nextTick()
+    expect(dummy).toMatchObject(['hello', undefined])
+  })
+
   it('watching single source: computed ref', async () => {
     const count = ref(0)
     const plus = computed(() => count.value + 1)
@@ -84,6 +95,23 @@ describe('api: watch', () => {
     count.value++
     await nextTick()
     expect(dummy).toMatchObject([2, 1])
+  })
+
+  it('watching primitive with deep: true', async () => {
+    const count = ref(0)
+    let dummy
+    watch(
+      count,
+      (c, prevCount) => {
+        dummy = [c, prevCount]
+      },
+      {
+        deep: true
+      }
+    )
+    count.value++
+    await nextTick()
+    expect(dummy).toMatchObject([1, 0])
   })
 
   it('watching multiple sources', async () => {

--- a/packages/runtime-core/src/apiWatch.ts
+++ b/packages/runtime-core/src/apiWatch.ts
@@ -285,11 +285,8 @@ export function instanceWatch(
 }
 
 function traverse(value: unknown, seen: Set<unknown> = new Set()) {
-  if (!isObject(value)) {
-    if (seen.size === 0) {
-      return value
-    }
-    return
+  if (!isObject(value) || seen.has(value)) {
+    return value
   }
   if (seen.has(value)) {
     return

--- a/packages/runtime-core/src/apiWatch.ts
+++ b/packages/runtime-core/src/apiWatch.ts
@@ -285,7 +285,13 @@ export function instanceWatch(
 }
 
 function traverse(value: unknown, seen: Set<unknown> = new Set()) {
-  if (!isObject(value) || seen.has(value)) {
+  if (!isObject(value)) {
+    if (seen.size === 0) {
+      return value
+    }
+    return
+  }
+  if (seen.has(value)) {
     return
   }
   seen.add(value)


### PR DESCRIPTION
if you pass `{deep:true}` and you are watching a primitive ref it will always be `undefined`

```ts
    const count = ref(0)
    let dummy
    watch(
      count,
      (c, prevCount) => {
        dummy = [c, prevCount]
      },
      {
        deep: true
      }
    )
```