### PR TITLE
types: fix ref(false) type to Ref<boolean>

### DIFF
--- a/packages/reactivity/src/ref.ts
+++ b/packages/reactivity/src/ref.ts
@@ -28,7 +28,10 @@ export function isRef(r: any): r is Ref {
   return r ? r._isRef === true : false
 }
 
-export function ref<T>(value: T): T extends Ref ? T : Ref<UnwrapRef<T>>
+export function ref<T extends object>(
+  value: T
+): T extends Ref ? T : Ref<UnwrapRef<T>>
+export function ref<T>(value: T): Ref<UnwrapRef<T>>
 export function ref<T = any>(): Ref<T | undefined>
 export function ref(value?: unknown) {
   return createRef(value)

--- a/test-dts/ref.test-d.ts
+++ b/test-dts/ref.test-d.ts
@@ -21,6 +21,16 @@ function plainType(arg: number | Ref<number>) {
   expectType<Ref<{ foo: number }>>(nestedRef)
   expectType<{ foo: number }>(nestedRef.value)
 
+  // ref boolean
+  const falseRef = ref(false)
+  expectType<Ref<boolean>>(falseRef)
+  expectType<boolean>(falseRef.value)
+
+  // ref true
+  const trueRef = ref<true>(true)
+  expectType<Ref<true>>(trueRef)
+  expectType<true>(trueRef.value)
+
   // tuple
   expectType<[number, string]>(unref(ref([1, '1'])))
 


### PR DESCRIPTION
if you do `ref(false)` the type generated is `Ref<true>|Ref<false>`

This fixes that

```ts
const foo = ref(false);

if (!foo.value) {
  foo.value = true; // error here
}
```
