### PR TITLE
fix(reactivity): allow setting property from a ref to another ref

### DIFF
--- a/packages/reactivity/__tests__/reactive.spec.ts
+++ b/packages/reactivity/__tests__/reactive.spec.ts
@@ -115,6 +115,21 @@ describe('reactivity/reactive', () => {
     expect(typeof obj.b).toBe(`number`)
   })
 
+  test('should allow setting property from a ref to another ref', () => {
+    const foo = ref(0)
+    const bar = ref(1)
+    const observed = reactive({ a: foo })
+    const dummy = computed(() => observed.a)
+    expect(dummy.value).toBe(0)
+
+    // @ts-ignore
+    observed.a = bar
+    expect(dummy.value).toBe(1)
+
+    bar.value++
+    expect(dummy.value).toBe(2)
+  })
+
   test('non-observable values', () => {
     const assertValue = (value: any) => {
       reactive(value)

--- a/packages/reactivity/src/baseHandlers.ts
+++ b/packages/reactivity/src/baseHandlers.ts
@@ -45,14 +45,14 @@ function createGetter(isReadonly = false, shallow = false) {
       return res
     }
 
+    !isReadonly && track(target, TrackOpTypes.GET, key)
+
     if (shallow) {
-      !isReadonly && track(target, TrackOpTypes.GET, key)
       return res
     }
 
     if (isRef(res)) {
       if (targetIsArray) {
-        !isReadonly && track(target, TrackOpTypes.GET, key)
         return res
       } else {
         // ref unwrapping, only for Objects, not for Arrays.
@@ -60,7 +60,6 @@ function createGetter(isReadonly = false, shallow = false) {
       }
     }
 
-    !isReadonly && track(target, TrackOpTypes.GET, key)
     return isObject(res)
       ? isReadonly
         ? // need to lazy access readonly and reactive here to avoid


### PR DESCRIPTION
I don't know how to deal with types, I have to use `@ts-ignore` in test.

Or should this use case not be allowed?