### PR TITLE
fix(runtime-core): assign value after children are render

### DIFF
--- a/packages/runtime-core/src/renderer.ts
+++ b/packages/runtime-core/src/renderer.ts
@@ -712,6 +712,16 @@ function baseCreateRenderer(
           optimized || !!vnode.dynamicChildren
         )
       }
+
+      /**
+       * When select is mounted with props.value,
+       * select won't be able to set any value because
+       * the options are not rendered yet.
+       */
+      if (props && props.value && el.value !== props.value) {
+        hostPatchProp(el, 'value', null, props.value, isSVG)
+      }
+
       if (transition && !transition.persisted) {
         transition.beforeEnter(el)
       }

--- a/packages/runtime-dom/__tests__/render.spec.ts
+++ b/packages/runtime-dom/__tests__/render.spec.ts
@@ -1,0 +1,25 @@
+import { render, h } from '../src'
+
+describe('runtime-dom: render', () => {
+  // #1318
+  test('set value of select', () => {
+    const root = document.createElement('div')
+    /**
+    <select value="B" >
+      <option value="A">A</option>
+      <option value="B">B</option>
+      <option value="C">C</option>
+    </select>
+   */
+    render(
+      h('select', { value: 'B' }, [
+        h('option', { value: 'A' }),
+        h('option', { value: 'B' }),
+        h('option', { value: 'C' })
+      ]),
+      root
+    )
+
+    expect((root.firstChild! as any).value).toBe('B')
+  })
+})


### PR DESCRIPTION
fix #1318

Problem is caused when the `select.value` is set, but there's no children options, so the value cannot be set. After the first child is render the `select` will reset to it, but if you bind `value` to other value, it will ignore. 

The implementation is in `runtime-core` but the test is on `runtime-dom` because is a bit trickier to test with test-utils