### PR TITLE
fix(compiler-dom): should bail hoisted on break content with innerHTM…

### DIFF
--- a/packages/compiler-dom/__tests__/transforms/stringifyStatic.spec.ts
+++ b/packages/compiler-dom/__tests__/transforms/stringifyStatic.spec.ts
@@ -237,6 +237,17 @@ describe('stringify static html', () => {
     expect(ast.hoists[0]).toMatchObject({
       type: NodeTypes.VNODE_CALL // not CALL_EXPRESSION
     })
+    
+    const { ast: ast2 } = compileWithStringify(
+      `<div><div>${repeat(
+        `<span class="foo">foo</span>`,
+        StringifyThresholds.ELEMENT_WITH_BINDING_COUNT
+      )}<input :indeterminate="true"></div></div>`
+    )
+    expect(ast2.hoists.length).toBe(1)
+    expect(ast2.hoists[0]).toMatchObject({
+      type: NodeTypes.VNODE_CALL // not CALL_EXPRESSION
+    })
   })
 
   // https://github.com/vitejs/vite/issues/226
@@ -249,17 +260,6 @@ describe('stringify static html', () => {
     )
     expect(ast.hoists.length).toBe(1)
     expect(ast.hoists[0]).toMatchObject({
-      type: NodeTypes.VNODE_CALL // not CALL_EXPRESSION
-    })
-
-    const { ast: ast2 } = compileWithStringify(
-      `<div><div>${repeat(
-        `<span class="foo">foo</span>`,
-        StringifyThresholds.ELEMENT_WITH_BINDING_COUNT
-      )}<input :indeterminate="true"></div></div>`
-    )
-    expect(ast2.hoists.length).toBe(1)
-    expect(ast2.hoists[0]).toMatchObject({
       type: NodeTypes.VNODE_CALL // not CALL_EXPRESSION
     })
   })

--- a/packages/compiler-dom/__tests__/transforms/stringifyStatic.spec.ts
+++ b/packages/compiler-dom/__tests__/transforms/stringifyStatic.spec.ts
@@ -225,4 +225,18 @@ describe('stringify static html', () => {
       type: NodeTypes.VNODE_CALL // not CALL_EXPRESSION
     })
   })
+
+  // https://github.com/vitejs/vite/issues/226
+  test('should bail on break content with innerHTML (eg.tables related tags)', () => {
+    const { ast } = compileWithStringify(
+      `<div><div>${repeat(
+        `<tr class="foo">foo</tr>`,
+        StringifyThresholds.ELEMENT_WITH_BINDING_COUNT
+      )}</div></div>`
+    )
+    expect(ast.hoists.length).toBe(1)
+    expect(ast.hoists[0]).toMatchObject({
+      type: NodeTypes.VNODE_CALL // not CALL_EXPRESSION
+    })
+  })
 })

--- a/packages/compiler-dom/__tests__/transforms/stringifyStatic.spec.ts
+++ b/packages/compiler-dom/__tests__/transforms/stringifyStatic.spec.ts
@@ -225,7 +225,7 @@ describe('stringify static html', () => {
       type: NodeTypes.VNODE_CALL // not CALL_EXPRESSION
     })
   })
-  
+
   test('should bail on non attribute bindings', () => {
     const { ast } = compileWithStringify(
       `<div><div>${repeat(
@@ -237,7 +237,7 @@ describe('stringify static html', () => {
     expect(ast.hoists[0]).toMatchObject({
       type: NodeTypes.VNODE_CALL // not CALL_EXPRESSION
     })
-    
+
     const { ast: ast2 } = compileWithStringify(
       `<div><div>${repeat(
         `<span class="foo">foo</span>`,

--- a/packages/compiler-dom/src/transforms/stringifyStatic.ts
+++ b/packages/compiler-dom/src/transforms/stringifyStatic.ts
@@ -25,7 +25,8 @@ import {
   toDisplayString,
   normalizeClass,
   normalizeStyle,
-  stringifyStyle
+  stringifyStyle,
+  makeMap
 } from '@vue/shared'
 
 export const enum StringifyThresholds {
@@ -59,6 +60,12 @@ type StringifiableNode = PlainElementNode | TextCallNode
  * This optimization is only performed in Node.js.
  */
 export const stringifyStatic: HoistTransform = (children, context) => {
+  if (
+    context.parent!.type === NodeTypes.ELEMENT &&
+    canNotStringifiableTag((context.parent as PlainElementNode).tag)
+  ) {
+    return
+  }
   let nc = 0 // current node count
   let ec = 0 // current element with binding count
   const currentChunk: StringifiableNode[] = []
@@ -135,6 +142,8 @@ const dataAriaRE = /^(data|aria)-/
 const isStringifiableAttr = (name: string) => {
   return isKnownAttr(name) || dataAriaRE.test(name)
 }
+
+const canNotStringifiableTag = makeMap('p,table,thead,tr,th,tbody,td,colspan')
 
 const replaceHoist = (
   node: StringifiableNode,


### PR DESCRIPTION
…L (eg.tables related tags)

fix #https://github.com/vitejs/vite/issues/226

## Bug Reson
Look like it's caused by innerHtml error with table related tags.

## Sloution  DOMParser(Fail)
``` js
 const div = "<div><span class=\"foo\"></span><span class=\"foo\"></span><span class=\"foo\"></span><span class=\"foo\"></span><span class=\"foo\"></span></div>"
    const doc = new DOMParser().parseFromString(div, "text/html")
    console.log(doc.body.innerHTML)
    console.log(div)
    console.log(div.trim() === document.body.innerHTML.trim())
    console.log(div.length, document.body.innerHTML.length)
```
``` js
// run result
<div><span class="foo"></span><span class="foo"></span><span class="foo"></span><span class="foo"></span><span class="foo"></span></div>
<div><span class="foo"></span><span class="foo"></span><span class="foo"></span><span class="foo"></span><span class="foo"></span></div>
false
136 4023
```
I think can be parse by DOMParser, but it meet error for normal case.This is brower test result. And other run result in jest jsdom.
```
<div><span class="\&quot;foo\&quot;"></span><span class="\&quot;foo\&quot;"></span><span class="\&quot;foo\&quot;"></span><span class="\&quot;foo\&quot;"></span><span class="\&quot;foo\&quot;"></span></div>
```
