### PR TITLE
fix(vnode): should skip `null/undefined/boolean` inside array children  fix #1342

### DIFF
--- a/packages/runtime-core/__tests__/vnode.spec.ts
+++ b/packages/runtime-core/__tests__/vnode.spec.ts
@@ -148,6 +148,11 @@ describe('vnode', () => {
         ShapeFlags.ELEMENT | ShapeFlags.ARRAY_CHILDREN
       )
     })
+
+    test('should skip null/undefined/boolean inside array children', () => {
+      const vnode = createVNode('div', null, [null, undefined, true])
+      expect(vnode.children!.length).toBe(0)
+    })
   })
 
   test('normalizeVNode', () => {

--- a/packages/runtime-core/src/vnode.ts
+++ b/packages/runtime-core/src/vnode.ts
@@ -488,16 +488,13 @@ export function createCommentVNode(
 }
 
 export function normalizeVNode(child: VNodeChild): VNode {
-  if (child == null || typeof child === 'boolean') {
-    // empty placeholder
-    return createVNode(Comment)
-  } else if (isArray(child)) {
+  if (isArray(child)) {
     // fragment
     return createVNode(Fragment, null, child)
   } else if (typeof child === 'object') {
     // already vnode, this should be the most common since compiled templates
     // always produce all-vnode children arrays
-    return child.el === null ? child : cloneVNode(child)
+    return child!.el === null ? child! : cloneVNode(child!)
   } else {
     // strings and numbers
     return createVNode(Text, null, String(child))
@@ -555,9 +552,7 @@ export function normalizeChildren(vnode: VNode, children: unknown) {
 }
 
 function normalizeArrayChildren(children: VNodeArrayChildren) {
-  return children.filter(
-    child => child !== null && child !== undefined && typeof child !== 'boolean'
-  )
+  return children.filter(child => child != null && typeof child !== 'boolean')
 }
 
 const handlersRE = /^on|^vnode/

--- a/packages/runtime-core/src/vnode.ts
+++ b/packages/runtime-core/src/vnode.ts
@@ -545,8 +545,19 @@ export function normalizeChildren(vnode: VNode, children: unknown) {
       type = ShapeFlags.TEXT_CHILDREN
     }
   }
+
+  if (isArray(children)) {
+    children = normalizeArrayChildren(children)
+  }
+
   vnode.children = children as VNodeNormalizedChildren
   vnode.shapeFlag |= type
+}
+
+function normalizeArrayChildren(children: VNodeArrayChildren) {
+  return children.filter(
+    child => child !== null && child !== undefined && typeof child !== 'boolean'
+  )
 }
 
 const handlersRE = /^on|^vnode/


### PR DESCRIPTION
fix #1342 