### PR TITLE
fix(runtime-core): allow setting props to object if prop is not expecting string

### DIFF
--- a/packages/runtime-dom/src/modules/props.ts
+++ b/packages/runtime-dom/src/modules/props.ts
@@ -31,7 +31,21 @@ export function patchDOMProp(
   if (value === '' && typeof el[key] === 'boolean') {
     // e.g. <select multiple> compiles to { multiple: '' }
     el[key] = true
-  } else {
+  } else if (isStringAttribute(el.tagName, key)) {
     el[key] = value == null ? '' : value
+  } else {
+    el[key] = value
+  }
+}
+
+function isStringAttribute(tagName: any, key: string) {
+  try {
+    // some dom properties accept '' but not other strings, e.g. <video>.volume
+    document.createElement(tagName)[key] = 'test string'
+    return true
+  } catch (e) {
+    if (e.name !== 'TypeError') throw e
+
+    return false
   }
 }


### PR DESCRIPTION
Turns out the best approach I can think of is to recreate the element and attempt setting some string to it and see if it fails.

fix #1049