### PR TITLE
fix(runtime-dom): event handlers with modifiers should get all event arguments

### DIFF
--- a/packages/runtime-dom/__tests__/directives/vOn.spec.ts
+++ b/packages/runtime-dom/__tests__/directives/vOn.spec.ts
@@ -118,4 +118,13 @@ describe('runtime-dom: v-on directive', () => {
       expect(fn).toBeCalled()
     })
   })
+
+  it('should handle multiple arguments when using modifiers', () => {
+    const el = document.createElement('div')
+    const fn = jest.fn()
+    const handler = withModifiers(fn, ['ctrl'])
+    const event = triggerEvent(el, 'click', e => (e.ctrlKey = true))
+    handler(event, 'value', true)
+    expect(fn).toBeCalledWith(event, 'value', true)
+  })
 })

--- a/packages/runtime-dom/src/directives/vOn.ts
+++ b/packages/runtime-dom/src/directives/vOn.ts
@@ -26,12 +26,12 @@ const modifierGuards: Record<
  * @internal
  */
 export const withModifiers = (fn: Function, modifiers: string[]) => {
-  return (event: Event) => {
+  return (event: Event, ...args: unknown[]) => {
     for (let i = 0; i < modifiers.length; i++) {
       const guard = modifierGuards[modifiers[i]]
       if (guard && guard(event, modifiers)) return
     }
-    return fn(event)
+    return fn(event, ...args)
   }
 }
 


### PR DESCRIPTION
Current Vue 3 behaviour: https://codepen.io/nekosaur/pen/dyYqgyZ

Regular event handler sends all arguments, but with modifier it only sends first one (event). This seems inconsistent.

Scenario is if one would like to enable the use of modifiers and short template syntax while sending custom event values.

See https://github.com/vuejs/vue/issues/10867, https://github.com/vuejs/vue/pull/10958, https://github.com/vuetifyjs/vuetify/issues/9720

