### PR TITLE
fix(runtime-core): handle dynamic children for fragment

### DIFF
--- a/packages/runtime-core/__tests__/vnode.spec.ts
+++ b/packages/runtime-core/__tests__/vnode.spec.ts
@@ -385,6 +385,36 @@ describe('vnode', () => {
       expect(vnode.dynamicChildren).toStrictEqual([vnode1])
     })
 
+    test('with keyed or unkeyed fragment', () => {
+      const hoist = createVNode('div')
+      let vnode1
+      const vnode = (openBlock(),
+      createBlock('div', null, [
+        (vnode1 = (openBlock(true),
+        createBlock(Fragment, null, [
+          hoist,
+          /*vnode2*/ createVNode(() => {}, null, 'text')
+        ])))
+      ]))
+      expect(vnode.dynamicChildren).toStrictEqual([vnode1])
+      expect(vnode1.dynamicChildren).toStrictEqual(null)
+    })
+
+    test('with stable fragment', () => {
+      const hoist = createVNode('div')
+      let vnode1, vnode2
+      const vnode = (openBlock(),
+      createBlock('div', null, [
+        (vnode1 = (openBlock(),
+        createBlock(Fragment, null, [
+          hoist,
+          (vnode2 = createVNode(() => {}, null, 'text'))
+        ])))
+      ]))
+      expect(vnode.dynamicChildren).toStrictEqual([vnode1])
+      expect(vnode1.dynamicChildren).toStrictEqual([vnode2])
+    })
+
     // #1039
     // <component :is="foo">{{ bar }}</component>
     // - content is compiled as slot

--- a/packages/runtime-core/src/renderer.ts
+++ b/packages/runtime-core/src/renderer.ts
@@ -918,11 +918,7 @@ function baseCreateRenderer(
         optimized
       )
     } else {
-      if (
-        patchFlag > 0 &&
-        patchFlag & PatchFlags.STABLE_FRAGMENT &&
-        dynamicChildren
-      ) {
+      if (dynamicChildren) {
         // a stable fragment (template root or <template v-for>) doesn't need to
         // patch children order, but it may contain dynamicChildren.
         patchBlockChildren(

--- a/packages/runtime-core/src/vnode.ts
+++ b/packages/runtime-core/src/vnode.ts
@@ -3,7 +3,6 @@ import {
   isFunction,
   isString,
   isObject,
-  EMPTY_ARR,
   extend,
   normalizeClass,
   normalizeStyle,
@@ -215,7 +214,7 @@ export function createBlock(
     true /* isBlock: prevent a block from tracking itself */
   )
   // save current block children on the block vnode
-  vnode.dynamicChildren = currentBlock || EMPTY_ARR
+  vnode.dynamicChildren = currentBlock
   // close block
   blockStack.pop()
   currentBlock = blockStack[blockStack.length - 1] || null


### PR DESCRIPTION
…nt in block fragment

fix #1153

the reason with bug: the dynamic children is [] when unmount fragment.