### PR TITLE
fix(warn): cast symbols to strings

### DIFF
--- a/packages/runtime-core/src/apiCreateApp.ts
+++ b/packages/runtime-core/src/apiCreateApp.ts
@@ -241,7 +241,7 @@ export function createAppAPI<HostElement>(
       provide(key, value) {
         if (__DEV__ && key in context.provides) {
           warn(
-            `App already provides property with key "${key}". ` +
+            `App already provides property with key "${String(key)}". ` +
               `It will be overwritten with the new value.`
           )
         }


### PR DESCRIPTION
Since `key` can be a `Symbol`, it needs to be cast, otherwise it throws and the symbol is not overridden