### PR TITLE
types: allow using ref with unknown generic types

### DIFF
--- a/packages/reactivity/src/ref.ts
+++ b/packages/reactivity/src/ref.ts
@@ -27,10 +27,23 @@ export function isRef(r: any): r is Ref {
   return r ? r.__v_isRef === true : false
 }
 
+// explicit `boolean` otherwise it will return
+// `Ref<true> | Ref<false>` instead of `Ref<boolean>`
+export function ref(value: boolean): Ref<boolean>
+// handles normal object
 export function ref<T extends object>(
   value: T
 ): T extends Ref ? T : Ref<UnwrapRef<T>>
-export function ref<T>(value: T): Ref<UnwrapRef<T>>
+
+// handles ref object
+export function ref<T extends Ref>(value: T): T
+
+// handles unknown and some odd types
+export function ref<T extends unknown | object>(
+  value: T
+): T extends Ref ? T : Ref<UnwrapRef<T>>
+
+// export function ref<T>(value: T): Ref<UnwrapRef<T>>
 export function ref<T = any>(): Ref<T | undefined>
 export function ref(value?: unknown) {
   return createRef(value)

--- a/test-dts/ref.test-d.ts
+++ b/test-dts/ref.test-d.ts
@@ -85,6 +85,39 @@ function withSymbol() {
 
 withSymbol()
 
+function generics<TGeneric extends { a: 1 }>() {
+  ;(function unknownGeneric<T>(v: T) {
+    const r = ref(v)
+    expectType<any>(r.value) // T in this case can be anything
+  })
+  ;(function stringGeneric<T extends string>(v: T) {
+    const r = ref(v)
+    expectType<string>(r.value)
+  })
+  ;(function assignedGeneric<T = TGeneric>(v: T) {
+    const r = ref(v)
+    expectType<any>(r.value) // T in this case can be anything
+  })
+  ;(function extendsGeneric<T extends TGeneric>(v: T) {
+    const r = ref(v)
+    expectType<{ a: 1 }>(r.value) // this will infer the actual type instead of being generic
+  })
+  ;(function functionGeneric<T extends (a: number, b: string) => number>(v: T) {
+    const r = ref(v)
+    expectType<(a: number, b: string) => number>(r.value) // this will infer the actual type instead of being generic
+  })
+  ;(function arrayGeneric<T extends Array<number>>(v: T) {
+    const r = ref(v)
+    expectType<Array<number>>(r.value)
+  })
+  ;(function tupleGeneric<T extends [number, string]>(v: T) {
+    const r = ref(v)
+    expectType<[number, string]>(r.value)
+  })
+}
+
+generics()
+
 const state = reactive({
   foo: {
     value: 1,


### PR DESCRIPTION
Allow handling the case where the type of the generic is unknown:
```ts
function useState<State = string>(initial: State) {
  const state = ref(initial)
  const set = (v: State) => void (state.value = v) // before: error `Type 'State' is not assignable to type 'UnwrapRef<State>'`
  return {}
}
```

There's a few caveats:
- When using `Ref<TGeneric>` and `TGeneric` doesn't extend, the `ref.value` will be `any`, this behaviour might be fine, but strict checking might cause some problems(`tsd`) [example](https://github.com/vuejs/vue-next/pull/1129/files#diff-61f52de9feff8d84f83ee7cff3ac806aR99)
- When using `Ref<TGeneric>` and `TGeneric` extends something, the `ref.value` will be extends type, [example](https://github.com/vuejs/vue-next/pull/1129/files#diff-61f52de9feff8d84f83ee7cff3ac806aR107)

