### PR TITLE
types(reactivity): creating type for return toRefs and export return type

### DIFF
--- a/packages/reactivity/src/index.ts
+++ b/packages/reactivity/src/index.ts
@@ -8,7 +8,8 @@ export {
   customRef,
   triggerRef,
   Ref,
-  UnwrapRef
+  UnwrapRef,
+  ToRefs
 } from './ref'
 export {
   reactive,

--- a/packages/reactivity/src/ref.ts
+++ b/packages/reactivity/src/ref.ts
@@ -20,6 +20,8 @@ export interface Ref<T = any> {
   value: T
 }
 
+export type ToRefs<T = any> = { [K in keyof T]: Ref<T[K]> }
+
 const convert = <T extends unknown>(val: T): T =>
   isObject(val) ? reactive(val) : val
 
@@ -108,9 +110,7 @@ export function customRef<T>(factory: CustomRefFactory<T>): Ref<T> {
   return r as any
 }
 
-export function toRefs<T extends object>(
-  object: T
-): { [K in keyof T]: Ref<T[K]> } {
+export function toRefs<T extends object>(object: T): ToRefs<T> {
   if (__DEV__ && !isProxy(object)) {
     console.warn(`toRefs() expects a reactive object but received a plain one.`)
   }

--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -153,7 +153,8 @@ export {
   Ref,
   ComputedRef,
   UnwrapRef,
-  WritableComputedOptions
+  WritableComputedOptions,
+  ToRefs
 } from '@vue/reactivity'
 export {
   // types


### PR DESCRIPTION
expose return type for `toRefs`

Some Typescript users might have some trouble when using `reactive` and with `toRefs`

```ts
interface Foo {
  a: number,
  b: number
}

interface FooReturn {
  foo: ToRefs<Foo> // naming might be confusing, suggestions welcome
}

function useFoo(){
  const state = reactive({
    a: { a:1, b:2}
  })

  return {
     foo: toRefs(state.a)
  }
}
```
