### PR TITLE
feat(watch): support directly watching reactive object in multiple sources with deep default

### DIFF
--- a/packages/runtime-core/__tests__/apiWatch.spec.ts
+++ b/packages/runtime-core/__tests__/apiWatch.spec.ts
@@ -155,9 +155,27 @@ describe('api: watch', () => {
     expect(dummy).toMatchObject([[2, true], [1, false]])
   })
 
+  it('watching multiple sources: reactive object (with automatic deep: true)', async () => {
+    const src = reactive({ count: 0 })
+    let dummy
+    watch([src], ([state]) => {
+      dummy = state
+      // assert types
+      state.count === 1
+    })
+    src.count++
+    await nextTick()
+    expect(dummy).toMatchObject({ count: 1 })
+  })
+
   it('warn invalid watch source', () => {
     // @ts-ignore
     watch(1, () => {})
+    expect(`Invalid watch source`).toHaveBeenWarned()
+  })
+
+  it('warn invalid watch source: multiple sources', () => {
+    watch([1], () => {})
     expect(`Invalid watch source`).toHaveBeenWarned()
   })
 


### PR DESCRIPTION
`watch([1], () => {})` won't cause type error, even before my changes, I don't know how to fix it.