### PR TITLE
feat(untracked): enable disabling tracking temporarily

### DIFF
--- a/packages/reactivity/__tests__/effect.spec.ts
+++ b/packages/reactivity/__tests__/effect.spec.ts
@@ -9,7 +9,7 @@ import {
   markRaw,
   ref
 } from '../src/index'
-import { ITERATE_KEY } from '../src/effect'
+import { ITERATE_KEY, untracked } from '../src/effect'
 
 describe('reactivity/effect', () => {
   it('should run the passed function once (wrapped by a effect)', () => {
@@ -791,5 +791,37 @@ describe('reactivity/effect', () => {
     expect(count.value).toBe(1)
     count.value = 10
     expect(count.value).toBe(11)
+  })
+
+  describe('untracked', () => {
+    test('should prevent tracking', () => {
+      const a = ref(1)
+      const b = ref(5)
+      let calls = 0
+      let dummy = 0
+      effect(() => {
+        calls++
+        dummy = 0
+        untracked(() => {
+          dummy += b.value
+        })
+        dummy += a.value
+      })
+
+      expect(calls).toBe(1)
+      expect(dummy).toBe(6)
+      // a should be tracked.
+      a.value = 2
+      expect(calls).toBe(2)
+      expect(dummy).toBe(7)
+      // b should not be tracked.
+      b.value = 10
+      expect(calls).toBe(2)
+      expect(dummy).toBe(7)
+      // newly set value to b should be used when a changes.
+      a.value = 3
+      expect(calls).toBe(3)
+      expect(dummy).toBe(13)
+    })
   })
 })

--- a/packages/reactivity/src/effect.ts
+++ b/packages/reactivity/src/effect.ts
@@ -162,6 +162,12 @@ export function track(target: object, type: TrackOpTypes, key: unknown) {
   }
 }
 
+export function untracked(cb: () => void): void {
+  pauseTracking()
+  cb()
+  resetTracking()
+}
+
 export function trigger(
   target: object,
   type: TriggerOpTypes,

--- a/packages/reactivity/src/index.ts
+++ b/packages/reactivity/src/index.ts
@@ -37,6 +37,7 @@ export {
   stop,
   trigger,
   track,
+  untracked,
   enableTracking,
   pauseTracking,
   resetTracking,

--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -21,7 +21,8 @@ export {
   shallowReactive,
   shallowReadonly,
   markRaw,
-  toRaw
+  toRaw,
+  untracked
 } from '@vue/reactivity'
 export { computed } from './apiComputed'
 export { watch, watchEffect } from './apiWatch'


### PR DESCRIPTION
In `computed` or `watchEffect` functions, it may be convenient to get a value of a ref without actually tracking it:

```typescript
const scrollOffsetX = computed(() => {
  return scrollX.value /* I do not want to track this */ - additionalBounds.sx /* reactive, should be tracked */;
});
```

The same can be achieved by explicitly defining which refs should be tracked in a `watch()`. This works find for me but I thought that this small utility function can be handy when you'd simply want to exclude tracking for one specific ref.

Proposed change in this PR:
```typescript
const scrollOffsetX = computed(() => {
  let scrollXValue = 0;
  untracked(() => scrollXValue = scrollX.value);
  return scrollXValue - additionalBounds.sx;
});
```

Alternatively we could export `pauseTracking` and `resetTracking` but that's a bit more dangerous. The `untracked` method protects the user against not resetting tracking.