### PR TITLE
fix(types): add RawSlots in h signature

### DIFF
--- a/packages/runtime-core/__tests__/h.spec.ts
+++ b/packages/runtime-core/__tests__/h.spec.ts
@@ -1,5 +1,6 @@
 import { h } from '../src/h'
 import { createVNode } from '../src/vnode'
+import { RawSlots } from '../src/componentSlots'
 
 // Since h is a thin layer on top of createVNode, we are only testing its
 // own logic here. Details of vnode creation is tested in vnode.spec.ts.
@@ -31,8 +32,14 @@ describe('renderer: h', () => {
   test('type + props + children', () => {
     // array
     expect(h('div', {}, ['foo'])).toMatchObject(createVNode('div', {}, ['foo']))
-    // default slot
+    // slots
+    const slots = {} as RawSlots
+    expect(h('div', {}, slots)).toMatchObject(createVNode('div', {}, slots))
     const Component = { template: '<br />' }
+    expect(h(Component, {}, slots)).toMatchObject(
+      createVNode(Component, {}, slots)
+    )
+    // default slot
     const slot = () => {}
     expect(h(Component, {}, slot)).toMatchObject(
       createVNode(Component, {}, slot)

--- a/packages/runtime-core/src/h.ts
+++ b/packages/runtime-core/src/h.ts
@@ -80,7 +80,7 @@ export function h(type: string, children?: RawChildren): VNode
 export function h(
   type: string,
   props?: RawProps | null,
-  children?: RawChildren
+  children?: RawChildren | RawSlots
 ): VNode
 
 // fragment

--- a/test-dts/h.test-d.ts
+++ b/test-dts/h.test-d.ts
@@ -23,6 +23,9 @@ describe('h inference w/ element', () => {
   expectError(h('div', { ref: [] }))
   expectError(h('div', { ref: {} }))
   expectError(h('div', { ref: 123 }))
+  // slots
+  const slots = { default: () => {} } // RawSlots
+  h('div', {}, slots)
 })
 
 describe('h inference w/ Fragment', () => {


### PR DESCRIPTION
`RawSlots` is supported as a third argument in most signatures except when the first one is a `string`. I _think_ this is a valid use-case, as @dobromir-hristov used it for stubs in VTU next.
We are currently forced to cast the parameter as `any` to make TS happy in VTU. This commit should fix that.