### PR TITLE
fix(compiler-core): should only skip `v-is` on <component>, don't inc…

### DIFF
--- a/packages/compiler-core/__tests__/transforms/transformElement.spec.ts
+++ b/packages/compiler-core/__tests__/transforms/transformElement.spec.ts
@@ -818,7 +818,9 @@ describe('compiler: element transform', () => {
               isStatic: true
             }
           ]
-        }
+        },
+        dynamicProps: undefined,
+        directives: undefined
       })
     })
 
@@ -835,7 +837,9 @@ describe('compiler: element transform', () => {
               isStatic: false
             }
           ]
-        }
+        },
+        dynamicProps: '["is"]',
+        directives: undefined
       })
     })
 
@@ -853,6 +857,7 @@ describe('compiler: element transform', () => {
             }
           ]
         },
+        dynamicProps: undefined,
         // should skip v-is runtime check
         directives: undefined
       })

--- a/packages/compiler-core/src/transforms/transformElement.ts
+++ b/packages/compiler-core/src/transforms/transformElement.ts
@@ -36,7 +36,6 @@ import {
   toValidAssetId,
   findProp,
   isCoreComponent,
-  isBindKey,
   findDir
 } from '../utils'
 import { buildSlots } from './vSlot'
@@ -346,11 +345,8 @@ export function buildProps(
       if (name === 'once') {
         continue
       }
-      // skip v-is and :is on <component>
-      if (
-        name === 'is' ||
-        (isBind && tag === 'component' && isBindKey(arg, 'is'))
-      ) {
+      // skip v-is on <component>
+      if (name === 'is') {
         continue
       }
       // skip v-on in SSR compilation

--- a/packages/compiler-ssr/__tests__/ssrComponent.spec.ts
+++ b/packages/compiler-ssr/__tests__/ssrComponent.spec.ts
@@ -34,7 +34,10 @@ describe('ssr: components', () => {
       const { ssrRenderComponent: _ssrRenderComponent } = require(\\"@vue/server-renderer\\")
 
       return function ssrRender(_ctx, _push, _parent) {
-        _push(_ssrRenderComponent(_resolveDynamicComponent(_ctx.foo), { prop: \\"b\\" }, null, _parent))
+        _push(_ssrRenderComponent(_resolveDynamicComponent(_ctx.foo), {
+          is: _ctx.foo,
+          prop: \\"b\\"
+        }, null, _parent))
       }"
     `)
   })


### PR DESCRIPTION
…lude `:is`

fix #1018