### PR TITLE
fix(v-model): allow multiline expressions (fix #1218)

### DIFF
--- a/packages/compiler-core/src/utils.ts
+++ b/packages/compiler-core/src/utils.ts
@@ -83,7 +83,7 @@ const nonIdentifierRE = /^\d|[^\$\w]/
 export const isSimpleIdentifier = (name: string): boolean =>
   !nonIdentifierRE.test(name)
 
-const memberExpRE = /^[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*|\[[^\]]+\])*$/
+const memberExpRE = /^\s*[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*|\[[^\]]+\])*\s*$/
 export const isMemberExpression = (path: string): boolean =>
   memberExpRE.test(path)
 

--- a/packages/compiler-dom/__tests__/transforms/__snapshots__/vModel.spec.ts.snap
+++ b/packages/compiler-dom/__tests__/transforms/__snapshots__/vModel.spec.ts.snap
@@ -215,3 +215,23 @@ return function render(_ctx, _cache) {
   }
 }"
 `;
+
+exports[`compiler: transform v-model simple expression with multiline 1`] = `
+"const _Vue = Vue
+
+return function render(_ctx, _cache) {
+  with (_ctx) {
+    const { vModelText: _vModelText, createVNode: _createVNode, withDirectives: _withDirectives, openBlock: _openBlock, createBlock: _createBlock } = _Vue
+
+    return _withDirectives((_openBlock(), _createBlock(\\"input\\", {
+      \\"onUpdate:modelValue\\": $event => (
+ model 
+ = $event)
+    }, null, 8 /* PROPS */, [\\"onUpdate:modelValue\\"])), [
+      [_vModelText, 
+ model 
+]
+    ])
+  }
+}"
+`;

--- a/packages/compiler-dom/__tests__/transforms/vModel.spec.ts
+++ b/packages/compiler-dom/__tests__/transforms/vModel.spec.ts
@@ -35,6 +35,13 @@ describe('compiler: transform v-model', () => {
     expect(generate(root).code).toMatchSnapshot()
   })
 
+  test('simple expression with multiline', () => {
+    const root = transformWithModel('<input v-model="\n model \n" />')
+
+    expect(root.helpers).toContain(V_MODEL_TEXT)
+    expect(generate(root).code).toMatchSnapshot()
+  })
+
   test('simple expression for input (text)', () => {
     const root = transformWithModel('<input type="text" v-model="model" />')
 


### PR DESCRIPTION
prettier breaks long/deeply nested expression attributes in new lines
(https://github.com/prettier/prettier/issues/5384) but this breaks the
compiler