### PR TITLE
perf(runtime-core): use `Array.prototype.fill()` instead of `for`

### DIFF
--- a/packages/runtime-core/src/renderer.ts
+++ b/packages/runtime-core/src/renderer.ts
@@ -1550,8 +1550,7 @@ function baseCreateRenderer(
       // and oldIndex = 0 is a special value indicating the new node has
       // no corresponding old node.
       // used for determining longest stable subsequence
-      const newIndexToOldIndexMap = new Array(toBePatched)
-      for (i = 0; i < toBePatched; i++) newIndexToOldIndexMap[i] = 0
+      const newIndexToOldIndexMap = new Array(toBePatched).fill(0)
 
       for (i = s1; i <= e1; i++) {
         const prevChild = c1[i]


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/3705199/80302199-26659300-87db-11ea-8344-8433d02a6f80.png)


online test link: [https://jsperf.com/forvsfill/1](https://jsperf.com/forvsfill/1)