### PR TITLE
fix(runtime-core): boolean values should not be rendered

### DIFF
--- a/packages/compiler-ssr/src/transforms/ssrTransformElement.ts
+++ b/packages/compiler-ssr/src/transforms/ssrTransformElement.ts
@@ -28,6 +28,7 @@ import {
 import {
   escapeHtml,
   isBooleanAttr,
+  isString,
   isSSRSafeAttrName,
   NO,
   propsToAttrMap
@@ -313,9 +314,7 @@ function removeStaticBinding(
   tag: TemplateLiteral['elements'],
   binding: string
 ) {
-  const i = tag.findIndex(
-    e => typeof e === 'string' && e.startsWith(` ${binding}=`)
-  )
+  const i = tag.findIndex(e => isString(e) && e.startsWith(` ${binding}=`))
   if (i > -1) {
     tag.splice(i, 1)
   }

--- a/packages/runtime-core/__tests__/vnode.spec.ts
+++ b/packages/runtime-core/__tests__/vnode.spec.ts
@@ -137,6 +137,12 @@ describe('vnode', () => {
       )
     })
 
+    test('boolean', () => {
+      const vnode = createVNode('p', null, false)
+      expect(vnode.children).toBe(null)
+      expect(vnode.shapeFlag).toBe(ShapeFlags.ELEMENT)
+    })
+
     test('element with slots', () => {
       const children = [createVNode('span', null, 'hello')]
       const vnode = createVNode('div', null, {

--- a/packages/runtime-core/src/helpers/renderList.ts
+++ b/packages/runtime-core/src/helpers/renderList.ts
@@ -1,5 +1,5 @@
 import { VNodeChild } from '../vnode'
-import { isArray, isString, isObject } from '@vue/shared'
+import { isArray, isNumber, isString, isObject } from '@vue/shared'
 
 // v-for string
 export function renderList(
@@ -46,7 +46,7 @@ export function renderList(
     for (let i = 0, l = source.length; i < l; i++) {
       ret[i] = renderItem(source[i], i)
     }
-  } else if (typeof source === 'number') {
+  } else if (isNumber(source)) {
     ret = new Array(source)
     for (let i = 0; i < source; i++) {
       ret[i] = renderItem(i + 1, i)

--- a/packages/runtime-core/src/vnode.ts
+++ b/packages/runtime-core/src/vnode.ts
@@ -2,6 +2,7 @@ import {
   isArray,
   isFunction,
   isString,
+  isBoolean,
   isObject,
   EMPTY_ARR,
   extend,
@@ -426,7 +427,7 @@ export function createCommentVNode(
 }
 
 export function normalizeVNode(child: VNodeChild): VNode {
-  if (child == null || typeof child === 'boolean') {
+  if (child == null || isBoolean(child)) {
     // empty placeholder
     return createVNode(Comment)
   } else if (isArray(child)) {
@@ -450,7 +451,7 @@ export function cloneIfMounted(child: VNode): VNode {
 export function normalizeChildren(vnode: VNode, children: unknown) {
   let type = 0
   const { shapeFlag } = vnode
-  if (children == null) {
+  if (children == null || isBoolean(children)) {
     children = null
   } else if (isArray(children)) {
     type = ShapeFlags.ARRAY_CHILDREN

--- a/packages/runtime-core/src/warning.ts
+++ b/packages/runtime-core/src/warning.ts
@@ -5,7 +5,7 @@ import {
   Component,
   formatComponentName
 } from './component'
-import { isString, isFunction } from '@vue/shared'
+import { isString, isNumber, isBoolean, isFunction } from '@vue/shared'
 import { toRaw, isRef, pauseTracking, resetTracking } from '@vue/reactivity'
 import { callWithErrorHandling, ErrorCodes } from './errorHandling'
 
@@ -134,11 +134,7 @@ function formatProp(key: string, value: unknown, raw?: boolean): any {
   if (isString(value)) {
     value = JSON.stringify(value)
     return raw ? value : [`${key}=${value}`]
-  } else if (
-    typeof value === 'number' ||
-    typeof value === 'boolean' ||
-    value == null
-  ) {
+  } else if (isNumber(value) || isBoolean(value) || value == null) {
     return raw ? value : [`${key}=${value}`]
   } else if (isRef(value)) {
     value = formatProp(key, toRaw(value.value), true)

--- a/packages/runtime-dom/src/modules/props.ts
+++ b/packages/runtime-dom/src/modules/props.ts
@@ -1,3 +1,5 @@
+import { isBoolean } from '@vue/shared'
+
 // __UNSAFE__
 // Reason: potentially setting innerHTML.
 // This can come from explicit usage of v-html or innerHTML as a prop in render
@@ -28,7 +30,7 @@ export function patchDOMProp(
     el.value = value == null ? '' : value
     return
   }
-  if (value === '' && typeof el[key] === 'boolean') {
+  if (value === '' && isBoolean(el[key])) {
     // e.g. <select multiple> compiles to { multiple: '' }
     el[key] = true
   } else {

--- a/packages/server-renderer/src/helpers/ssrRenderAttrs.ts
+++ b/packages/server-renderer/src/helpers/ssrRenderAttrs.ts
@@ -4,6 +4,8 @@ import {
   normalizeStyle,
   propsToAttrMap,
   isString,
+  isNumber,
+  isBoolean,
   isOn,
   isSSRSafeAttrName,
   isBooleanAttr,
@@ -75,8 +77,7 @@ function isRenderableValue(value: unknown): boolean {
   if (value == null) {
     return false
   }
-  const type = typeof value
-  return type === 'string' || type === 'number' || type === 'boolean'
+  return isString(value) || isNumber(value) || isBoolean(value)
 }
 
 export function ssrRenderClass(raw: unknown): string {

--- a/packages/server-renderer/src/helpers/ssrRenderList.ts
+++ b/packages/server-renderer/src/helpers/ssrRenderList.ts
@@ -1,4 +1,4 @@
-import { isArray, isString, isObject } from '@vue/shared'
+import { isArray, isNumber, isString, isObject } from '@vue/shared'
 
 export function ssrRenderList(
   source: unknown,
@@ -8,7 +8,7 @@ export function ssrRenderList(
     for (let i = 0, l = source.length; i < l; i++) {
       renderItem(source[i], i)
     }
-  } else if (typeof source === 'number') {
+  } else if (isNumber(source)) {
     for (let i = 0; i < source; i++) {
       renderItem(i + 1, i)
     }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -53,8 +53,11 @@ export const hasOwn = (
 export const isArray = Array.isArray
 export const isFunction = (val: unknown): val is Function =>
   typeof val === 'function'
+export const isNumber = (val: unknown): val is number => typeof val === 'number'
 export const isString = (val: unknown): val is string => typeof val === 'string'
 export const isSymbol = (val: unknown): val is symbol => typeof val === 'symbol'
+export const isBoolean = (val: unknown): val is boolean =>
+  typeof val === 'boolean'
 export const isObject = (val: unknown): val is Record<any, any> =>
   val !== null && typeof val === 'object'
 

--- a/packages/shared/src/normalizeProp.ts
+++ b/packages/shared/src/normalizeProp.ts
@@ -1,4 +1,4 @@
-import { isArray, isString, isObject, hyphenate } from './'
+import { isArray, isNumber, isString, isObject, hyphenate } from './'
 import { isNoUnitNumericStyleProp } from './domAttrConfig'
 
 export function normalizeStyle(
@@ -32,7 +32,7 @@ export function stringifyStyle(
     const normalizedKey = key.startsWith(`--`) ? key : hyphenate(key)
     if (
       isString(value) ||
-      (typeof value === 'number' && isNoUnitNumericStyleProp(normalizedKey))
+      (isNumber(value) && isNoUnitNumericStyleProp(normalizedKey))
     ) {
       // only render valid values
       ret += `${normalizedKey}:${value};`


### PR DESCRIPTION
Since Vue3 supports VNode directly as children, we need to support short-circuit expression for conditional rendering:
```js
const { createApp, h } = Vue

createApp({
    setup() {
        return () => h('div', false && h('h1', 'hello'))
    }
}).mount('#app')
```
Current behavior: https://jsfiddle.net/HcySunYang/7yzchkjm/.

And, in this PR, I modified the code related to the variable type, using the function defined in `@vue/shared` instead.


