### PR TITLE
fix(runtime-core): should update parent host el when component self u…

### DIFF
--- a/packages/runtime-core/__tests__/rendererComponent.spec.ts
+++ b/packages/runtime-core/__tests__/rendererComponent.spec.ts
@@ -1,0 +1,44 @@
+import {
+  ref,
+  h,
+  render,
+  nodeOps,
+  serializeInner,
+  nextTick,
+  VNode
+} from '@vue/runtime-test'
+
+describe('renderer: component', () => {
+  test('should update parent(hoc) component host el when child component self update', async () => {
+    const value = ref(true)
+    let parentVnode: VNode
+    let childVnode1: VNode
+    let childVnode2: VNode
+
+    const Parent = {
+      render: () => {
+        // let Parent first rerender
+        console.log(value.value)
+        return (parentVnode = h(Child))
+      }
+    }
+
+    const Child = {
+      render: () => {
+        return value.value
+          ? (childVnode1 = h('div'))
+          : (childVnode2 = h('span'))
+      }
+    }
+
+    const root = nodeOps.createElement('div')
+    render(h(Parent), root)
+    expect(serializeInner(root)).toBe(`<div></div>`)
+    expect(parentVnode!.el).toBe(childVnode1!.el)
+
+    value.value = false
+    await nextTick()
+    expect(serializeInner(root)).toBe(`<span></span>`)
+    expect(parentVnode!.el).toBe(childVnode2!.el)
+  })
+})

--- a/packages/runtime-core/src/componentRenderUtils.ts
+++ b/packages/runtime-core/src/componentRenderUtils.ts
@@ -319,7 +319,7 @@ export function updateHOCHostEl(
   el: typeof vnode.el // HostNode
 ) {
   while (parent && parent.subTree === vnode) {
-    ;(vnode = parent.vnode).el = parent.subTree.el = el
+    ;(vnode = parent.vnode).el = el
     parent = parent.parent
   }
 }

--- a/packages/runtime-core/src/componentRenderUtils.ts
+++ b/packages/runtime-core/src/componentRenderUtils.ts
@@ -11,7 +11,8 @@ import {
   cloneVNode,
   Fragment,
   VNodeArrayChildren,
-  isVNode
+  isVNode,
+  isSameVNodeType
 } from './vnode'
 import { handleError, ErrorCodes } from './errorHandling'
 import { PatchFlags, ShapeFlags, isOn } from '@vue/shared'
@@ -318,8 +319,8 @@ export function updateHOCHostEl(
   { vnode, parent }: ComponentInternalInstance,
   el: typeof vnode.el // HostNode
 ) {
-  while (parent && parent.subTree === vnode) {
-    ;(vnode = parent.vnode).el = el
+  while (parent && isSameVNodeType(parent.subTree, vnode)) {
+    ;(vnode = parent.vnode).el = parent.subTree.el = el
     parent = parent.parent
   }
 }

--- a/packages/runtime-core/src/componentRenderUtils.ts
+++ b/packages/runtime-core/src/componentRenderUtils.ts
@@ -11,8 +11,7 @@ import {
   cloneVNode,
   Fragment,
   VNodeArrayChildren,
-  isVNode,
-  isSameVNodeType
+  isVNode
 } from './vnode'
 import { handleError, ErrorCodes } from './errorHandling'
 import { PatchFlags, ShapeFlags, isOn } from '@vue/shared'
@@ -319,7 +318,7 @@ export function updateHOCHostEl(
   { vnode, parent }: ComponentInternalInstance,
   el: typeof vnode.el // HostNode
 ) {
-  while (parent && isSameVNodeType(parent.subTree, vnode)) {
+  while (parent && parent.subTree === vnode) {
     ;(vnode = parent.vnode).el = parent.subTree.el = el
     parent = parent.parent
   }

--- a/packages/runtime-core/src/renderer.ts
+++ b/packages/runtime-core/src/renderer.ts
@@ -1216,6 +1216,7 @@ function baseCreateRenderer(
       // no update needed. just copy over properties
       n2.component = n1.component
       n2.el = n1.el
+      // instance.vnode = n2
     }
   }
 

--- a/packages/runtime-core/src/renderer.ts
+++ b/packages/runtime-core/src/renderer.ts
@@ -1216,7 +1216,7 @@ function baseCreateRenderer(
       // no update needed. just copy over properties
       n2.component = n1.component
       n2.el = n1.el
-      // instance.vnode = n2
+      instance.vnode = n2
     }
   }
 

--- a/packages/runtime-core/src/renderer.ts
+++ b/packages/runtime-core/src/renderer.ts
@@ -1304,6 +1304,7 @@ function baseCreateRenderer(
         // This is triggered by mutation of component's own state (next: null)
         // OR parent calling processComponent (next: VNode)
         let { next, bu, u, parent, vnode } = instance
+        let originNext = next
         let vnodeHook: VNodeHook | null | undefined
         if (__DEV__) {
           pushWarningContext(next || instance.vnode)
@@ -1355,7 +1356,7 @@ function baseCreateRenderer(
           endMeasure(instance, `patch`)
         }
         next.el = nextTree.el
-        if (next === null) {
+        if (originNext === null) {
           // self-triggered update. In case of HOC, update parent component
           // vnode el. HOC is indicated by parent instance's subTree pointing
           // to child component's vnode


### PR DESCRIPTION
…pdated

fix #1357

### Bug Reason
Incorrect judge conditions with the `next === null` which mean slef updated, because `next` is changed before used it.
It caused the `el` of `keepalvie` vnode always is `comment` (the init value of `router-view` vnode is undefined, it is `comment` after normalized).Actually it should be `div` of `Home` component `el`.
