### PR TITLE
perf(core): use startsWith instead of indexOf 0

### DIFF
--- a/packages/runtime-core/src/componentEmits.ts
+++ b/packages/runtime-core/src/componentEmits.ts
@@ -73,7 +73,7 @@ export function emit(
   let handler = props[`on${capitalize(event)}`]
   // for v-model update:xxx events, also trigger kebab-case equivalent
   // for props passed via kebab-case
-  if (!handler && event.indexOf('update:') === 0) {
+  if (!handler && event.startsWith('update:')) {
     event = hyphenate(event)
     handler = props[`on${capitalize(event)}`]
   }

--- a/packages/runtime-dom/src/modules/attrs.ts
+++ b/packages/runtime-dom/src/modules/attrs.ts
@@ -8,7 +8,7 @@ export function patchAttr(
   value: any,
   isSVG: boolean
 ) {
-  if (isSVG && key.indexOf('xlink:') === 0) {
+  if (isSVG && key.startsWith('xlink:')) {
     if (value == null) {
       el.removeAttributeNS(xlinkNS, key.slice(6, key.length))
     } else {

--- a/packages/runtime-dom/src/patchProp.ts
+++ b/packages/runtime-dom/src/patchProp.ts
@@ -30,7 +30,7 @@ export const patchProp: RendererOptions<Node, Element>['patchProp'] = (
     default:
       if (isOn(key)) {
         // ignore v-model listeners
-        if (key.indexOf('onUpdate:') < 0) {
+        if (!key.startsWith('onUpdate:')) {
           patchEvent(el, key, prevValue, nextValue, parentComponent)
         }
       } else if (

--- a/packages/shared/src/normalizeProp.ts
+++ b/packages/shared/src/normalizeProp.ts
@@ -29,7 +29,7 @@ export function stringifyStyle(
   }
   for (const key in styles) {
     const value = styles[key]
-    const normalizedKey = key.indexOf(`--`) === 0 ? key : hyphenate(key)
+    const normalizedKey = key.startsWith(`--`) ? key : hyphenate(key)
     if (
       isString(value) ||
       (typeof value === 'number' && isNoUnitNumericStyleProp(normalizedKey))


### PR DESCRIPTION
In a few places, `someString.indexOf(somePrefix) === 0` is used to check if a string starts with some prefix. Using `startsWith` instead should enable the check to short-circuit in the negative case (indexOf will scan the whole string in the negative case); it also has clearer intent. In one case, checking if something was a v-model listener, the logic was checking existence of a string, but it should always be a prefix, so startsWith seems to make more sense.