### PR TITLE
refactor(compiler-core): remove extra new line

### DIFF
--- a/packages/compiler-core/__tests__/__snapshots__/codegen.spec.ts.snap
+++ b/packages/compiler-core/__tests__/__snapshots__/codegen.spec.ts.snap
@@ -69,7 +69,6 @@ return function render(_ctx, _cache) {
     const _directive_my_dir_0 = _resolveDirective(\\"my_dir_0\\")
     const _directive_my_dir_1 = _resolveDirective(\\"my_dir_1\\")
     let _temp0, _temp1, _temp2
-
     return null
   }
 }"
@@ -108,7 +107,6 @@ exports[`compiler: codegen function mode preamble 1`] = `
 return function render(_ctx, _cache) {
   with (_ctx) {
     const { createVNode: _createVNode, resolveDirective: _resolveDirective } = _Vue
-
     return null
   }
 }"
@@ -187,7 +185,6 @@ exports[`compiler: codegen temps 1`] = `
 return function render(_ctx, _cache) {
   with (_ctx) {
     let _temp0, _temp1, _temp2
-
     return null
   }
 }"

--- a/packages/compiler-core/__tests__/__snapshots__/compile.spec.ts.snap
+++ b/packages/compiler-core/__tests__/__snapshots__/compile.spec.ts.snap
@@ -6,7 +6,6 @@ exports[`compiler: integration tests function mode 1`] = `
 return function render(_ctx, _cache) {
   with (_ctx) {
     const { toDisplayString: _toDisplayString, createVNode: _createVNode, openBlock: _openBlock, createBlock: _createBlock, createCommentVNode: _createCommentVNode, createTextVNode: _createTextVNode, Fragment: _Fragment, renderList: _renderList } = _Vue
-
     return (_openBlock(), _createBlock(\\"div\\", {
       id: \\"foo\\",
       class: bar.baz

--- a/packages/compiler-core/__tests__/__snapshots__/scopeId.spec.ts.snap
+++ b/packages/compiler-core/__tests__/__snapshots__/scopeId.spec.ts.snap
@@ -24,7 +24,6 @@ const _withId = /*#__PURE__*/_withScopeId(\\"test\\")
 
 export const render = /*#__PURE__*/_withId(function render(_ctx, _cache) {
   const _component_Child = _resolveComponent(\\"Child\\")
-
   return (_openBlock(), _createBlock(_component_Child, null, {
     default: _withId(() => [
       _createVNode(\\"div\\")
@@ -40,7 +39,6 @@ const _withId = /*#__PURE__*/_withScopeId(\\"test\\")
 
 export const render = /*#__PURE__*/_withId(function render(_ctx, _cache) {
   const _component_Child = _resolveComponent(\\"Child\\")
-
   return (_openBlock(), _createBlock(_component_Child, null, _createSlots({ _: 1 }, [
     (_ctx.ok)
       ? {
@@ -68,7 +66,6 @@ const _withId = /*#__PURE__*/_withScopeId(\\"test\\")
 
 export const render = /*#__PURE__*/_withId(function render(_ctx, _cache) {
   const _component_Child = _resolveComponent(\\"Child\\")
-
   return (_openBlock(), _createBlock(_component_Child, null, {
     foo: _withId(({ msg }) => [
       _createTextVNode(_toDisplayString(msg), 1 /* TEXT */)

--- a/packages/compiler-core/__tests__/transforms/__snapshots__/hoistStatic.spec.ts.snap
+++ b/packages/compiler-core/__tests__/transforms/__snapshots__/hoistStatic.spec.ts.snap
@@ -9,7 +9,6 @@ const _hoisted_1 = /*#__PURE__*/_createVNode(\\"div\\", { key: \\"foo\\" }, null
 return function render(_ctx, _cache) {
   with (_ctx) {
     const { createVNode: _createVNode, openBlock: _openBlock, createBlock: _createBlock } = _Vue
-
     return (_openBlock(), _createBlock(\\"div\\", null, [
       _hoisted_1
     ]))
@@ -29,7 +28,6 @@ const _hoisted_1 = /*#__PURE__*/_createVNode(\\"p\\", null, [
 return function render(_ctx, _cache) {
   with (_ctx) {
     const { createVNode: _createVNode, openBlock: _openBlock, createBlock: _createBlock } = _Vue
-
     return (_openBlock(), _createBlock(\\"div\\", null, [
       _hoisted_1
     ]))
@@ -48,7 +46,6 @@ const _hoisted_1 = /*#__PURE__*/_createVNode(\\"div\\", null, [
 return function render(_ctx, _cache) {
   with (_ctx) {
     const { createCommentVNode: _createCommentVNode, createVNode: _createVNode, openBlock: _openBlock, createBlock: _createBlock } = _Vue
-
     return (_openBlock(), _createBlock(\\"div\\", null, [
       _hoisted_1
     ]))
@@ -66,7 +63,6 @@ const _hoisted_2 = /*#__PURE__*/_createVNode(\\"div\\", null, null, -1 /* HOISTE
 return function render(_ctx, _cache) {
   with (_ctx) {
     const { createVNode: _createVNode, openBlock: _openBlock, createBlock: _createBlock } = _Vue
-
     return (_openBlock(), _createBlock(\\"div\\", null, [
       _hoisted_1,
       _hoisted_2
@@ -84,7 +80,6 @@ const _hoisted_1 = /*#__PURE__*/_createVNode(\\"span\\", { class: \\"inline\\" }
 return function render(_ctx, _cache) {
   with (_ctx) {
     const { createVNode: _createVNode, openBlock: _openBlock, createBlock: _createBlock } = _Vue
-
     return (_openBlock(), _createBlock(\\"div\\", null, [
       _hoisted_1
     ]))
@@ -101,9 +96,7 @@ const _hoisted_1 = { id: \\"foo\\" }
 return function render(_ctx, _cache) {
   with (_ctx) {
     const { resolveDirective: _resolveDirective, createVNode: _createVNode, withDirectives: _withDirectives, openBlock: _openBlock, createBlock: _createBlock } = _Vue
-
     const _directive_foo = _resolveDirective(\\"foo\\")
-
     return (_openBlock(), _createBlock(\\"div\\", null, [
       _withDirectives(_createVNode(\\"div\\", _hoisted_1, null, 512 /* NEED_PATCH */), [
         [_directive_foo]
@@ -122,7 +115,6 @@ const _hoisted_1 = { id: \\"foo\\" }
 return function render(_ctx, _cache) {
   with (_ctx) {
     const { toDisplayString: _toDisplayString, createVNode: _createVNode, openBlock: _openBlock, createBlock: _createBlock } = _Vue
-
     return (_openBlock(), _createBlock(\\"div\\", null, [
       _createVNode(\\"div\\", _hoisted_1, _toDisplayString(hello), 1 /* TEXT */)
     ]))
@@ -139,9 +131,7 @@ const _hoisted_1 = { id: \\"foo\\" }
 return function render(_ctx, _cache) {
   with (_ctx) {
     const { resolveComponent: _resolveComponent, createVNode: _createVNode, openBlock: _openBlock, createBlock: _createBlock } = _Vue
-
     const _component_Comp = _resolveComponent(\\"Comp\\")
-
     return (_openBlock(), _createBlock(\\"div\\", null, [
       _createVNode(\\"div\\", _hoisted_1, [
         _createVNode(_component_Comp)
@@ -160,7 +150,6 @@ const _hoisted_1 = { class: { foo: true } }
 return function render(_ctx, _cache) {
   with (_ctx) {
     const { toDisplayString: _toDisplayString, createVNode: _createVNode, openBlock: _openBlock, createBlock: _createBlock } = _Vue
-
     return (_openBlock(), _createBlock(\\"div\\", null, [
       _createVNode(\\"span\\", _hoisted_1, _toDisplayString(_ctx.bar), 1 /* TEXT */)
     ]))
@@ -177,7 +166,6 @@ const _hoisted_1 = /*#__PURE__*/_createVNode(\\"span\\", null, \\"foo \\" + /*#_
 return function render(_ctx, _cache) {
   with (_ctx) {
     const { toDisplayString: _toDisplayString, createVNode: _createVNode, openBlock: _openBlock, createBlock: _createBlock } = _Vue
-
     return (_openBlock(), _createBlock(\\"div\\", null, [
       _hoisted_1
     ]))
@@ -194,7 +182,6 @@ const _hoisted_1 = /*#__PURE__*/_createVNode(\\"span\\", { foo: 0 }, /*#__PURE__
 return function render(_ctx, _cache) {
   with (_ctx) {
     const { toDisplayString: _toDisplayString, createVNode: _createVNode, openBlock: _openBlock, createBlock: _createBlock } = _Vue
-
     return (_openBlock(), _createBlock(\\"div\\", null, [
       _hoisted_1
     ]))
@@ -222,7 +209,6 @@ exports[`compiler: hoistStatic transform prefixIdentifiers should NOT hoist expr
 return function render(_ctx, _cache) {
   with (_ctx) {
     const { renderList: _renderList, Fragment: _Fragment, openBlock: _openBlock, createBlock: _createBlock, toDisplayString: _toDisplayString, createVNode: _createVNode } = _Vue
-
     return (_openBlock(), _createBlock(\\"div\\", null, [
       (_openBlock(true), _createBlock(_Fragment, null, _renderList(_ctx.list, (o) => {
         return (_openBlock(), _createBlock(\\"p\\", null, [
@@ -240,9 +226,7 @@ exports[`compiler: hoistStatic transform prefixIdentifiers should NOT hoist expr
 return function render(_ctx, _cache) {
   with (_ctx) {
     const { toDisplayString: _toDisplayString, createTextVNode: _createTextVNode, resolveComponent: _resolveComponent, withCtx: _withCtx, createVNode: _createVNode, openBlock: _openBlock, createBlock: _createBlock } = _Vue
-
     const _component_Comp = _resolveComponent(\\"Comp\\")
-
     return (_openBlock(), _createBlock(_component_Comp, null, {
       default: _withCtx(({ foo }) => [
         _createTextVNode(_toDisplayString(_ctx.foo), 1 /* TEXT */)
@@ -259,7 +243,6 @@ exports[`compiler: hoistStatic transform prefixIdentifiers should NOT hoist expr
 return function render(_ctx, _cache) {
   with (_ctx) {
     const { renderList: _renderList, Fragment: _Fragment, openBlock: _openBlock, createBlock: _createBlock, toDisplayString: _toDisplayString, createVNode: _createVNode } = _Vue
-
     return (_openBlock(), _createBlock(\\"div\\", null, [
       (_openBlock(true), _createBlock(_Fragment, null, _renderList(_ctx.list, (o) => {
         return (_openBlock(), _createBlock(\\"p\\", null, [
@@ -277,9 +260,7 @@ exports[`compiler: hoistStatic transform should NOT hoist components 1`] = `
 return function render(_ctx, _cache) {
   with (_ctx) {
     const { resolveComponent: _resolveComponent, createVNode: _createVNode, openBlock: _openBlock, createBlock: _createBlock } = _Vue
-
     const _component_Comp = _resolveComponent(\\"Comp\\")
-
     return (_openBlock(), _createBlock(\\"div\\", null, [
       _createVNode(_component_Comp)
     ]))
@@ -293,7 +274,6 @@ exports[`compiler: hoistStatic transform should NOT hoist element with dynamic k
 return function render(_ctx, _cache) {
   with (_ctx) {
     const { openBlock: _openBlock, createBlock: _createBlock, createVNode: _createVNode } = _Vue
-
     return (_openBlock(), _createBlock(\\"div\\", null, [
       (_openBlock(), _createBlock(\\"div\\", { key: foo }))
     ]))
@@ -307,7 +287,6 @@ exports[`compiler: hoistStatic transform should NOT hoist element with dynamic p
 return function render(_ctx, _cache) {
   with (_ctx) {
     const { createVNode: _createVNode, openBlock: _openBlock, createBlock: _createBlock } = _Vue
-
     return (_openBlock(), _createBlock(\\"div\\", null, [
       _createVNode(\\"div\\", { id: foo }, null, 8 /* PROPS */, [\\"id\\"])
     ]))
@@ -321,7 +300,6 @@ exports[`compiler: hoistStatic transform should NOT hoist element with dynamic r
 return function render(_ctx, _cache) {
   with (_ctx) {
     const { createVNode: _createVNode, openBlock: _openBlock, createBlock: _createBlock } = _Vue
-
     return (_openBlock(), _createBlock(\\"div\\", null, [
       _createVNode(\\"div\\", { ref: foo }, null, 512 /* NEED_PATCH */)
     ]))
@@ -335,7 +313,6 @@ exports[`compiler: hoistStatic transform should NOT hoist root node 1`] = `
 return function render(_ctx, _cache) {
   with (_ctx) {
     const { createVNode: _createVNode, openBlock: _openBlock, createBlock: _createBlock } = _Vue
-
     return (_openBlock(), _createBlock(\\"div\\"))
   }
 }"
@@ -351,7 +328,6 @@ const _hoisted_2 = /*#__PURE__*/_createVNode(\\"span\\", null, null, -1 /* HOIST
 return function render(_ctx, _cache) {
   with (_ctx) {
     const { renderList: _renderList, Fragment: _Fragment, openBlock: _openBlock, createBlock: _createBlock, createVNode: _createVNode } = _Vue
-
     return (_openBlock(), _createBlock(\\"div\\", null, [
       (_openBlock(true), _createBlock(_Fragment, null, _renderList(list, (i) => {
         return (_openBlock(), _createBlock(\\"div\\", _hoisted_1, [
@@ -376,7 +352,6 @@ const _hoisted_2 = /*#__PURE__*/_createVNode(\\"span\\", null, null, -1 /* HOIST
 return function render(_ctx, _cache) {
   with (_ctx) {
     const { createVNode: _createVNode, openBlock: _openBlock, createBlock: _createBlock, createCommentVNode: _createCommentVNode } = _Vue
-
     return (_openBlock(), _createBlock(\\"div\\", null, [
       ok
         ? (_openBlock(), _createBlock(\\"div\\", _hoisted_1, [

--- a/packages/compiler-core/__tests__/transforms/__snapshots__/transformText.spec.ts.snap
+++ b/packages/compiler-core/__tests__/transforms/__snapshots__/transformText.spec.ts.snap
@@ -6,7 +6,6 @@ exports[`compiler: transform text <template v-for> 1`] = `
 return function render(_ctx, _cache) {
   with (_ctx) {
     const { renderList: _renderList, Fragment: _Fragment, openBlock: _openBlock, createBlock: _createBlock, createTextVNode: _createTextVNode } = _Vue
-
     return (_openBlock(true), _createBlock(_Fragment, null, _renderList(list, (i) => {
       return (_openBlock(), _createBlock(_Fragment, null, [
         _createTextVNode(\\"foo\\")
@@ -22,7 +21,6 @@ exports[`compiler: transform text consecutive text 1`] = `
 return function render(_ctx, _cache) {
   with (_ctx) {
     const { toDisplayString: _toDisplayString } = _Vue
-
     return _toDisplayString(foo) + \\" bar \\" + _toDisplayString(baz)
   }
 }"
@@ -34,7 +32,6 @@ exports[`compiler: transform text consecutive text between elements 1`] = `
 return function render(_ctx, _cache) {
   with (_ctx) {
     const { createVNode: _createVNode, toDisplayString: _toDisplayString, createTextVNode: _createTextVNode, Fragment: _Fragment, openBlock: _openBlock, createBlock: _createBlock } = _Vue
-
     return (_openBlock(), _createBlock(_Fragment, null, [
       _createVNode(\\"div\\"),
       _createTextVNode(_toDisplayString(foo) + \\" bar \\" + _toDisplayString(baz), 1 /* TEXT */),
@@ -50,7 +47,6 @@ exports[`compiler: transform text consecutive text mixed with elements 1`] = `
 return function render(_ctx, _cache) {
   with (_ctx) {
     const { createVNode: _createVNode, toDisplayString: _toDisplayString, createTextVNode: _createTextVNode, Fragment: _Fragment, openBlock: _openBlock, createBlock: _createBlock } = _Vue
-
     return (_openBlock(), _createBlock(_Fragment, null, [
       _createVNode(\\"div\\"),
       _createTextVNode(_toDisplayString(foo) + \\" bar \\" + _toDisplayString(baz), 1 /* TEXT */),
@@ -68,7 +64,6 @@ exports[`compiler: transform text no consecutive text 1`] = `
 return function render(_ctx, _cache) {
   with (_ctx) {
     const { toDisplayString: _toDisplayString } = _Vue
-
     return _toDisplayString(foo)
   }
 }"
@@ -80,7 +75,6 @@ exports[`compiler: transform text text between elements (static) 1`] = `
 return function render(_ctx, _cache) {
   with (_ctx) {
     const { createVNode: _createVNode, createTextVNode: _createTextVNode, Fragment: _Fragment, openBlock: _openBlock, createBlock: _createBlock } = _Vue
-
     return (_openBlock(), _createBlock(_Fragment, null, [
       _createVNode(\\"div\\"),
       _createTextVNode(\\"hello\\"),

--- a/packages/compiler-core/__tests__/transforms/__snapshots__/vFor.spec.ts.snap
+++ b/packages/compiler-core/__tests__/transforms/__snapshots__/vFor.spec.ts.snap
@@ -6,7 +6,6 @@ exports[`compiler: v-for codegen basic v-for 1`] = `
 return function render(_ctx, _cache) {
   with (_ctx) {
     const { renderList: _renderList, Fragment: _Fragment, openBlock: _openBlock, createBlock: _createBlock, createVNode: _createVNode } = _Vue
-
     return (_openBlock(true), _createBlock(_Fragment, null, _renderList(items, (item) => {
       return (_openBlock(), _createBlock(\\"span\\"))
     }), 256 /* UNKEYED_FRAGMENT */))
@@ -20,7 +19,6 @@ exports[`compiler: v-for codegen keyed template v-for 1`] = `
 return function render(_ctx, _cache) {
   with (_ctx) {
     const { renderList: _renderList, Fragment: _Fragment, openBlock: _openBlock, createBlock: _createBlock, createVNode: _createVNode } = _Vue
-
     return (_openBlock(true), _createBlock(_Fragment, null, _renderList(items, (item) => {
       return (_openBlock(), _createBlock(_Fragment, { key: item }, [
         \\"hello\\",
@@ -37,7 +35,6 @@ exports[`compiler: v-for codegen keyed v-for 1`] = `
 return function render(_ctx, _cache) {
   with (_ctx) {
     const { renderList: _renderList, Fragment: _Fragment, openBlock: _openBlock, createBlock: _createBlock } = _Vue
-
     return (_openBlock(true), _createBlock(_Fragment, null, _renderList(items, (item) => {
       return (_openBlock(), _createBlock(\\"span\\", { key: item }))
     }), 128 /* KEYED_FRAGMENT */))
@@ -51,7 +48,6 @@ exports[`compiler: v-for codegen skipped key 1`] = `
 return function render(_ctx, _cache) {
   with (_ctx) {
     const { renderList: _renderList, Fragment: _Fragment, openBlock: _openBlock, createBlock: _createBlock, createVNode: _createVNode } = _Vue
-
     return (_openBlock(true), _createBlock(_Fragment, null, _renderList(items, (item, __, index) => {
       return (_openBlock(), _createBlock(\\"span\\"))
     }), 256 /* UNKEYED_FRAGMENT */))
@@ -65,7 +61,6 @@ exports[`compiler: v-for codegen skipped value & key 1`] = `
 return function render(_ctx, _cache) {
   with (_ctx) {
     const { renderList: _renderList, Fragment: _Fragment, openBlock: _openBlock, createBlock: _createBlock, createVNode: _createVNode } = _Vue
-
     return (_openBlock(true), _createBlock(_Fragment, null, _renderList(items, (_, __, index) => {
       return (_openBlock(), _createBlock(\\"span\\"))
     }), 256 /* UNKEYED_FRAGMENT */))
@@ -79,7 +74,6 @@ exports[`compiler: v-for codegen skipped value 1`] = `
 return function render(_ctx, _cache) {
   with (_ctx) {
     const { renderList: _renderList, Fragment: _Fragment, openBlock: _openBlock, createBlock: _createBlock, createVNode: _createVNode } = _Vue
-
     return (_openBlock(true), _createBlock(_Fragment, null, _renderList(items, (_, key, index) => {
       return (_openBlock(), _createBlock(\\"span\\"))
     }), 256 /* UNKEYED_FRAGMENT */))
@@ -93,7 +87,6 @@ exports[`compiler: v-for codegen template v-for 1`] = `
 return function render(_ctx, _cache) {
   with (_ctx) {
     const { renderList: _renderList, Fragment: _Fragment, openBlock: _openBlock, createBlock: _createBlock, createVNode: _createVNode } = _Vue
-
     return (_openBlock(true), _createBlock(_Fragment, null, _renderList(items, (item) => {
       return (_openBlock(), _createBlock(_Fragment, null, [
         \\"hello\\",
@@ -110,7 +103,6 @@ exports[`compiler: v-for codegen template v-for w/ <slot/> 1`] = `
 return function render(_ctx, _cache) {
   with (_ctx) {
     const { renderList: _renderList, Fragment: _Fragment, openBlock: _openBlock, createBlock: _createBlock, renderSlot: _renderSlot } = _Vue
-
     return (_openBlock(true), _createBlock(_Fragment, null, _renderList(items, (item) => {
       return _renderSlot($slots, \\"default\\")
     }), 256 /* UNKEYED_FRAGMENT */))
@@ -124,7 +116,6 @@ exports[`compiler: v-for codegen v-for on <slot/> 1`] = `
 return function render(_ctx, _cache) {
   with (_ctx) {
     const { renderList: _renderList, Fragment: _Fragment, openBlock: _openBlock, createBlock: _createBlock, renderSlot: _renderSlot } = _Vue
-
     return (_openBlock(true), _createBlock(_Fragment, null, _renderList(items, (item) => {
       return _renderSlot($slots, \\"default\\")
     }), 256 /* UNKEYED_FRAGMENT */))
@@ -138,9 +129,7 @@ exports[`compiler: v-for codegen v-for on element with custom directive 1`] = `
 return function render(_ctx, _cache) {
   with (_ctx) {
     const { renderList: _renderList, Fragment: _Fragment, openBlock: _openBlock, createBlock: _createBlock, resolveDirective: _resolveDirective, createVNode: _createVNode, withDirectives: _withDirectives } = _Vue
-
     const _directive_foo = _resolveDirective(\\"foo\\")
-
     return (_openBlock(true), _createBlock(_Fragment, null, _renderList(list, (i) => {
       return _withDirectives((_openBlock(), _createBlock(\\"div\\", null, null, 512 /* NEED_PATCH */)), [
         [_directive_foo]
@@ -156,7 +145,6 @@ exports[`compiler: v-for codegen v-if + v-for 1`] = `
 return function render(_ctx, _cache) {
   with (_ctx) {
     const { renderList: _renderList, Fragment: _Fragment, openBlock: _openBlock, createBlock: _createBlock, createVNode: _createVNode, createCommentVNode: _createCommentVNode } = _Vue
-
     return ok
       ? (_openBlock(true), _createBlock(_Fragment, { key: 0 }, _renderList(list, (i) => {
           return (_openBlock(), _createBlock(\\"div\\"))
@@ -172,7 +160,6 @@ exports[`compiler: v-for codegen value + key + index 1`] = `
 return function render(_ctx, _cache) {
   with (_ctx) {
     const { renderList: _renderList, Fragment: _Fragment, openBlock: _openBlock, createBlock: _createBlock, createVNode: _createVNode } = _Vue
-
     return (_openBlock(true), _createBlock(_Fragment, null, _renderList(items, (item, key, index) => {
       return (_openBlock(), _createBlock(\\"span\\"))
     }), 256 /* UNKEYED_FRAGMENT */))

--- a/packages/compiler-core/__tests__/transforms/__snapshots__/vIf.spec.ts.snap
+++ b/packages/compiler-core/__tests__/transforms/__snapshots__/vIf.spec.ts.snap
@@ -6,7 +6,6 @@ exports[`compiler: v-if codegen basic v-if 1`] = `
 return function render(_ctx, _cache) {
   with (_ctx) {
     const { createVNode: _createVNode, openBlock: _openBlock, createBlock: _createBlock, createCommentVNode: _createCommentVNode } = _Vue
-
     return ok
       ? (_openBlock(), _createBlock(\\"div\\", { key: 0 }))
       : _createCommentVNode(\\"v-if\\", true)
@@ -20,7 +19,6 @@ exports[`compiler: v-if codegen template v-if 1`] = `
 return function render(_ctx, _cache) {
   with (_ctx) {
     const { createVNode: _createVNode, Fragment: _Fragment, openBlock: _openBlock, createBlock: _createBlock, createCommentVNode: _createCommentVNode } = _Vue
-
     return ok
       ? (_openBlock(), _createBlock(_Fragment, { key: 0 }, [
           _createVNode(\\"div\\"),
@@ -38,7 +36,6 @@ exports[`compiler: v-if codegen template v-if w/ single <slot/> child 1`] = `
 return function render(_ctx, _cache) {
   with (_ctx) {
     const { renderSlot: _renderSlot, createCommentVNode: _createCommentVNode } = _Vue
-
     return ok
       ? _renderSlot($slots, \\"default\\", { key: 0 })
       : _createCommentVNode(\\"v-if\\", true)
@@ -52,7 +49,6 @@ exports[`compiler: v-if codegen v-if + v-else 1`] = `
 return function render(_ctx, _cache) {
   with (_ctx) {
     const { createVNode: _createVNode, openBlock: _openBlock, createBlock: _createBlock, createCommentVNode: _createCommentVNode } = _Vue
-
     return ok
       ? (_openBlock(), _createBlock(\\"div\\", { key: 0 }))
       : (_openBlock(), _createBlock(\\"p\\", { key: 1 }))
@@ -66,7 +62,6 @@ exports[`compiler: v-if codegen v-if + v-else-if + v-else 1`] = `
 return function render(_ctx, _cache) {
   with (_ctx) {
     const { createVNode: _createVNode, openBlock: _openBlock, createBlock: _createBlock, createCommentVNode: _createCommentVNode, Fragment: _Fragment } = _Vue
-
     return ok
       ? (_openBlock(), _createBlock(\\"div\\", { key: 0 }))
       : orNot
@@ -82,7 +77,6 @@ exports[`compiler: v-if codegen v-if + v-else-if 1`] = `
 return function render(_ctx, _cache) {
   with (_ctx) {
     const { createVNode: _createVNode, openBlock: _openBlock, createBlock: _createBlock, createCommentVNode: _createCommentVNode } = _Vue
-
     return ok
       ? (_openBlock(), _createBlock(\\"div\\", { key: 0 }))
       : orNot
@@ -98,7 +92,6 @@ exports[`compiler: v-if codegen v-if on <slot/> 1`] = `
 return function render(_ctx, _cache) {
   with (_ctx) {
     const { renderSlot: _renderSlot, createCommentVNode: _createCommentVNode } = _Vue
-
     return ok
       ? _renderSlot($slots, \\"default\\", { key: 0 })
       : _createCommentVNode(\\"v-if\\", true)
@@ -112,7 +105,6 @@ exports[`compiler: v-if codegen v-if with key 1`] = `
 return function render(_ctx, _cache) {
   with (_ctx) {
     const { createVNode: _createVNode, openBlock: _openBlock, createBlock: _createBlock, createCommentVNode: _createCommentVNode } = _Vue
-
     return ok
       ? (_openBlock(), _createBlock(\\"div\\", { key: \\"some-key\\" }))
       : _createCommentVNode(\\"v-if\\", true)

--- a/packages/compiler-core/__tests__/transforms/__snapshots__/vModel.spec.ts.snap
+++ b/packages/compiler-core/__tests__/transforms/__snapshots__/vModel.spec.ts.snap
@@ -17,7 +17,6 @@ exports[`compiler: transform v-model compound expression 1`] = `
 return function render(_ctx, _cache) {
   with (_ctx) {
     const { createVNode: _createVNode, openBlock: _openBlock, createBlock: _createBlock } = _Vue
-
     return (_openBlock(), _createBlock(\\"input\\", {
       modelValue: model[index],
       \\"onUpdate:modelValue\\": $event => (model[index] = $event)
@@ -43,7 +42,6 @@ exports[`compiler: transform v-model simple expression 1`] = `
 return function render(_ctx, _cache) {
   with (_ctx) {
     const { createVNode: _createVNode, openBlock: _openBlock, createBlock: _createBlock } = _Vue
-
     return (_openBlock(), _createBlock(\\"input\\", {
       modelValue: model,
       \\"onUpdate:modelValue\\": $event => (model = $event)
@@ -58,7 +56,6 @@ exports[`compiler: transform v-model with argument 1`] = `
 return function render(_ctx, _cache) {
   with (_ctx) {
     const { createVNode: _createVNode, openBlock: _openBlock, createBlock: _createBlock } = _Vue
-
     return (_openBlock(), _createBlock(\\"input\\", {
       value: model,
       \\"onUpdate:value\\": $event => (model = $event)
@@ -84,7 +81,6 @@ exports[`compiler: transform v-model with dynamic argument 1`] = `
 return function render(_ctx, _cache) {
   with (_ctx) {
     const { createVNode: _createVNode, openBlock: _openBlock, createBlock: _createBlock } = _Vue
-
     return (_openBlock(), _createBlock(\\"input\\", {
       [value]: model,
       [\\"onUpdate:\\" + value]: $event => (model = $event)

--- a/packages/compiler-core/__tests__/transforms/__snapshots__/vOnce.spec.ts.snap
+++ b/packages/compiler-core/__tests__/transforms/__snapshots__/vOnce.spec.ts.snap
@@ -6,7 +6,6 @@ exports[`compiler: v-once transform as root node 1`] = `
 return function render(_ctx, _cache) {
   with (_ctx) {
     const { setBlockTracking: _setBlockTracking, createVNode: _createVNode } = _Vue
-
     return _cache[1] || (
       _setBlockTracking(-1),
       _cache[1] = _createVNode(\\"div\\", { id: foo }, null, 8 /* PROPS */, [\\"id\\"]),
@@ -23,9 +22,7 @@ exports[`compiler: v-once transform on component 1`] = `
 return function render(_ctx, _cache) {
   with (_ctx) {
     const { setBlockTracking: _setBlockTracking, resolveComponent: _resolveComponent, createVNode: _createVNode, openBlock: _openBlock, createBlock: _createBlock } = _Vue
-
     const _component_Comp = _resolveComponent(\\"Comp\\")
-
     return (_openBlock(), _createBlock(\\"div\\", null, [
       _cache[1] || (
         _setBlockTracking(-1),
@@ -44,7 +41,6 @@ exports[`compiler: v-once transform on nested plain element 1`] = `
 return function render(_ctx, _cache) {
   with (_ctx) {
     const { setBlockTracking: _setBlockTracking, createVNode: _createVNode, openBlock: _openBlock, createBlock: _createBlock } = _Vue
-
     return (_openBlock(), _createBlock(\\"div\\", null, [
       _cache[1] || (
         _setBlockTracking(-1),
@@ -63,7 +59,6 @@ exports[`compiler: v-once transform on slot outlet 1`] = `
 return function render(_ctx, _cache) {
   with (_ctx) {
     const { setBlockTracking: _setBlockTracking, renderSlot: _renderSlot, createVNode: _createVNode, openBlock: _openBlock, createBlock: _createBlock } = _Vue
-
     return (_openBlock(), _createBlock(\\"div\\", null, [
       _cache[1] || (
         _setBlockTracking(-1),
@@ -82,7 +77,6 @@ exports[`compiler: v-once transform with hoistStatic: true 1`] = `
 return function render(_ctx, _cache) {
   with (_ctx) {
     const { setBlockTracking: _setBlockTracking, createVNode: _createVNode, openBlock: _openBlock, createBlock: _createBlock } = _Vue
-
     return (_openBlock(), _createBlock(\\"div\\", null, [
       _cache[1] || (
         _setBlockTracking(-1),

--- a/packages/compiler-core/__tests__/transforms/__snapshots__/vSlot.spec.ts.snap
+++ b/packages/compiler-core/__tests__/transforms/__snapshots__/vSlot.spec.ts.snap
@@ -5,7 +5,6 @@ exports[`compiler: transform component slots dynamically named slots 1`] = `
 
 return function render(_ctx, _cache) {
   const _component_Comp = _resolveComponent(\\"Comp\\")
-
   return (_openBlock(), _createBlock(_component_Comp, null, {
     [_ctx.one]: _withCtx(({ foo }) => [_toDisplayString(foo), _toDisplayString(_ctx.bar)]),
     [_ctx.two]: _withCtx(({ bar }) => [_toDisplayString(_ctx.foo), _toDisplayString(bar)]),
@@ -19,7 +18,6 @@ exports[`compiler: transform component slots implicit default slot 1`] = `
 
 return function render(_ctx, _cache) {
   const _component_Comp = _resolveComponent(\\"Comp\\")
-
   return (_openBlock(), _createBlock(_component_Comp, null, {
     default: _withCtx(() => [
       _createVNode(\\"div\\")
@@ -34,7 +32,6 @@ exports[`compiler: transform component slots named slot with v-for w/ prefixIden
 
 return function render(_ctx, _cache) {
   const _component_Comp = _resolveComponent(\\"Comp\\")
-
   return (_openBlock(), _createBlock(_component_Comp, null, _createSlots({ _: 1 }, [
     _renderList(_ctx.list, (name) => {
       return {
@@ -51,7 +48,6 @@ exports[`compiler: transform component slots named slot with v-if + prefixIdenti
 
 return function render(_ctx, _cache) {
   const _component_Comp = _resolveComponent(\\"Comp\\")
-
   return (_openBlock(), _createBlock(_component_Comp, null, _createSlots({ _: 1 }, [
     (_ctx.ok)
       ? {
@@ -69,9 +65,7 @@ exports[`compiler: transform component slots named slot with v-if + v-else-if + 
 return function render(_ctx, _cache) {
   with (_ctx) {
     const { resolveComponent: _resolveComponent, withCtx: _withCtx, createSlots: _createSlots, createVNode: _createVNode, openBlock: _openBlock, createBlock: _createBlock } = _Vue
-
     const _component_Comp = _resolveComponent(\\"Comp\\")
-
     return (_openBlock(), _createBlock(_component_Comp, null, _createSlots({ _: 1 }, [
       ok
         ? {
@@ -98,9 +92,7 @@ exports[`compiler: transform component slots named slot with v-if 1`] = `
 return function render(_ctx, _cache) {
   with (_ctx) {
     const { resolveComponent: _resolveComponent, withCtx: _withCtx, createSlots: _createSlots, createVNode: _createVNode, openBlock: _openBlock, createBlock: _createBlock } = _Vue
-
     const _component_Comp = _resolveComponent(\\"Comp\\")
-
     return (_openBlock(), _createBlock(_component_Comp, null, _createSlots({ _: 1 }, [
       ok
         ? {
@@ -119,9 +111,7 @@ exports[`compiler: transform component slots named slots w/ implicit default slo
 return function render(_ctx, _cache) {
   with (_ctx) {
     const { createVNode: _createVNode, resolveComponent: _resolveComponent, withCtx: _withCtx, openBlock: _openBlock, createBlock: _createBlock } = _Vue
-
     const _component_Comp = _resolveComponent(\\"Comp\\")
-
     return (_openBlock(), _createBlock(_component_Comp, null, {
       one: _withCtx(() => [\\"foo\\"]),
       default: _withCtx(() => [
@@ -140,7 +130,6 @@ exports[`compiler: transform component slots nested slots scoping 1`] = `
 return function render(_ctx, _cache) {
   const _component_Inner = _resolveComponent(\\"Inner\\")
   const _component_Comp = _resolveComponent(\\"Comp\\")
-
   return (_openBlock(), _createBlock(_component_Comp, null, {
     default: _withCtx(({ foo }) => [
       _createVNode(_component_Inner, null, {
@@ -162,7 +151,6 @@ exports[`compiler: transform component slots on component dynamically named slot
 
 return function render(_ctx, _cache) {
   const _component_Comp = _resolveComponent(\\"Comp\\")
-
   return (_openBlock(), _createBlock(_component_Comp, null, {
     [_ctx.named]: _withCtx(({ foo }) => [_toDisplayString(foo), _toDisplayString(_ctx.bar)]),
     _: 1
@@ -175,7 +163,6 @@ exports[`compiler: transform component slots on component named slot 1`] = `
 
 return function render(_ctx, _cache) {
   const _component_Comp = _resolveComponent(\\"Comp\\")
-
   return (_openBlock(), _createBlock(_component_Comp, null, {
     named: _withCtx(({ foo }) => [_toDisplayString(foo), _toDisplayString(_ctx.bar)]),
     _: 1
@@ -188,7 +175,6 @@ exports[`compiler: transform component slots on-component default slot 1`] = `
 
 return function render(_ctx, _cache) {
   const _component_Comp = _resolveComponent(\\"Comp\\")
-
   return (_openBlock(), _createBlock(_component_Comp, null, {
     default: _withCtx(({ foo }) => [_toDisplayString(foo), _toDisplayString(_ctx.bar)]),
     _: 1
@@ -201,7 +187,6 @@ exports[`compiler: transform component slots template named slots 1`] = `
 
 return function render(_ctx, _cache) {
   const _component_Comp = _resolveComponent(\\"Comp\\")
-
   return (_openBlock(), _createBlock(_component_Comp, null, {
     one: _withCtx(({ foo }) => [_toDisplayString(foo), _toDisplayString(_ctx.bar)]),
     two: _withCtx(({ bar }) => [_toDisplayString(_ctx.foo), _toDisplayString(bar)]),

--- a/packages/compiler-core/src/codegen.ts
+++ b/packages/compiler-core/src/codegen.ts
@@ -225,7 +225,6 @@ export function generate(
           .map(s => `${helperNameMap[s]}: _${helperNameMap[s]}`)
           .join(', ')} } = _Vue`
       )
-      push(`\n`)
       newline()
     }
   }
@@ -250,7 +249,6 @@ export function generate(
     }
   }
   if (ast.components.length || ast.directives.length || ast.temps) {
-    push(`\n`)
     newline()
   }
 

--- a/packages/compiler-dom/__tests__/__snapshots__/index.spec.ts.snap
+++ b/packages/compiler-dom/__tests__/__snapshots__/index.spec.ts.snap
@@ -6,7 +6,6 @@ exports[`compile should contain standard transforms 1`] = `
 return function render(_ctx, _cache) {
   with (_ctx) {
     const { createVNode: _createVNode, Fragment: _Fragment, openBlock: _openBlock, createBlock: _createBlock } = _Vue
-
     return (_openBlock(), _createBlock(_Fragment, null, [
       _createVNode(\\"div\\", { textContent: text }, null, 8 /* PROPS */, [\\"textContent\\"]),
       _createVNode(\\"div\\", { innerHTML: html }, null, 8 /* PROPS */, [\\"innerHTML\\"]),

--- a/packages/compiler-dom/__tests__/transforms/__snapshots__/vModel.spec.ts.snap
+++ b/packages/compiler-dom/__tests__/transforms/__snapshots__/vModel.spec.ts.snap
@@ -6,7 +6,6 @@ exports[`compiler: transform v-model input w/ dynamic v-bind 1`] = `
 return function render(_ctx, _cache) {
   with (_ctx) {
     const { vModelDynamic: _vModelDynamic, mergeProps: _mergeProps, createVNode: _createVNode, withDirectives: _withDirectives, openBlock: _openBlock, createBlock: _createBlock } = _Vue
-
     return _withDirectives((_openBlock(), _createBlock(\\"input\\", _mergeProps(obj, {
       \\"onUpdate:modelValue\\": $event => (model = $event)
     }), null, 16 /* FULL_PROPS */, [\\"onUpdate:modelValue\\"])), [
@@ -22,9 +21,7 @@ exports[`compiler: transform v-model input w/ dynamic v-bind 2`] = `
 return function render(_ctx, _cache) {
   with (_ctx) {
     const { vModelDynamic: _vModelDynamic, resolveDirective: _resolveDirective, createVNode: _createVNode, withDirectives: _withDirectives, openBlock: _openBlock, createBlock: _createBlock } = _Vue
-
     const _directive_bind = _resolveDirective(\\"bind\\")
-
     return _withDirectives((_openBlock(), _createBlock(\\"input\\", {
       \\"onUpdate:modelValue\\": $event => (model = $event)
     }, null, 8 /* PROPS */, [\\"onUpdate:modelValue\\"])), [
@@ -41,7 +38,6 @@ exports[`compiler: transform v-model modifiers .lazy 1`] = `
 return function render(_ctx, _cache) {
   with (_ctx) {
     const { vModelText: _vModelText, createVNode: _createVNode, withDirectives: _withDirectives, openBlock: _openBlock, createBlock: _createBlock } = _Vue
-
     return _withDirectives((_openBlock(), _createBlock(\\"input\\", {
       \\"onUpdate:modelValue\\": $event => (model = $event)
     }, null, 8 /* PROPS */, [\\"onUpdate:modelValue\\"])), [
@@ -62,7 +58,6 @@ exports[`compiler: transform v-model modifiers .number 1`] = `
 return function render(_ctx, _cache) {
   with (_ctx) {
     const { vModelText: _vModelText, createVNode: _createVNode, withDirectives: _withDirectives, openBlock: _openBlock, createBlock: _createBlock } = _Vue
-
     return _withDirectives((_openBlock(), _createBlock(\\"input\\", {
       \\"onUpdate:modelValue\\": $event => (model = $event)
     }, null, 8 /* PROPS */, [\\"onUpdate:modelValue\\"])), [
@@ -83,7 +78,6 @@ exports[`compiler: transform v-model modifiers .trim 1`] = `
 return function render(_ctx, _cache) {
   with (_ctx) {
     const { vModelText: _vModelText, createVNode: _createVNode, withDirectives: _withDirectives, openBlock: _openBlock, createBlock: _createBlock } = _Vue
-
     return _withDirectives((_openBlock(), _createBlock(\\"input\\", {
       \\"onUpdate:modelValue\\": $event => (model = $event)
     }, null, 8 /* PROPS */, [\\"onUpdate:modelValue\\"])), [
@@ -104,7 +98,6 @@ exports[`compiler: transform v-model simple expression 1`] = `
 return function render(_ctx, _cache) {
   with (_ctx) {
     const { vModelText: _vModelText, createVNode: _createVNode, withDirectives: _withDirectives, openBlock: _openBlock, createBlock: _createBlock } = _Vue
-
     return _withDirectives((_openBlock(), _createBlock(\\"input\\", {
       \\"onUpdate:modelValue\\": $event => (model = $event)
     }, null, 8 /* PROPS */, [\\"onUpdate:modelValue\\"])), [
@@ -120,7 +113,6 @@ exports[`compiler: transform v-model simple expression for input (checkbox) 1`] 
 return function render(_ctx, _cache) {
   with (_ctx) {
     const { vModelCheckbox: _vModelCheckbox, createVNode: _createVNode, withDirectives: _withDirectives, openBlock: _openBlock, createBlock: _createBlock } = _Vue
-
     return _withDirectives((_openBlock(), _createBlock(\\"input\\", {
       type: \\"checkbox\\",
       \\"onUpdate:modelValue\\": $event => (model = $event)
@@ -137,9 +129,7 @@ exports[`compiler: transform v-model simple expression for input (dynamic type) 
 return function render(_ctx, _cache) {
   with (_ctx) {
     const { vModelDynamic: _vModelDynamic, resolveDirective: _resolveDirective, createVNode: _createVNode, withDirectives: _withDirectives, openBlock: _openBlock, createBlock: _createBlock } = _Vue
-
     const _directive_bind = _resolveDirective(\\"bind\\")
-
     return _withDirectives((_openBlock(), _createBlock(\\"input\\", {
       \\"onUpdate:modelValue\\": $event => (model = $event)
     }, null, 8 /* PROPS */, [\\"onUpdate:modelValue\\"])), [
@@ -156,7 +146,6 @@ exports[`compiler: transform v-model simple expression for input (radio) 1`] = `
 return function render(_ctx, _cache) {
   with (_ctx) {
     const { vModelRadio: _vModelRadio, createVNode: _createVNode, withDirectives: _withDirectives, openBlock: _openBlock, createBlock: _createBlock } = _Vue
-
     return _withDirectives((_openBlock(), _createBlock(\\"input\\", {
       type: \\"radio\\",
       \\"onUpdate:modelValue\\": $event => (model = $event)
@@ -173,7 +162,6 @@ exports[`compiler: transform v-model simple expression for input (text) 1`] = `
 return function render(_ctx, _cache) {
   with (_ctx) {
     const { vModelText: _vModelText, createVNode: _createVNode, withDirectives: _withDirectives, openBlock: _openBlock, createBlock: _createBlock } = _Vue
-
     return _withDirectives((_openBlock(), _createBlock(\\"input\\", {
       type: \\"text\\",
       \\"onUpdate:modelValue\\": $event => (model = $event)
@@ -190,7 +178,6 @@ exports[`compiler: transform v-model simple expression for select 1`] = `
 return function render(_ctx, _cache) {
   with (_ctx) {
     const { vModelSelect: _vModelSelect, createVNode: _createVNode, withDirectives: _withDirectives, openBlock: _openBlock, createBlock: _createBlock } = _Vue
-
     return _withDirectives((_openBlock(), _createBlock(\\"select\\", {
       \\"onUpdate:modelValue\\": $event => (model = $event)
     }, null, 8 /* PROPS */, [\\"onUpdate:modelValue\\"])), [
@@ -206,7 +193,6 @@ exports[`compiler: transform v-model simple expression for textarea 1`] = `
 return function render(_ctx, _cache) {
   with (_ctx) {
     const { vModelText: _vModelText, createVNode: _createVNode, withDirectives: _withDirectives, openBlock: _openBlock, createBlock: _createBlock } = _Vue
-
     return _withDirectives((_openBlock(), _createBlock(\\"textarea\\", {
       \\"onUpdate:modelValue\\": $event => (model = $event)
     }, null, 8 /* PROPS */, [\\"onUpdate:modelValue\\"])), [

--- a/packages/compiler-dom/__tests__/transforms/__snapshots__/vShow.spec.ts.snap
+++ b/packages/compiler-dom/__tests__/transforms/__snapshots__/vShow.spec.ts.snap
@@ -6,7 +6,6 @@ exports[`compiler: v-show transform simple expression 1`] = `
 return function render(_ctx, _cache) {
   with (_ctx) {
     const { vShow: _vShow, createVNode: _createVNode, withDirectives: _withDirectives, openBlock: _openBlock, createBlock: _createBlock } = _Vue
-
     return _withDirectives((_openBlock(), _createBlock(\\"div\\", null, null, 512 /* NEED_PATCH */)), [
       [_vShow, a]
     ])

--- a/packages/compiler-ssr/__tests__/ssrComponent.spec.ts
+++ b/packages/compiler-ssr/__tests__/ssrComponent.spec.ts
@@ -5,10 +5,9 @@ describe('ssr: components', () => {
     expect(compile(`<foo id="a" :prop="b" />`).code).toMatchInlineSnapshot(`
       "const { resolveComponent: _resolveComponent } = require(\\"vue\\")
       const { ssrRenderComponent: _ssrRenderComponent } = require(\\"@vue/server-renderer\\")
-
+      
       return function ssrRender(_ctx, _push, _parent) {
         const _component_foo = _resolveComponent(\\"foo\\")
-
         _push(_ssrRenderComponent(_component_foo, {
           id: \\"a\\",
           prop: _ctx.b
@@ -44,10 +43,9 @@ describe('ssr: components', () => {
       expect(compile(`<foo>hello<div/></foo>`).code).toMatchInlineSnapshot(`
         "const { resolveComponent: _resolveComponent, withCtx: _withCtx, createVNode: _createVNode, createTextVNode: _createTextVNode } = require(\\"vue\\")
         const { ssrRenderComponent: _ssrRenderComponent } = require(\\"@vue/server-renderer\\")
-
+        
         return function ssrRender(_ctx, _push, _parent) {
           const _component_foo = _resolveComponent(\\"foo\\")
-
           _push(_ssrRenderComponent(_component_foo, null, {
             default: _withCtx((_, _push, _parent, _scopeId) => {
               if (_push) {
@@ -70,10 +68,9 @@ describe('ssr: components', () => {
         .toMatchInlineSnapshot(`
         "const { resolveComponent: _resolveComponent, withCtx: _withCtx, toDisplayString: _toDisplayString, createTextVNode: _createTextVNode } = require(\\"vue\\")
         const { ssrRenderComponent: _ssrRenderComponent, ssrInterpolate: _ssrInterpolate } = require(\\"@vue/server-renderer\\")
-
+        
         return function ssrRender(_ctx, _push, _parent) {
           const _component_foo = _resolveComponent(\\"foo\\")
-
           _push(_ssrRenderComponent(_component_foo, null, {
             default: _withCtx(({ msg }, _push, _parent, _scopeId) => {
               if (_push) {
@@ -99,10 +96,9 @@ describe('ssr: components', () => {
       ).toMatchInlineSnapshot(`
         "const { resolveComponent: _resolveComponent, withCtx: _withCtx, createTextVNode: _createTextVNode } = require(\\"vue\\")
         const { ssrRenderComponent: _ssrRenderComponent } = require(\\"@vue/server-renderer\\")
-
+        
         return function ssrRender(_ctx, _push, _parent) {
           const _component_foo = _resolveComponent(\\"foo\\")
-
           _push(_ssrRenderComponent(_component_foo, null, {
             default: _withCtx((_, _push, _parent, _scopeId) => {
               if (_push) {
@@ -136,10 +132,9 @@ describe('ssr: components', () => {
       ).toMatchInlineSnapshot(`
         "const { resolveComponent: _resolveComponent, withCtx: _withCtx, createTextVNode: _createTextVNode, createSlots: _createSlots } = require(\\"vue\\")
         const { ssrRenderComponent: _ssrRenderComponent } = require(\\"@vue/server-renderer\\")
-
+        
         return function ssrRender(_ctx, _push, _parent) {
           const _component_foo = _resolveComponent(\\"foo\\")
-
           _push(_ssrRenderComponent(_component_foo, null, _createSlots({ _: 1 }, [
             (_ctx.ok)
               ? {
@@ -168,10 +163,9 @@ describe('ssr: components', () => {
       ).toMatchInlineSnapshot(`
         "const { resolveComponent: _resolveComponent, withCtx: _withCtx, toDisplayString: _toDisplayString, createTextVNode: _createTextVNode, renderList: _renderList, createSlots: _createSlots } = require(\\"vue\\")
         const { ssrRenderComponent: _ssrRenderComponent, ssrInterpolate: _ssrInterpolate } = require(\\"@vue/server-renderer\\")
-
+        
         return function ssrRender(_ctx, _push, _parent) {
           const _component_foo = _resolveComponent(\\"foo\\")
-
           _push(_ssrRenderComponent(_component_foo, null, _createSlots({ _: 1 }, [
             _renderList(_ctx.names, (key) => {
               return {
@@ -209,10 +203,9 @@ describe('ssr: components', () => {
       ).toMatchInlineSnapshot(`
         "const { resolveComponent: _resolveComponent, withCtx: _withCtx, renderList: _renderList, Fragment: _Fragment, openBlock: _openBlock, createBlock: _createBlock, createVNode: _createVNode, createCommentVNode: _createCommentVNode } = require(\\"vue\\")
         const { ssrRenderComponent: _ssrRenderComponent, ssrRenderList: _ssrRenderList } = require(\\"@vue/server-renderer\\")
-
+        
         return function ssrRender(_ctx, _push, _parent) {
           const _component_foo = _resolveComponent(\\"foo\\")
-
           _push(_ssrRenderComponent(_component_foo, null, {
             foo: _withCtx(({ list }, _push, _parent, _scopeId) => {
               if (_push) {
@@ -287,10 +280,9 @@ describe('ssr: components', () => {
         .toMatchInlineSnapshot(`
         "const { resolveComponent: _resolveComponent } = require(\\"vue\\")
         const { ssrRenderComponent: _ssrRenderComponent } = require(\\"@vue/server-renderer\\")
-
+        
         return function ssrRender(_ctx, _push, _parent) {
           const _component_foo = _resolveComponent(\\"foo\\")
-
           _push(_ssrRenderComponent(_component_foo, null, null, _parent))
         }"
       `)

--- a/packages/compiler-ssr/__tests__/ssrElement.spec.ts
+++ b/packages/compiler-ssr/__tests__/ssrElement.spec.ts
@@ -52,10 +52,9 @@ describe('ssr: element', () => {
       expect(compile(`<textarea v-bind="obj">fallback</textarea>`).code)
         .toMatchInlineSnapshot(`
         "const { ssrRenderAttrs: _ssrRenderAttrs, ssrInterpolate: _ssrInterpolate } = require(\\"@vue/server-renderer\\")
-
+        
         return function ssrRender(_ctx, _push, _parent) {
           let _temp0
-
           _push(\`<textarea\${
             _ssrRenderAttrs(_temp0 = _ctx.obj, \\"textarea\\")
           }>\${

--- a/packages/compiler-ssr/__tests__/ssrScopeId.spec.ts
+++ b/packages/compiler-ssr/__tests__/ssrScopeId.spec.ts
@@ -25,10 +25,9 @@ describe('ssr: scopeId', () => {
     ).toMatchInlineSnapshot(`
       "const { resolveComponent: _resolveComponent, withCtx: _withCtx, createTextVNode: _createTextVNode } = require(\\"vue\\")
       const { ssrRenderComponent: _ssrRenderComponent } = require(\\"@vue/server-renderer\\")
-
+      
       return function ssrRender(_ctx, _push, _parent) {
         const _component_foo = _resolveComponent(\\"foo\\")
-
         _push(_ssrRenderComponent(_component_foo, null, {
           default: _withCtx((_, _push, _parent, _scopeId) => {
             if (_push) {
@@ -53,10 +52,9 @@ describe('ssr: scopeId', () => {
     ).toMatchInlineSnapshot(`
       "const { resolveComponent: _resolveComponent, withCtx: _withCtx, createVNode: _createVNode } = require(\\"vue\\")
       const { ssrRenderComponent: _ssrRenderComponent } = require(\\"@vue/server-renderer\\")
-
+      
       return function ssrRender(_ctx, _push, _parent) {
         const _component_foo = _resolveComponent(\\"foo\\")
-
         _push(_ssrRenderComponent(_component_foo, null, {
           default: _withCtx((_, _push, _parent, _scopeId) => {
             if (_push) {
@@ -81,11 +79,10 @@ describe('ssr: scopeId', () => {
     ).toMatchInlineSnapshot(`
       "const { resolveComponent: _resolveComponent, withCtx: _withCtx, createVNode: _createVNode } = require(\\"vue\\")
       const { ssrRenderComponent: _ssrRenderComponent } = require(\\"@vue/server-renderer\\")
-
+      
       return function ssrRender(_ctx, _push, _parent) {
         const _component_foo = _resolveComponent(\\"foo\\")
         const _component_bar = _resolveComponent(\\"bar\\")
-
         _push(_ssrRenderComponent(_component_foo, null, {
           default: _withCtx((_, _push, _parent, _scopeId) => {
             if (_push) {

--- a/packages/compiler-ssr/__tests__/ssrSuspense.spec.ts
+++ b/packages/compiler-ssr/__tests__/ssrSuspense.spec.ts
@@ -5,10 +5,9 @@ describe('ssr compile: suspense', () => {
     expect(compile(`<suspense><foo/></suspense>`).code).toMatchInlineSnapshot(`
       "const { resolveComponent: _resolveComponent, withCtx: _withCtx } = require(\\"vue\\")
       const { ssrRenderComponent: _ssrRenderComponent, ssrRenderSuspense: _ssrRenderSuspense } = require(\\"@vue/server-renderer\\")
-
+      
       return function ssrRender(_ctx, _push, _parent) {
         const _component_foo = _resolveComponent(\\"foo\\")
-
         _ssrRenderSuspense(_push, {
           default: () => {
             _push(_ssrRenderComponent(_component_foo, null, null, _parent))
@@ -32,10 +31,9 @@ describe('ssr compile: suspense', () => {
     ).toMatchInlineSnapshot(`
       "const { resolveComponent: _resolveComponent, withCtx: _withCtx } = require(\\"vue\\")
       const { ssrRenderComponent: _ssrRenderComponent, ssrRenderSuspense: _ssrRenderSuspense } = require(\\"@vue/server-renderer\\")
-
+      
       return function ssrRender(_ctx, _push, _parent) {
         const _component_foo = _resolveComponent(\\"foo\\")
-
         _ssrRenderSuspense(_push, {
           default: () => {
             _push(_ssrRenderComponent(_component_foo, null, null, _parent))

--- a/packages/compiler-ssr/__tests__/ssrVModel.spec.ts
+++ b/packages/compiler-ssr/__tests__/ssrVModel.spec.ts
@@ -114,10 +114,9 @@ describe('ssr: v-model', () => {
       .toMatchInlineSnapshot(`
       "const { mergeProps: _mergeProps } = require(\\"vue\\")
       const { ssrRenderAttrs: _ssrRenderAttrs, ssrGetDynamicModelProps: _ssrGetDynamicModelProps } = require(\\"@vue/server-renderer\\")
-
+      
       return function ssrRender(_ctx, _push, _parent) {
         let _temp0
-
         _push(\`<input\${_ssrRenderAttrs((_temp0 = _ctx.obj, _mergeProps(_temp0, _ssrGetDynamicModelProps(_temp0, _ctx.foo))))}>\`)
       }"
     `)
@@ -126,10 +125,9 @@ describe('ssr: v-model', () => {
       .toMatchInlineSnapshot(`
       "const { mergeProps: _mergeProps } = require(\\"vue\\")
       const { ssrRenderAttrs: _ssrRenderAttrs, ssrGetDynamicModelProps: _ssrGetDynamicModelProps } = require(\\"@vue/server-renderer\\")
-
+      
       return function ssrRender(_ctx, _push, _parent) {
         let _temp0
-
         _push(\`<input\${_ssrRenderAttrs((_temp0 = _mergeProps({ id: \\"x\\" }, _ctx.obj, { class: \\"y\\" }), _mergeProps(_temp0, _ssrGetDynamicModelProps(_temp0, _ctx.foo))))}>\`)
       }"
     `)


### PR DESCRIPTION
```diff
+ vue.global.prod.js min:95.79kb / gzip:36.42kb / brotli:32.77kb
- vue.global.prod.js min:95.81kb / gzip:36.43kb / brotli:32.77kb
```

main changes, in `codegen.ts`

```diff
diff --git a/packages/compiler-core/src/codegen.ts b/packages/compiler-core/src/codegen.ts
index d7d8b8bf..2f06ed58 100644
--- a/packages/compiler-core/src/codegen.ts
+++ b/packages/compiler-core/src/codegen.ts
@@ -225,7 +225,6 @@ export function generate(
           .map(s => `${helperNameMap[s]}: _${helperNameMap[s]}`)
           .join(', ')} } = _Vue`
       )
-      push(`\n`)
diff --git a/packages/compiler-core/src/codegen.ts b/packages/compiler-core/src/codegen.ts
index d7d8b8bf..2f06ed58 100644
--- a/packages/compiler-core/src/codegen.ts
+++ b/packages/compiler-core/src/codegen.ts
@@ -225,7 +225,6 @@ export function generate(
           .map(s => `${helperNameMap[s]}: _${helperNameMap[s]}`)
           .join(', ')} } = _Vue`
       )
-      push(`\n`)
       newline()
     }
```