### PR TITLE
watch pr

### DIFF
--- a/packages/runtime-core/src/apiWatch.ts
+++ b/packages/runtime-core/src/apiWatch.ts
@@ -152,7 +152,7 @@ function doWatch(
   } else if (cb) {
     // getter with cb
     getter = () =>
-      callWithErrorHandling(source, instance, ErrorCodes.WATCH_GETTER)
+      callWithErrorHandling(cb, instance, ErrorCodes.WATCH_GETTER)
   } else {
     // no cb -> simple effect
     getter = () => {


### PR DESCRIPTION
I think when the first parameter of the watch API is a reactive object, when creating a getter in dowatch, the first parameter of callwitherrorhandling should be callback,

for example
```
 let obj = reactive({ name: 'gavin', age: 1 })
 watch(obj, () => {
        console.log('obj change', obj.name)
  })
 obj.name = 'sss'
```
If the first parameter of callwitherrorhandling is source, the execution error message is FN is no a function.
