### PR TITLE
fix(compiler-core): keep event handlers noninitial arguments

### DIFF
--- a/packages/compiler-core/__tests__/transforms/__snapshots__/hoistStatic.spec.ts.snap
+++ b/packages/compiler-core/__tests__/transforms/__snapshots__/hoistStatic.spec.ts.snap
@@ -209,7 +209,7 @@ export function render(_ctx, _cache) {
   return (_openBlock(), _createBlock(\\"div\\", null, [
     _createVNode(\\"div\\", null, [
       _createVNode(\\"div\\", {
-        onClick: _cache[1] || (_cache[1] = $event => (_ctx.foo($event)))
+        onClick: _cache[1] || (_cache[1] = ($event, ...args) => (_ctx.foo($event, ...args)))
       })
     ])
   ]))

--- a/packages/compiler-core/__tests__/transforms/vOn.spec.ts
+++ b/packages/compiler-core/__tests__/transforms/vOn.spec.ts
@@ -142,7 +142,7 @@ describe('compiler: transform v-on', () => {
           key: { content: `onClick` },
           value: {
             type: NodeTypes.COMPOUND_EXPRESSION,
-            children: [`$event => (`, { content: `i++` }, `)`]
+            children: [`($event, ...args) => (`, { content: `i++` }, `)`]
           }
         }
       ]
@@ -160,7 +160,11 @@ describe('compiler: transform v-on', () => {
             // should wrap with `{` for multiple statements
             // in this case the return value is discarded and the behavior is
             // consistent with 2.x
-            children: [`$event => {`, { content: `foo();bar()` }, `}`]
+            children: [
+              `($event, ...args) => {`,
+              { content: `foo();bar()` },
+              `}`
+            ]
           }
         }
       ]
@@ -178,7 +182,7 @@ describe('compiler: transform v-on', () => {
           value: {
             type: NodeTypes.COMPOUND_EXPRESSION,
             children: [
-              `$event => (`,
+              `($event, ...args) => (`,
               {
                 type: NodeTypes.COMPOUND_EXPRESSION,
                 children: [
@@ -208,7 +212,7 @@ describe('compiler: transform v-on', () => {
           value: {
             type: NodeTypes.COMPOUND_EXPRESSION,
             children: [
-              `$event => {`,
+              `($event, ...args) => {`,
               {
                 children: [
                   { content: `_ctx.foo` },
@@ -382,7 +386,11 @@ describe('compiler: transform v-on', () => {
         index: 1,
         value: {
           type: NodeTypes.COMPOUND_EXPRESSION,
-          children: [`$event => (`, { content: `_ctx.foo($event)` }, `)`]
+          children: [
+            `($event, ...args) => (`,
+            { content: `_ctx.foo($event, ...args)` },
+            `)`
+          ]
         }
       })
     })
@@ -426,7 +434,7 @@ describe('compiler: transform v-on', () => {
         value: {
           type: NodeTypes.COMPOUND_EXPRESSION,
           children: [
-            `$event => (`,
+            `($event, ...args) => (`,
             { children: [{ content: `_ctx.foo` }, `++`] },
             `)`
           ]

--- a/packages/compiler-core/src/transforms/vOn.ts
+++ b/packages/compiler-core/src/transforms/vOn.ts
@@ -82,9 +82,9 @@ export const transformOn: DirectiveTransform = (
       // avoiding the need to be patched.
       if (isCacheable && isMemberExp) {
         if (exp.type === NodeTypes.SIMPLE_EXPRESSION) {
-          exp.content += `($event)`
+          exp.content += `($event, ...args)`
         } else {
-          exp.children.push(`($event)`)
+          exp.children.push(`($event, ...args)`)
         }
       }
     }
@@ -92,7 +92,7 @@ export const transformOn: DirectiveTransform = (
     if (isInlineStatement || (isCacheable && isMemberExp)) {
       // wrap inline statement in a function expression
       exp = createCompoundExpression([
-        `$event => ${hasMultipleStatements ? `{` : `(`}`,
+        `($event, ...args) => ${hasMultipleStatements ? `{` : `(`}`,
         exp,
         hasMultipleStatements ? `}` : `)`
       ])


### PR DESCRIPTION
When the compiler encounters a template such as this
```html
<AComponent @an-event="anEventHandler" />
```
the function passed as the prop `onAnEvent` to `<AComponent>` is generated like this
```js
$event => _ctx.anEventHandler($event)
```

This becomes a problem when the event is emitted with more than one argument. Only the first argument, `$event`, is passed to the event handler.
This is especially evident when wanting to use the transition enter/leave's `resolve` function.
```html
<script>
export default {
  setup: () => ({
    onEnter (el, resolve) {
      ...
      resolve() // Uncaught TypeError: resolve is not a function
    }
  })
}
</script>

<template>
  <transition @enter="onEnter">
    <... v-if="..." />
  </transition>
</template>
```

This PR fixes this by replacing `$event` with `($event, ...args)` in code generation for the vOn transform.
Resulting in functions like `($event, ...args) => _ctx.eventHandler($event, ...args)`.

### Note
This is my first pr to vuejs, and I have limited experience in working with tests. Although the tests are passing, I'm not convinced everything is correct.
When working to resolve this issue, [this line](https://github.com/cathrinevaage/vue-next/blob/8e45c556c105c3baa5ceeb54d30ea057b969835b/packages/compiler-core/src/transforms/vOn.ts#L87) was never touched. I can also see that the coverage test doesn't touch it either. I haven't quite understood what it does, but I decided to change it anyway.

##### Additional note
e2e kept failing when running the tests. Sometimes they passed, other times the failed. I don't know if this is common, or if it's related to my setup somehow. I've managed to at some point get all tests to pass, while running them individually.