### PR TITLE
fix(runtime-core): unable to set object to dom props

### DIFF
--- a/packages/runtime-dom/__tests__/patchProps.spec.ts
+++ b/packages/runtime-dom/__tests__/patchProps.spec.ts
@@ -7,7 +7,7 @@ describe('runtime-dom: props patching', () => {
     patchProp(el, 'id', null, 'foo')
     expect(el.id).toBe('foo')
     patchProp(el, 'id', null, null)
-    expect(el.id).toBe('')
+    expect(el.id).toBe('null')
   })
 
   test('value', () => {
@@ -28,6 +28,16 @@ describe('runtime-dom: props patching', () => {
     expect(el.multiple).toBe(true)
     patchProp(el, 'multiple', null, null)
     expect(el.multiple).toBe(false)
+  })
+
+  // #1049
+  test('object prop', () => {
+    const el = document.createElement('video')
+    const object = {}
+    const set = jest.fn()
+    Object.defineProperty(el, 'srcObject', { enumerable: true, set })
+    patchProp(el, 'srcObject', null, object)
+    expect(set).toHaveBeenCalledWith(object)
   })
 
   test('innerHTML unmount prev children', () => {

--- a/packages/runtime-dom/src/modules/props.ts
+++ b/packages/runtime-dom/src/modules/props.ts
@@ -32,6 +32,6 @@ export function patchDOMProp(
     // e.g. <select multiple> compiles to { multiple: '' }
     el[key] = true
   } else {
-    el[key] = value == null ? '' : value
+    el[key] = value
   }
 }


### PR DESCRIPTION
This PR is an alternative to https://github.com/vuejs/vue-next/pull/1092. https://github.com/vuejs/vue-next/pull/1092 probably is quite expensive to do, since a new element is created per prop just to check if that prop is string assignable.

This PR removes casting nullish values to `''` for props which I personally think will make more sense because user can expect default browser behaviour for setting `<element>.prop`.

fix #1049
