### PR TITLE
fix(runtime-core): properly change v-on object keys

### DIFF
--- a/packages/runtime-core/__tests__/helpers/toHandlers.spec.ts
+++ b/packages/runtime-core/__tests__/helpers/toHandlers.spec.ts
@@ -18,8 +18,8 @@ describe('toHandlers', () => {
     const change = () => {}
 
     expect(toHandlers({ input, change })).toStrictEqual({
-      oninput: input,
-      onchange: change
+      onInput: input,
+      onChange: change
     })
   })
 })

--- a/packages/runtime-core/src/helpers/toHandlers.ts
+++ b/packages/runtime-core/src/helpers/toHandlers.ts
@@ -1,4 +1,4 @@
-import { isObject } from '@vue/shared'
+import { isObject, capitalize } from '@vue/shared'
 import { warn } from '../warning'
 
 /**
@@ -12,7 +12,7 @@ export function toHandlers(obj: Record<string, any>): Record<string, any> {
     return ret
   }
   for (const key in obj) {
-    ret[`on${key}`] = obj[key]
+    ret[`on${capitalize(key)}`] = obj[key]
   }
   return ret
 }


### PR DESCRIPTION
`emit('eventName')` will call a prop with the name `onEventName`.
`@eventName="eventHandler"` will be compiled into the prop `onEventName: event => _ctx.eventHandler(event)`.
Both of those are completely fine, and event handlers are called as expected.

If you opt to use `v-on` with an object, it will probably not work as expected.
`v-on="{ eventName: eventHandler }"` is compiled to prop `{ oneventName: eventhandler }`, and will thus never be called by `emit('eventName')`.
Currently you'll have to capitalize the event name, `v-on"{ EventName: eventHandler }"`.
This is clunky, and it breaks with the common pattern that event names are in camelCase.

This PR fixes this by capitalizing the object keys before they're prepended with `'on'`.