### PR TITLE
fix(runtime-core): set prop directly to value if failed to set empty string

### DIFF
--- a/packages/runtime-dom/src/modules/props.ts
+++ b/packages/runtime-dom/src/modules/props.ts
@@ -32,6 +32,11 @@ export function patchDOMProp(
     // e.g. <select multiple> compiles to { multiple: '' }
     el[key] = true
   } else {
-    el[key] = value == null ? '' : value
+    try {
+      el[key] = value == null ? '' : value
+    } catch (e) {
+      if (e.name !== 'TypeError') throw e
+      el[key] = value
+    }
   }
 }


### PR DESCRIPTION
This PR is a variation of https://github.com/vuejs/vue-next/pull/1092. Instead of creating the new element to check if it accept string, set the current element directly and catch type error.

I think this approach has a fallback tho: Some prop like `<video>.volume` will accept `''`. So passing nullish value will mean setting `volume` to `''`. Which is quite a weird behaviour imo.

fix #1049