### PR TITLE
fix(compiler-core): ignore empty siblings between v-if and v-else-if/else

### DIFF
--- a/packages/compiler-core/src/transforms/vIf.ts
+++ b/packages/compiler-core/src/transforms/vIf.ts
@@ -109,12 +109,20 @@ export function processIf(
     const siblings = context.parent!.children
     const comments = []
     let i = siblings.indexOf(node)
+    console.log('siub', [...siblings])
     while (i-- >= -1) {
       const sibling = siblings[i]
       if (__DEV__ && sibling && sibling.type === NodeTypes.COMMENT) {
         context.removeNode(sibling)
         comments.unshift(sibling)
         continue
+      }
+      // check for empty text nodes
+      if (sibling && sibling.type === NodeTypes.TEXT) {
+        if (!/[^\t\r\n\f ]/.test(sibling.content)) {
+          context.removeNode(sibling)
+          continue
+        }
       }
       if (sibling && sibling.type === NodeTypes.IF) {
         // move the node to the if node's branches

--- a/packages/compiler-core/src/transforms/vIf.ts
+++ b/packages/compiler-core/src/transforms/vIf.ts
@@ -109,7 +109,6 @@ export function processIf(
     const siblings = context.parent!.children
     const comments = []
     let i = siblings.indexOf(node)
-    console.log('siub', [...siblings])
     while (i-- >= -1) {
       const sibling = siblings[i]
       if (__DEV__ && sibling && sibling.type === NodeTypes.COMMENT) {


### PR DESCRIPTION
fix https://github.com/vuejs/vue-next/issues/1256

Instead of using at the compiler parsing as in https://github.com/vuejs/vue-next/pull/1262, we ignore the whitespace elements when getting the siblings for `vif`

 https://github.com/vuejs/vue-next/blob/master/packages/compiler-core/src/parse.ts#L203 

EDIT: 
```html
<div id="app">
	<div />
	<!-- loading -->
	<div />

	Hello
</div>
```

```ts
import { createVNode as _createVNode, createTextVNode as _createTextVNode, openBlock as _openBlock, createBlock as _createBlock } from "vue"

export function render(_ctx, _cache) {
  return (_openBlock(), _createBlock("div", { id: "app" }, [
    _createVNode("div"),
    _createTextVNode(" " + " ", 1 /* TEXT */),
    _createVNode("div"),
    _createTextVNode(" Hello ")
  ]))
}
```

## NOTE  
` _createTextVNode(" " + " ", 1 /* TEXT */),`  shouldn't be in the output, for not having it on the output https://github.com/vuejs/vue-next/pull/1262 does the job