### PR TITLE
types: export ComponentOptionsBase 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,5 +69,5 @@ workflows:
     jobs:
       - test
       - test-dts
-      - test-declarations
+      - test-declaration
       - check-size

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,6 +45,15 @@ jobs:
       - *save_cache
       - run: yarn test-dts
 
+  test-declaration:
+    <<: *defaults
+    steps:
+      - checkout
+      - *restore_cache
+      - *install_deps
+      - *save_cache
+      - run: yarn test-declaration
+
   check-size:
     <<: *defaults
     steps:
@@ -60,4 +69,5 @@ workflows:
     jobs:
       - test
       - test-dts
+      - test-declarations
       - check-size

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "ls-lint": "ls-lint",
     "test": "node scripts/build.js vue -f global -d && jest",
     "test-dts": "node scripts/build.js shared reactivity runtime-core runtime-dom -dt -f esm-bundler && tsd",
+    "test-declaration": "node scripts/build.js shared reactivity runtime-core runtime-dom -dt -f esm-bundler && tsc -p ./test-declarations/tsconfig.declaration.json",
     "release": "node scripts/release.js",
     "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s",
     "dev-compiler": "npm-run-all --parallel \"dev template-explorer\" serve",

--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -190,6 +190,7 @@ export {
 } from './component'
 export {
   ComponentOptions,
+  ComponentOptionsBase,
   ComponentOptionsWithoutProps,
   ComponentOptionsWithObjectProps,
   ComponentOptionsWithArrayProps,

--- a/test-declarations/defineComponent.declaration.ts
+++ b/test-declarations/defineComponent.declaration.ts
@@ -1,0 +1,26 @@
+import { defineComponent } from '@vue/runtime-dom'
+
+export const Comp = defineComponent({})
+
+export const FuncComp = defineComponent((props: { a: string }) => {})
+
+export const PropsComp = defineComponent({
+  props: {
+    a: String
+  },
+
+  setup(props, ctx) {
+    return {
+      pa: props.a
+    }
+  }
+})
+
+export const PropNamesComp = defineComponent({
+  props: ['a'],
+  setup(props, ctx) {
+    return {
+      pa: props.a
+    }
+  }
+})

--- a/test-declarations/tsconfig.declaration.json
+++ b/test-declarations/tsconfig.declaration.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "paths": {
+      "@vue/*": ["packages/*/dist"],
+      "vue": ["packages/vue/dist"]
+    }
+  },
+  "include": ["./"]
+}


### PR DESCRIPTION
Error, when trying to build types for `defineComponent`
```log
semantic error TS4023: Exported variable 'TestComponent' has or is using name 'ComponentOptionsBase' from external module "test-project/node_modules/@vue/runtime-core/dist/runtime-core" but cannot be named.
```
```ts
const TestComponent = defineComponent({
  name: "Test",
  render() {
    return h("a");
  },
});
```

This is cause because the defineComponent returning type uses `ComponentOptionsBase` and typescript cannot export that type correctly

Added new folder that we can populate with tests, it runs a simple tsc with a declaration option, and instead of getting the source files for the packages, it uses the built files from `@vue/*/dist` 

