### PR TITLE
Fix ExtractComputedReturns in typescript ^3.9

### DIFF
--- a/packages/runtime-core/src/componentOptions.ts
+++ b/packages/runtime-core/src/componentOptions.ts
@@ -196,9 +196,11 @@ export interface MethodOptions {
 }
 
 export type ExtractComputedReturns<T extends any> = {
-  [key in keyof T]: T[key] extends { get: Function }
+  [key in keyof T]: T[key] extends { get: (...args: any) => any }
     ? ReturnType<T[key]['get']>
-    : ReturnType<T[key]>
+    : T[key] extends (...args: any) => any
+      ? ReturnType<T[key]>
+      : any
 }
 
 type WatchOptionItem =


### PR DESCRIPTION
In typescript ^3.9, `ReturnType` behaves differently, which breaks `ExtractComputedReturns`:

Typescript Playground links:

[3.9.2](https://www.typescriptlang.org/play/index.html?ssl=1&ssc=1&pln=6&pc=1#code/KYDwDg9gTgLgBDAnmYcCiIZQIYGMYDCEAtmAK4zAAmASsDGVAHYDOAPACpyiVNUtxsTRAD44AXjgBvAFBw4AbQDWwRHACWTOCsQQAZnA4BdAFyHlqo90zA+AqXADm9MwDEyTfOohaAvnPk4AH44OgZmDmRgTgtEIwUAcmcYBKMRAPkzMMYmSJQYnTSZfyA)

[3.8,3](https://www.typescriptlang.org/play/index.html?ts=3.8.3&ssl=1&ssc=1&pln=6&pc=1#code/KYDwDg9gTgLgBDAnmYcCiIZQIYGMYDCEAtmAK4zAAmASsDGVAHYDOAPACpyiVNUtxsTRAD44AXjgBvAFBw4AbQDWwRHACWTOCsQQAZnA4BdAFyHlqo90zA+AqXADm9MwDEyTfOohaAvnPk4AH44OgZmDmRgTgtEIwUAcmcYBKMRAPkzMMYmSJQYnTSZfyA)

The fix is to explicitly cast as a function signature type instead of `Function`, according to https://github.com/microsoft/TypeScript/issues/34540. Here's another Playground link with the fix, no more red squigglies: [Playground Link](https://www.typescriptlang.org/play/index.html?ssl=1&ssc=1&pln=6&pc=1#code/KYDwDg9gTgLgBDAnmYcCiIZQIYGMYDCEAtmAK4zAAmASsDGVAHYDOAPACpyiVNUtxsTRAD44AXjgBvAFBw4AbQDWwRHACWTOCsQQAZnA4BdAFyHlqo90zA+AqXADm9MwAoAdJ+xRHLM0MQASgkxALgAXzl5OAB+ODoGZg5kYE4LRCMFAHJnGCyjESj5Mw50qx5bfjgPLx8-QWFg8VDhIui4hMYmZJQ0nQK24obEGUigA)