### PR TITLE
fix(compiler-core): generate the correct tree if comment is between if/else

### DIFF
--- a/packages/compiler-core/src/parse.ts
+++ b/packages/compiler-core/src/parse.ts
@@ -239,16 +239,15 @@ function parseChildren(
     }
   }
 
-  return removedWhitespace ? nodes.filter(Boolean) : nodes
+  const processedNodes = __DEV__
+    ? nodes
+    : /// ignore comments in production check issue #1256
+      nodes.filter(x => !x || x.type !== NodeTypes.COMMENT)
+
+  return removedWhitespace ? processedNodes.filter(Boolean) : processedNodes
 }
 
 function pushNode(nodes: TemplateChildNode[], node: TemplateChildNode): void {
-  // ignore comments in production
-  /* istanbul ignore next */
-  if (!__DEV__ && node.type === NodeTypes.COMMENT) {
-    return
-  }
-
   if (node.type === NodeTypes.TEXT) {
     const prev = last(nodes)
     // Merge if both this and the previous node are text and those are


### PR DESCRIPTION
fix https://github.com/vuejs/vue-next/issues/1256

Different approach than https://github.com/vuejs/vue-next/pull/1260 

This parses the template as in dev, but strips the `Comment` nodes at the end, this ensures the whiteline removal still runs.

EDIT: 
```html
<div id="app">
	<div />
	<!-- loading -->
	<div />

	Hello
</div>
```

ouputs: 
```ts
import { createVNode as _createVNode, createTextVNode as _createTextVNode, openBlock as _openBlock, createBlock as _createBlock } from "vue"

export function render(_ctx, _cache) {
  return (_openBlock(), _createBlock("div", { id: "app" }, [
    _createVNode("div"),
    _createVNode("div"),
    _createTextVNode(" Hello ")
  ]))
}
```
