### PR TITLE
chore: LegacyOptions doesn't need to be exported

### DIFF
--- a/packages/runtime-core/src/componentOptions.ts
+++ b/packages/runtime-core/src/componentOptions.ts
@@ -217,7 +217,7 @@ type ComponentInjectOptions =
       string | symbol | { from: string | symbol; default?: unknown }
     >
 
-export interface LegacyOptions<
+interface LegacyOptions<
   Props,
   D,
   C extends ComputedOptions,


### PR DESCRIPTION
`LegacyOptions` isn't used by other modules, so we can remove `export`