### PR TITLE
support static tbody tr td elements

### DIFF
--- a/packages/runtime-dom/__tests__/rendererStaticNode.spec.ts
+++ b/packages/runtime-dom/__tests__/rendererStaticNode.spec.ts
@@ -48,7 +48,6 @@ describe('static vnode handling', () => {
     expect(root.innerHTML).toBe(`<div><b></b><b></b>${content}</div>`)
   })
 
-
   test('should support tbody tr td...',()=>{
     const content1 = `<tbody><tr><td>hello</td></tr></tbody>`
     const content2 = `<tr><td>hello</td></tr>`
@@ -64,9 +63,5 @@ describe('static vnode handling', () => {
     expect(root.innerHTML).toBe(`<table>${content2}</table>`)
     render(h('tr', [s3]), root)
     expect(root.innerHTML).toBe(`<tr>${content3}</tr>`)
-
-    
   })
-
-
 })

--- a/packages/runtime-dom/__tests__/rendererStaticNode.spec.ts
+++ b/packages/runtime-dom/__tests__/rendererStaticNode.spec.ts
@@ -47,4 +47,26 @@ describe('static vnode handling', () => {
     render(h('div', [h('b'), h('b'), s]), root)
     expect(root.innerHTML).toBe(`<div><b></b><b></b>${content}</div>`)
   })
+
+
+  test('should support tbody tr td...',()=>{
+    const content1 = `<tbody><tr><td>hello</td></tr></tbody>`
+    const content2 = `<tr><td>hello</td></tr>`
+    const content3 = `<td>hello</td>`
+
+    const root = document.createElement('div')
+    const s1 = createStaticVNode(content1,1)
+    const s2 = createStaticVNode(content2,1)
+    const s3 = createStaticVNode(content3,1)
+    render(h('table', [s1]), root)
+    expect(root.innerHTML).toBe(`<table>${content1}</table>`)
+    render(h('table', [s2]), root)
+    expect(root.innerHTML).toBe(`<table>${content2}</table>`)
+    render(h('tr', [s3]), root)
+    expect(root.innerHTML).toBe(`<tr>${content3}</tr>`)
+
+    
+  })
+
+
 })

--- a/packages/runtime-dom/src/nodeOps.ts
+++ b/packages/runtime-dom/src/nodeOps.ts
@@ -1,5 +1,9 @@
 import { RendererOptions } from '@vue/runtime-core'
 
+
+interface wrapConfig {
+  [name: string]: [number,string,string]
+}
 export const svgNS = 'http://www.w3.org/2000/svg'
 
 const doc = (typeof document !== 'undefined' ? document : null) as Document
@@ -7,12 +11,11 @@ const doc = (typeof document !== 'undefined' ? document : null) as Document
 let tempContainer: HTMLElement
 let tempSVGContainer: SVGElement
 
-let wrapMap:any = {
+let wrapMap:wrapConfig = {
   thead: [ 1, "<table>", "</table>" ],
   tr: [ 2, "<table><tbody>", "</tbody></table>" ],
   td: [ 3, "<table><tbody><tr>", "</tr></tbody></table>" ],
-  col: [ 2, "<table><tbody></tbody><colgroup>", "</colgroup></table>" ],
-  _default: [ 0, "", "" ]
+  col: [ 2, "<table><tbody></tbody><colgroup>", "</colgroup></table>" ]
 }
 wrapMap.tbody = wrapMap.tfoot = wrapMap.colgroup = wrapMap.caption = wrapMap.thead
 wrapMap.th = wrapMap.td
@@ -78,7 +81,8 @@ export const nodeOps: Omit<RendererOptions<Node, Element>, 'patchProp'> = {
 
     const tag = ( rtagName.exec( content ) || ["", ""] )[1].toLowerCase()
     if(wrapMap[tag]){
-      let [depth, before, after] = wrapMap[ tag ] || wrapMap._default
+      // wrapping table labels to tr|td elements to return correct dom 
+      let [depth, before, after] = wrapMap[ tag ] || [ 0, "", "" ]
       temp.innerHTML = before+content+after
       while(depth--){
         temp = temp.firstChild as HTMLElement|SVGElement

--- a/packages/runtime-dom/src/nodeOps.ts
+++ b/packages/runtime-dom/src/nodeOps.ts
@@ -78,7 +78,6 @@ export const nodeOps: Omit<RendererOptions<Node, Element>, 'patchProp'> = {
       ? tempSVGContainer ||
         (tempSVGContainer = doc.createElementNS(svgNS, 'svg'))
       : tempContainer || (tempContainer = doc.createElement('div'))
-
     const tag = ( rtagName.exec( content ) || ["", ""] )[1].toLowerCase()
     if(wrapMap[tag]){
       // wrapping table labels to tr|td elements to return correct dom 
@@ -100,7 +99,7 @@ export const nodeOps: Omit<RendererOptions<Node, Element>, 'patchProp'> = {
       node = temp.firstChild as Element
     }
     return [first, last]
-  },
+  }
 }
 
 

--- a/packages/runtime-dom/src/nodeOps.ts
+++ b/packages/runtime-dom/src/nodeOps.ts
@@ -7,6 +7,18 @@ const doc = (typeof document !== 'undefined' ? document : null) as Document
 let tempContainer: HTMLElement
 let tempSVGContainer: SVGElement
 
+let wrapMap:any = {
+  thead: [ 1, "<table>", "</table>" ],
+  tr: [ 2, "<table><tbody>", "</tbody></table>" ],
+  td: [ 3, "<table><tbody><tr>", "</tr></tbody></table>" ],
+  col: [ 2, "<table><tbody></tbody><colgroup>", "</colgroup></table>" ],
+  _default: [ 0, "", "" ]
+}
+wrapMap.tbody = wrapMap.tfoot = wrapMap.colgroup = wrapMap.caption = wrapMap.thead
+wrapMap.th = wrapMap.td
+const rtagName = /<([\w:]+)/
+
+
 export const nodeOps: Omit<RendererOptions<Node, Element>, 'patchProp'> = {
   insert: (child, parent, anchor) => {
     if (anchor) {
@@ -59,11 +71,22 @@ export const nodeOps: Omit<RendererOptions<Node, Element>, 'patchProp'> = {
   // Static content here can only come from compiled templates.
   // As long as the user only uses trusted templates, this is safe.
   insertStaticContent(content, parent, anchor, isSVG) {
-    const temp = isSVG
+    let temp = isSVG
       ? tempSVGContainer ||
         (tempSVGContainer = doc.createElementNS(svgNS, 'svg'))
       : tempContainer || (tempContainer = doc.createElement('div'))
-    temp.innerHTML = content
+
+    const tag = ( rtagName.exec( content ) || ["", ""] )[1].toLowerCase()
+    if(wrapMap[tag]){
+      let [depth, before, after] = wrapMap[ tag ] || wrapMap._default
+      temp.innerHTML = before+content+after
+      while(depth--){
+        temp = temp.firstChild as HTMLElement|SVGElement
+      }
+    }else{
+      temp.innerHTML = content
+    }
+
     const first = temp.firstChild as Element
     let node: Element | null = first
     let last: Element = node
@@ -73,5 +96,7 @@ export const nodeOps: Omit<RendererOptions<Node, Element>, 'patchProp'> = {
       node = temp.firstChild as Element
     }
     return [first, last]
-  }
+  },
 }
+
+


### PR DESCRIPTION
Direct set `div.innerHTML` in insertStaticContent  will result in lost rendering of table tags such as tr,td， we need to wrap the right table elements before innerHTML

## template example
[template code](https://vue-next-template-explorer.netlify.app/#%7B%22src%22%3A%22%3Ctable%3E%5Cn%20%20%3Ctr%3E%5Cn%20%20%20%20%3Ctd%20class%3D%5C%22col-md-1%5C%22%3E%20vue3%20%3C%2Ftd%3E%5Cn%20%20%20%20%3Ctd%20class%3D%5C%22col-md-1%5C%22%3E%20vue3%20%3C%2Ftd%3E%5Cn%20%20%20%20%3Ctd%20class%3D%5C%22col-md-1%5C%22%3E%20vue3%20%3C%2Ftd%3E%5Cn%20%20%20%20%3Ctd%20class%3D%5C%22col-md-1%5C%22%3E%20vue3%20%3C%2Ftd%3E%5Cn%20%20%20%20%3Ctd%20class%3D%5C%22col-md-1%5C%22%3E%20vue3%20%3C%2Ftd%3E%5Cn%20%20%3C%2Ftr%3E%5Cn%3C%2Ftable%3E%22%2C%22ssr%22%3Afalse%2C%22options%22%3A%7B%22mode%22%3A%22module%22%2C%22prefixIdentifiers%22%3Afalse%2C%22optimizeBindings%22%3Afalse%2C%22hoistStatic%22%3Atrue%2C%22cacheHandlers%22%3Afalse%2C%22scopeId%22%3Anull%7D%7D)
[vue bug project](https://github.com/shengxinjing/vue3-static-table)

reder a simple table in App.vue
```html
<template>
<table>
  <tr>
    <td class="col-md-1"> vue3 </td>
    <td class="col-md-1"> vue3 </td>
    <td class="col-md-1"> vue3 </td>
    <td class="col-md-1"> vue3 </td>
    <td class="col-md-1"> vue3 </td>
  </tr>
</table>
</template>

<script>
export default {
  
}
</script>

<style>
.col-md-1{
  border:1px solid black;
}
</style>
```

but only render the text
```html
<table> vue3  vue3  vue3  vue3  vue3 </table>
```



## Bug Reason


```javascript
const div = document.createElement('div')
div.innerHTML = '<tr><td class=\"col-md-1\"> vue3 </td><td class=\"col-md-1\"> vue3 </td><td class=\"col-md-1\"> vue3 </td><td class=\"col-md-1\"> vue3 </td><td class=\"col-md-1\"> vue3 </td></tr>'
console.log(div.innerHTML)
VM379:3  vue3  vue3  vue3  vue3  vue3 
```