### PR TITLE
feat(runtime-core): expose exception if app.errorHandler throws exception

### DIFF
--- a/packages/runtime-core/src/errorHandling.ts
+++ b/packages/runtime-core/src/errorHandling.ts
@@ -68,7 +68,12 @@ export function callWithErrorHandling(
   try {
     res = args ? fn(...args) : fn()
   } catch (err) {
-    handleError(err, instance, type)
+    // if the error handler throws error, rethrow it
+    if (type === ErrorCodes.APP_ERROR_HANDLER) {
+      throw err
+    } else {
+      handleError(err, instance, type)
+    }
   }
   return res
 }

--- a/packages/runtime-core/src/errorHandling.ts
+++ b/packages/runtime-core/src/errorHandling.ts
@@ -69,7 +69,10 @@ export function callWithErrorHandling(
     res = args ? fn(...args) : fn()
   } catch (err) {
     // if the error handler throws error, rethrow it
-    if (type === ErrorCodes.APP_ERROR_HANDLER) {
+    if (
+      type === ErrorCodes.APP_ERROR_HANDLER ||
+      type === ErrorCodes.APP_WARN_HANDLER
+    ) {
       throw err
     } else {
       handleError(err, instance, type)


### PR DESCRIPTION
## Problem

If any of `app.context.errorHandler` or `app.context.warnHandler` throws an exception it will call it self over and over.

This behaviour is problematic specially when doing asserts in the setup, making the test to pass and the error to be obfuscated.

```ts
// not currently failing
// failing after this PR
  it("fail", () => {
    createVue({
      setup() {
        expect(1).toBe(2);
      },
    }).mount();
  });



export const createVue = (component: Component, props?: any) => {
  const app = createApp(component, props);

  const el = document.createElement("div");

  const mount = () => app.mount(el);

  const destroy = () => app.unmount(el);

  app.config.errorHandler = (err: any) => {
    throw err;
  };

  return {
    el,
    mount,
    destroy
  };
};
```
https://github.com/pikax/vue-composable/blob/vue3/packages/web/__tests__/utils.ts#L5-L23


jest log of the build, the file `broadcastChannel.spec.ts` should have tests failing, but they are passing and just logging error.

> NOTE: `[Vue warn]: Unhandled error during execution of app errorHandler 
        at <Anonymous> (Root)` is caused by the errorHandler exception

```log
PASS  packages/web/__tests__/web/broadcastChannel.spec.ts
  ● Console

    console.warn node_modules/@vue/runtime-core/dist/runtime-core.cjs.js:39
      [Vue warn]: Unhandled error during execution of app errorHandler 
        at <Anonymous> (Root)
    console.error node_modules/@vue/runtime-core/dist/runtime-core.cjs.js:212
      JestAssertionError: expect(received).toBe(expected) // Object.is equality
      
      If it should pass with deep equality, replace "toBe" with "toStrictEqual"
      
      Expected: {"test": 1}
      Received: serializes to the same string
          at setup (/root/repo/packages/web/__tests__/web/broadcastChannel.spec.ts:109:28)
          at callWithErrorHandling (/root/repo/node_modules/@vue/runtime-core/dist/runtime-core.cjs.js:153:22)
          at setupStatefulComponent (/root/repo/node_modules/@vue/runtime-core/dist/runtime-core.cjs.js:4818:29)
          at setupComponent (/root/repo/node_modules/@vue/runtime-core/dist/runtime-core.cjs.js:4780:11)
          at mountComponent (/root/repo/node_modules/@vue/runtime-core/dist/runtime-core.cjs.js:2686:9)
          at processComponent (/root/repo/node_modules/@vue/runtime-core/dist/runtime-core.cjs.js:2665:17)
          at patch (/root/repo/node_modules/@vue/runtime-core/dist/runtime-core.cjs.js:2382:21)
          at render (/root/repo/node_modules/@vue/runtime-core/dist/runtime-core.cjs.js:3379:13)
          at mount (/root/repo/node_modules/@vue/runtime-core/dist/runtime-core.cjs.js:1989:25)
          at Object.app.mount (/root/repo/node_modules/@vue/runtime-dom/dist/runtime-dom.cjs.js:1550:23)
          at Object.mount (/root/repo/packages/web/__tests__/utils.ts:10:27)
          at Object.<anonymous> (/root/repo/packages/web/__tests__/web/broadcastChannel.spec.ts:112:8)
          at Object.asyncJestTest (/root/repo/node_modules/jest-jasmine2/build/jasmineAsyncInstall.js:100:37)
          at /root/repo/node_modules/jest-jasmine2/build/queueRunner.js:45:12
          at new Promise (<anonymous>)
          at mapper (/root/repo/node_modules/jest-jasmine2/build/queueRunner.js:28:19)
          at /root/repo/node_modules/jest-jasmine2/build/queueRunner.js:75:41 {
        matcherResult: {
          actual: { test: 1 },
          expected: { test: 1 },
          message: [Function],
          name: 'toBe',
          pass: false
        }
      }
    console.warn node_modules/@vue/runtime-core/dist/runtime-core.cjs.js:39
      [Vue warn]: Unhandled error during execution of app errorHandler 
        at <Anonymous> (Root)
    console.error node_modules/@vue/runtime-core/dist/runtime-core.cjs.js:212
      JestAssertionError: expect(received).toBe(expected) // Object.is equality
      
      If it should pass with deep equality, replace "toBe" with "toStrictEqual"
      
      Expected: {"test": 1}
      Received: serializes to the same string
          at setup (/root/repo/packages/web/__tests__/web/broadcastChannel.spec.ts:130:34)
          at callWithErrorHandling (/root/repo/node_modules/@vue/runtime-core/dist/runtime-core.cjs.js:153:22)
          at setupStatefulComponent (/root/repo/node_modules/@vue/runtime-core/dist/runtime-core.cjs.js:4818:29)
          at setupComponent (/root/repo/node_modules/@vue/runtime-core/dist/runtime-core.cjs.js:4780:11)
          at mountComponent (/root/repo/node_modules/@vue/runtime-core/dist/runtime-core.cjs.js:2686:9)
          at processComponent (/root/repo/node_modules/@vue/runtime-core/dist/runtime-core.cjs.js:2665:17)
          at patch (/root/repo/node_modules/@vue/runtime-core/dist/runtime-core.cjs.js:2382:21)
          at render (/root/repo/node_modules/@vue/runtime-core/dist/runtime-core.cjs.js:3379:13)
          at mount (/root/repo/node_modules/@vue/runtime-core/dist/runtime-core.cjs.js:1989:25)
          at Object.app.mount (/root/repo/node_modules/@vue/runtime-dom/dist/runtime-dom.cjs.js:1550:23)
          at Object.mount (/root/repo/packages/web/__tests__/utils.ts:10:27)
          at Object.<anonymous> (/root/repo/packages/web/__tests__/web/broadcastChannel.spec.ts:136:8)
          at Object.asyncJestTest (/root/repo/node_modules/jest-jasmine2/build/jasmineAsyncInstall.js:100:37)
          at /root/repo/node_modules/jest-jasmine2/build/queueRunner.js:45:12
          at new Promise (<anonymous>)
          at mapper (/root/repo/node_modules/jest-jasmine2/build/queueRunner.js:28:19)
          at /root/repo/node_modules/jest-jasmine2/build/queueRunner.js:75:41 {
        matcherResult: {
          actual: { test: 1 },
          expected: { test: 1 },
          message: [Function],
          name: 'toBe',
          pass: false
        }
      }

```