### PR TITLE
Use named import over `import *`

### DIFF
--- a/packages/reactivity/__tests__/collections/Set.spec.ts
+++ b/packages/reactivity/__tests__/collections/Set.spec.ts
@@ -412,13 +412,13 @@ describe('reactivity/collections', () => {
         `Reactive Set contains both the raw and reactive`
       ).toHaveBeenWarned()
     })
-    
+
     it('thisArg', () => {
-      const raw = new Set([ 'value' ])
+      const raw = new Set(['value'])
       const proxy = reactive(raw)
       const thisArg = {}
       let count = 0
-      proxy.forEach(function (this :{}, value, _, set) {
+      proxy.forEach(function(this: {}, value, _, set) {
         ++count
         expect(this).toBe(thisArg)
         expect(value).toBe('value')

--- a/packages/reactivity/src/baseHandlers.ts
+++ b/packages/reactivity/src/baseHandlers.ts
@@ -49,7 +49,7 @@ function createGetter(isReadonly = false, shallow = false) {
     }
     const res = Reflect.get(target, key, receiver)
 
-    if (isSymbol(key) && builtInSymbols.has(key) || key === '__proto__') {
+    if ((isSymbol(key) && builtInSymbols.has(key)) || key === '__proto__') {
       return res
     }
 

--- a/packages/runtime-core/src/componentProps.ts
+++ b/packages/runtime-core/src/componentProps.ts
@@ -220,9 +220,7 @@ function setFullProps(
   props: Data,
   attrs: Data
 ) {
-  const [options, needCastKeys] = normalizePropsOptions(
-    instance.type.props
-  )
+  const [options, needCastKeys] = normalizePropsOptions(instance.type.props)
   const emits = instance.type.emits
 
   if (rawProps) {

--- a/packages/runtime-dom/types/jsx.d.ts
+++ b/packages/runtime-dom/types/jsx.d.ts
@@ -28,9 +28,9 @@ import { Ref, ComponentPublicInstance } from '@vue/runtime-core'
 //                 Kanitkorn Sujautra <https://github.com/lukyth>
 //                 Sebastian Silbermann <https://github.com/eps1lon>
 
-import * as CSS from 'csstype'
+import { Properties as CSS_Properties } from 'csstype'
 
-export interface CSSProperties extends CSS.Properties<string | number> {
+export interface CSSProperties extends CSS_Properties<string | number> {
   /**
    * The index signature was removed to enable closed typing for style
    * using CSSType. You're able to use type assertion or module augmentation


### PR DESCRIPTION
refactor(runtime-dom): use named import over `import *`; also apply linting

While this may not impact build size, coming as this does in a declaration file, having come across one named import in source (as a general no-no in an audit trying to minimize package size), thought we would offer this more focused import which instead exclusively draws in the property actually used. Also found a few linting fixes upon running `yarn lint`.

Thanks!