### PR TITLE
fix(ExtractComputedReturns): use explicit Record type

### DIFF
--- a/packages/runtime-core/src/componentOptions.ts
+++ b/packages/runtime-core/src/componentOptions.ts
@@ -195,7 +195,7 @@ export interface MethodOptions {
   [key: string]: Function
 }
 
-export type ExtractComputedReturns<T extends any> = {
+export type ExtractComputedReturns<T extends Record<any, any>> = {
   [key in keyof T]: T[key] extends { get: Function }
     ? ReturnType<T[key]['get']>
     : ReturnType<T[key]>


### PR DESCRIPTION
This PR fixes the following errors I was seeing.

```
app/client/node_modules/@vue/runtime-core/dist/runtime-core.d.ts:437:20 - error TS2344: Type 'Function & T[key]["get"]' does not satisfy the constraint '(...args: any) => any'.
  Type 'Function' provides no match for the signature '(...args: any): any'.

437     } ? ReturnType<T[key]['get']> : ReturnType<T[key]>;
                       ~~~~~~~~~~~~~

app/client/node_modules/@vue/runtime-core/dist/runtime-core.d.ts:437:48 - error TS2344: Type 'T[key]' does not satisfy the constraint '(...args: any) => any'.
  Type 'T[keyof T]' is not assignable to type '(...args: any) => any'.
    Type 'T[string] | T[number] | T[symbol]' is not assignable to type '(...args: any) => any'.
      Type 'T[string]' is not assignable to type '(...args: any) => any'.

437     } ? ReturnType<T[key]['get']> : ReturnType<T[key]>;
                                                   ~~~~~~
```