### PR TITLE
fix(runtime-core): eager property access cache issue (fix #1016)

### DIFF
--- a/packages/runtime-core/src/componentOptions.ts
+++ b/packages/runtime-core/src/componentOptions.ts
@@ -314,6 +314,10 @@ export function applyOptions(
     applyMixins(instance, mixins)
   }
 
+  // invalidate access cache in case mixins or extends
+  // accessed fields that are defined later
+  instance.accessCache = {}
+
   const checkDuplicateProperties = __DEV__ ? createDuplicateChecker() : null
 
   if (__DEV__ && propsOptions) {


### PR DESCRIPTION
Certain options like data, watch, and provide, run synchronously when applying options and may attempt to access fields that don't exist yet. Since the public instance proxy handler attempts to cache these accesses, the field may end up with the wrong code (data vs. setup, etc), and appear as if it does not exist to options that get applied later (we see this primarily with mixins, as in [#1016](https://github.com/vuejs/vue-next/issues/1016)). 

This PR fixes that issue by replacing the `instance.accessCache` object after applying mixins. It is possible to instead add keys to the cache as they are applied, but that would involve more code and could unnecessarily cache fields not needed during render. Adding additional logic in the proxy handler itself didn't seem wise, since it is a "hotspot."

I found another issue where a computed on a mixin that depends on data from a later mixin does not update after that data is added. To fix this, if the computed value is undefined, the computed is recreated.

I also noticed that inject was not available to the data option as it was in Vue 2, so I moved application of inject options up before data, but kept the dupe check after the other options.