### PR TITLE
types: add test for unwrapRef `value` and rollback Ref.isRefSymbol symbol

### DIFF
--- a/packages/reactivity/__tests__/reactive.spec.ts
+++ b/packages/reactivity/__tests__/reactive.spec.ts
@@ -129,6 +129,17 @@ describe('reactivity/reactive', () => {
     expect(typeof obj.b).toBe(`number`)
   })
 
+  it('should not unwrap interface with `value` property', () => {
+    const o = {
+      a: 1,
+      value: {
+        b: 2
+      }
+    }
+    const r = reactive(o)
+    expect(r.value.b).toMatchObject(o)
+  })
+
   test('non-observable values', () => {
     const assertValue = (value: any) => {
       reactive(value)

--- a/packages/reactivity/__tests__/reactive.spec.ts
+++ b/packages/reactivity/__tests__/reactive.spec.ts
@@ -137,7 +137,7 @@ describe('reactivity/reactive', () => {
       }
     }
     const r = reactive(o)
-    expect(r.value.b).toMatchObject(o)
+    expect(r).toMatchObject(o)
   })
 
   test('non-observable values', () => {

--- a/packages/reactivity/src/ref.ts
+++ b/packages/reactivity/src/ref.ts
@@ -5,11 +5,23 @@ import { reactive, isProxy, toRaw } from './reactive'
 import { ComputedRef } from './computed'
 import { CollectionTypes } from './collectionHandlers'
 
+declare const isRefSymbol: unique symbol
 export interface Ref<T = any> {
+  // This field is necessary to allow TS to differentiate a Ref from a plain
+  // object that happens to have a "value" field.
+  // However, checking a symbol on an arbitrary object is much slower than
+  // checking a plain property, so we use a __v_isRef plain property for isRef()
+  // check in the actual implementation.
+  // The reason for not just declaring __v_isRef in the interface is because we
+  // don't want this internal field to leak into userland autocompletion -
+  // a private symbol, on the other hand, achieves just that.
+  [isRefSymbol]: true
+
   /**
    * @internal
    */
   __v_isRef: true
+
   value: T
 }
 

--- a/test-dts/ref.test-d.ts
+++ b/test-dts/ref.test-d.ts
@@ -42,6 +42,9 @@ function plainType(arg: number | Ref<number>) {
   expectType<Ref<IteratorFoo | null | undefined>>(
     ref<IteratorFoo | null | undefined>()
   )
+
+  // with value
+  expect<Ref<{ value: { a: number } }>>(ref({ value: { a: 1 } }))
 }
 
 plainType(1)


### PR DESCRIPTION
Bring back `isRefSymbol` and leave it as public to allow typescript to unwrap it correctly in the user side.

Also added dts test to check if the types are correct

fixes #1111 