### PR TITLE
Transition hooks

### DIFF
--- a/packages/runtime-core/src/components/BaseTransition.ts
+++ b/packages/runtime-core/src/components/BaseTransition.ts
@@ -13,7 +13,6 @@ import {
 import { warn } from '../warning'
 import { isKeepAlive } from './KeepAlive'
 import { toRaw } from '@vue/reactivity'
-import { callWithAsyncErrorHandling, ErrorCodes } from '../errorHandling'
 import { ShapeFlags } from '@vue/shared'
 import { onBeforeUnmount, onMounted } from '../apiLifecycle'
 import { RendererElement } from '../renderer'
@@ -69,11 +68,6 @@ export interface TransitionHooks {
   ): void
   delayedLeave?(): void
 }
-
-export type TransitionHookCaller<HostElement = RendererElement> = (
-  hook?: TransitionOtherHook<HostElement> | TransitionActiveHook<HostElement>,
-  args?: any[]
-) => void
 
 export type PendingCallback = (cancelled?: boolean) => void
 

--- a/packages/runtime-core/src/components/BaseTransition.ts
+++ b/packages/runtime-core/src/components/BaseTransition.ts
@@ -51,10 +51,10 @@ export interface BaseTransitionProps<HostElement = RendererElement> {
 export type TransitionActiveHook<HostElement = RendererElement> = (
   el: HostElement,
   done: () => void
-) => void | undefined
+) => void
 export type TransitionOtherHook<HostElement = RendererElement> = (
   el: HostElement
-) => void | undefined
+) => void
 
 export interface TransitionHooks {
   persisted: boolean

--- a/packages/runtime-core/src/components/BaseTransition.ts
+++ b/packages/runtime-core/src/components/BaseTransition.ts
@@ -126,7 +126,12 @@ const BaseTransitionImpl = {
     onBeforeLeave: Function,
     onLeave: Function,
     onAfterLeave: Function,
-    onLeaveCancelled: Function
+    onLeaveCancelled: Function,
+    // appear
+    onBeforeAppear: Function,
+    onAppear: Function,
+    onAfterAppear: Function,
+    onAppearCancelled: Function
   },
 
   setup(props: BaseTransitionProps, { slots }: SetupContext) {

--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -196,7 +196,12 @@ export {
   DirectiveArguments
 } from './directives'
 export { SuspenseBoundary } from './components/Suspense'
-export { TransitionState, TransitionHooks } from './components/BaseTransition'
+export {
+  TransitionState,
+  TransitionHooks,
+  TransitionActiveHook,
+  TransitionOtherHook
+} from './components/BaseTransition'
 export {
   AsyncComponentOptions,
   AsyncComponentLoader

--- a/packages/runtime-dom/src/components/Transition.ts
+++ b/packages/runtime-dom/src/components/Transition.ts
@@ -5,15 +5,13 @@ import {
   warn,
   FunctionalComponent,
   getCurrentInstance,
-  callWithAsyncErrorHandling
+  callWithAsyncErrorHandling,
+  RendererElement,
+  TransitionActiveHook,
+  TransitionOtherHook
 } from '@vue/runtime-core'
 import { isObject } from '@vue/shared'
 import { ErrorCodes } from 'packages/runtime-core/src/errorHandling'
-import {
-  TransitionActiveHook,
-  TransitionHookCaller,
-  TransitionOtherHook
-} from '@vue/runtime-core/src/components/BaseTransition'
 
 const TRANSITION = 'transition'
 const ANIMATION = 'animation'
@@ -34,6 +32,11 @@ export interface TransitionProps extends BaseTransitionProps<Element> {
   leaveActiveClass?: string
   leaveToClass?: string
 }
+
+export type TransitionHookCaller<HostElement = RendererElement> = (
+  hook?: TransitionOtherHook<HostElement> | TransitionActiveHook<HostElement>,
+  args?: any[]
+) => void
 
 // DOM Transition is a higher-order-component based on the platform-agnostic
 // base Transition component, with DOM-specific logic.

--- a/packages/runtime-dom/src/components/Transition.ts
+++ b/packages/runtime-dom/src/components/Transition.ts
@@ -84,17 +84,14 @@ export function resolveTransitionProps({
   onEnter,
   onAfterEnter,
   onEnterCancelled,
-
   onBeforeLeave,
   onLeave,
   onAfterLeave,
-
   onLeaveCancelled,
   onBeforeAppear = onBeforeEnter,
   onAppear = onEnter,
   onAfterAppear = onAfterEnter,
   onAppearCancelled = onEnterCancelled,
-
   ...baseProps
 }: TransitionProps): BaseTransitionProps<Element> {
   if (!css) {

--- a/packages/runtime-dom/src/components/Transition.ts
+++ b/packages/runtime-dom/src/components/Transition.ts
@@ -79,6 +79,22 @@ export function resolveTransitionProps({
   leaveFromClass = `${name}-leave-from`,
   leaveActiveClass = `${name}-leave-active`,
   leaveToClass = `${name}-leave-to`,
+  appear,
+  onBeforeEnter,
+  onEnter,
+  onAfterEnter,
+  onEnterCancelled,
+
+  onBeforeLeave,
+  onLeave,
+  onAfterLeave,
+
+  onLeaveCancelled,
+  onBeforeAppear = onBeforeEnter,
+  onAppear = onEnter,
+  onAfterAppear = onAfterEnter,
+  onAppearCancelled = onEnterCancelled,
+
   ...baseProps
 }: TransitionProps): BaseTransitionProps<Element> {
   if (!css) {
@@ -89,21 +105,7 @@ export function resolveTransitionProps({
   const durations = normalizeDuration(duration)
   const enterDuration = durations && durations[0]
   const leaveDuration = durations && durations[1]
-  let {
-    appear,
-    onBeforeEnter,
-    onAfterEnter,
-    onBeforeLeave,
-    onAfterLeave,
-    onEnter,
-    onLeave,
-    onEnterCancelled,
-    onLeaveCancelled,
-    onAfterAppear,
-    onAppear,
-    onAppearCancelled,
-    onBeforeAppear
-  } = baseProps
+
   // is appearing
   const originEnterClass = [enterFromClass, enterActiveClass, enterToClass]
   const originEnterHook: any[] = [
@@ -119,10 +121,10 @@ export function resolveTransitionProps({
       appearToClass
     ]
     ;[onBeforeEnter, onEnter, onBeforeEnter, onEnterCancelled] = [
-      onBeforeAppear || onBeforeEnter,
-      onAppear || onEnter,
-      onAfterAppear || onAfterEnter,
-      onAppearCancelled || onEnterCancelled
+      onBeforeAppear,
+      onAppear,
+      onAfterAppear,
+      onAppearCancelled
     ]
   }
 

--- a/packages/runtime-dom/src/components/Transition.ts
+++ b/packages/runtime-dom/src/components/Transition.ts
@@ -205,7 +205,6 @@ export function resolveTransitionProps({
       })
     },
     onAfterLeave(el) {
-      finishEnter(el)
       callHook(onAfterLeave, [el])
     },
     onEnterCancelled(el) {


### PR DESCRIPTION
### Bug Fix
1. Should call appear hook when have a `appear` props, and add appear hooks props into `BaseTransitionProps`.
2.Should call `onLeaveCancelled` and `onEnterCancelled` hook.

### Feature
1. It is not correct context which call hook in `BaseTransition`. because it will throw error with wrapped function  in `Transition`.It is should happend in user provider hooks.