### PR TITLE
Incorrectly determine node stringifiable when unstringifiable child exists after threshold is met(fix #1128)

### DIFF
--- a/packages/compiler-dom/__tests__/transforms/stringifyStatic.spec.ts
+++ b/packages/compiler-dom/__tests__/transforms/stringifyStatic.spec.ts
@@ -225,4 +225,28 @@ describe('stringify static html', () => {
       type: NodeTypes.VNODE_CALL // not CALL_EXPRESSION
     })
   })
+
+  test('should bail on non attribute bindings', () => {
+    const { ast } = compileWithStringify(
+      `<div><div>${repeat(
+        `<span class="foo">foo</span>`,
+        StringifyThresholds.ELEMENT_WITH_BINDING_COUNT
+      )}<input indeterminate></div></div>`
+    )
+    expect(ast.hoists.length).toBe(1)
+    expect(ast.hoists[0]).toMatchObject({
+      type: NodeTypes.VNODE_CALL // not CALL_EXPRESSION
+    })
+
+    const { ast: ast2 } = compileWithStringify(
+      `<div><div>${repeat(
+        `<span class="foo">foo</span>`,
+        StringifyThresholds.ELEMENT_WITH_BINDING_COUNT
+      )}<input :indeterminate="true"></div></div>`
+    )
+    expect(ast2.hoists.length).toBe(1)
+    expect(ast2.hoists[0]).toMatchObject({
+      type: NodeTypes.VNODE_CALL // not CALL_EXPRESSION
+    })
+  })
 })

--- a/packages/compiler-dom/src/transforms/stringifyStatic.ts
+++ b/packages/compiler-dom/src/transforms/stringifyStatic.ts
@@ -189,16 +189,10 @@ function analyzeNode(node: StringifiableNode): [number, number] | false {
     }
     for (let i = 0; i < node.children.length; i++) {
       nc++
-      if (nc >= StringifyThresholds.NODE_COUNT) {
-        return true
-      }
       const child = node.children[i]
       if (child.type === NodeTypes.ELEMENT) {
         if (child.props.length > 0) {
           ec++
-          if (ec >= StringifyThresholds.ELEMENT_WITH_BINDING_COUNT) {
-            return true
-          }
         }
         walk(child)
         if (bailed) {


### PR DESCRIPTION
**Version**
3.0.0-beta.14

**Reproduction link**
[vue-next-template-explorer](https://vue-next-template-explorer.netlify.app/#%7B%22src%22%3A%22%3Cdiv%3E%5Cn%20%20%3Cdiv%3E%5Cn%20%20%20%20%5Cn%20%20%20%20%3Cdiv%20%2F%3E%5Cn%20%20%20%20%3Cdiv%20%2F%3E%5Cn%20%20%20%20%3Cdiv%20%2F%3E%5Cn%20%20%20%20%3Cdiv%20%2F%3E%5Cn%20%20%20%20%3Cdiv%20%2F%3E%5Cn%20%20%20%20%3Cdiv%20%2F%3E%5Cn%20%20%20%20%3Cdiv%20%2F%3E%5Cn%20%20%20%20%3Cdiv%20%2F%3E%5Cn%20%20%20%20%3Cdiv%20%2F%3E%5Cn%20%20%20%20%3Cdiv%20%2F%3E%5Cn%20%20%20%20%3Cdiv%20%2F%3E%5Cn%20%20%20%20%3Cdiv%20%2F%3E%5Cn%20%20%20%20%3Cdiv%20%2F%3E%5Cn%20%20%20%20%3Cdiv%20%2F%3E%5Cn%20%20%20%20%3Cdiv%20%2F%3E%5Cn%20%20%20%20%3Cdiv%20%2F%3E%5Cn%20%20%20%20%3Cdiv%20%2F%3E%5Cn%20%20%20%20%3Cdiv%20%2F%3E%5Cn%20%20%20%20%3Cdiv%20%2F%3E%5Cn%20%20%20%20%3Cinput%20type%3D%5C%22checkbox%5C%22%20indeterminate%20%2F%3E%5Cn%20%20%3C%2Fdiv%3E%5Cn%3C%2Fdiv%3E%22%2C%22ssr%22%3Afalse%2C%22options%22%3A%7B%22mode%22%3A%22module%22%2C%22prefixIdentifiers%22%3Atrue%2C%22optimizeBindings%22%3Afalse%2C%22hoistStatic%22%3Atrue%2C%22cacheHandlers%22%3Atrue%2C%22scopeId%22%3Anull%7D%7D)

**What is expected?**
Set properties correctly after the threshold is met, instead attributes.

**What is actually happening?**
Properties are treated as attribute, if unstringifiable node appear after threshold(20).

**How to fix?**
Should not stop checking stringifiable when threshold is met.