### PR TITLE
Add flag to disable reactivity

### DIFF
--- a/packages/reactivity/src/reactive.ts
+++ b/packages/reactivity/src/reactive.ts
@@ -29,7 +29,6 @@ const isObservableType = /*#__PURE__*/ makeMap(
 
 const canObserve = (value: any): boolean => {
   return (
-    !value._isVue &&
     !value._isVNode &&
     isObservableType(toRawType(value)) &&
     !rawValues.has(value) &&

--- a/packages/reactivity/src/reactive.ts
+++ b/packages/reactivity/src/reactive.ts
@@ -30,6 +30,7 @@ const isObservableType = /*#__PURE__*/ makeMap(
 const canObserve = (value: any): boolean => {
   return (
     !value._isVNode &&
+    !value._notReactive &&
     isObservableType(toRawType(value)) &&
     !rawValues.has(value) &&
     !Object.isFrozen(value)

--- a/packages/runtime-core/src/errorHandling.ts
+++ b/packages/runtime-core/src/errorHandling.ts
@@ -81,7 +81,7 @@ export function callWithAsyncErrorHandling(
 ): any[] {
   if (isFunction(fn)) {
     const res = callWithErrorHandling(fn, instance, type, args)
-    if (res && !res._isVue && isPromise(res)) {
+    if (res && isPromise(res)) {
       res.catch(err => {
         handleError(err, instance, type)
       })


### PR DESCRIPTION
In Vugel we noticed that when using a template ref `<container ref="test" />` and then use the `ref` function rather than `shallowRef` function:
```typescript
const test = ref("test");
```
We get a proxy to the node.
When invoking any method on `test`, the proxyfication of it causes the JIT optimizer to deopt functions, leading to performance problems. This problem doesn't really occur in vue dom itself, but it does affect all javascript-based custom renderers.

We'd like developers to always use shallowRef for template refs to avoid these problems, so we'd like to disable reactivity. Judging by the source code it can be fixed by marking *every* node as raw using `markAsRaw`, but that would affect performance. Internally `_isVNode` and `_isVue` are used for a similar reason. `_isVue` doesn't seem to be set anywhere, so I guess it's old and should be removed?! For our own use case this PR adds the `_notReactive` flag. We can simply set it on our prototype.

By the way, the Composition API describes [how to use template refs](https://vue-composition-api-rfc.netlify.app/api.html#template-refs). Shouldn't it use `shallowRef` rather than `ref`? It doesn't seem to make sense to make all (HTML) element attributes reactive? The typical use case is that a developer wants to get a reference to the template.