### PR TITLE
Feat/proxy performance

### DIFF
--- a/packages/runtime-core/src/component.ts
+++ b/packages/runtime-core/src/component.ts
@@ -13,7 +13,8 @@ import {
   exposeSetupStateOnRenderContext,
   createInstanceProxy,
   createInstanceWithProxy,
-  PropGetterFactory
+  PropGetterFactory,
+  PropGetter
 } from './componentProxy'
 import { ComponentPropsOptions, initProps } from './componentProps'
 import { Slots, initSlots, InternalSlots } from './componentSlots'
@@ -188,7 +189,7 @@ export interface ComponentInternalInstance {
   /**
    * Provides a quick property accessor in the context proxy.
    */
-  propGetters: Record<string, () => any> | null
+  propGetters: Record<string, PropGetter> | null
 
   /**
    * cache for render function values that rely on _ctx but won't need updates

--- a/packages/runtime-core/src/component.ts
+++ b/packages/runtime-core/src/component.ts
@@ -13,7 +13,6 @@ import {
   exposeSetupStateOnRenderContext,
   createInstanceProxy,
   createInstanceWithProxy,
-  PropGetterFactory,
   PropGetter
 } from './componentProxy'
 import { ComponentPropsOptions, initProps } from './componentProps'
@@ -182,11 +181,6 @@ export interface ComponentInternalInstance {
   effects: ReactiveEffect[] | null
 
   /**
-   * Creates a fast instance/property-specific access function to be used in the context proxy.
-   */
-  propGetterFactory: PropGetterFactory | null
-
-  /**
    * Provides a quick property accessor in the context proxy.
    */
   propGetters: Record<string, PropGetter> | null
@@ -351,7 +345,6 @@ export function createComponentInstance(
     withProxy: null,
     effects: null,
     provides: parent ? parent.provides : Object.create(appContext.provides),
-    propGetterFactory: null,
     propGetters: null,
 
     renderCache: [],

--- a/packages/runtime-core/src/componentProxy.ts
+++ b/packages/runtime-core/src/componentProxy.ts
@@ -201,7 +201,6 @@ const PublicInstanceProxyHandlers: ProxyHandler<any> = {
           value
         })
       } else {
-        console.log('setting', key)
         ctx[key] = value
       }
     }

--- a/packages/runtime-core/src/componentProxy.ts
+++ b/packages/runtime-core/src/componentProxy.ts
@@ -375,7 +375,7 @@ function createMemberPropGetter(obj: any, key: string): PropGetter {
   return new Function('o', `return () => o["${key}"]`)(obj)
 }
 
-type PropGetter = () => any
+export type PropGetter = () => any
 export type PropGetterFactory = (key: string) => PropGetter
 
 // dev only

--- a/packages/runtime-core/src/componentProxy.ts
+++ b/packages/runtime-core/src/componentProxy.ts
@@ -129,6 +129,8 @@ function getPropGetter(
 function getPublicInstanceProxyHandlers(
   instance: ComponentInternalInstance
 ): ProxyHandler<any> {
+  // We create a new get and has function per instance, because it allows us to
+  // scope the instance object directly making the (total) 'get' time ~25% faster.
   return {
     ...PublicInstanceProxyHandlers,
     get(c: ComponentRenderContext, key: string) {


### PR DESCRIPTION
As mentioned in https://github.com/vuejs/vue-next/issues/1227, variable access from templates is a major hotspot in terms of performance. This PR reduces up to 80% of the variable access time. It does so by creating ultra-fast and optimizable getter functions.

The peformance difference can be seen here. Notice that the left side is with the changes in this PR, right side is the current Vue implementation. The 'get' time is much lower (70 vs 420) and overall it causes a performance improvement of about 10%.

![performance](https://user-images.githubusercontent.com/120531/83033513-7e402580-a037-11ea-89ae-b963a01b7fd0.png)

In terms of memory usage, getter functions must be created per instance. Initial tests proved that it seems to has little effect on the memory usage.