### PR TITLE
fix(types): export ComponentOptionsMixin

### DIFF
--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -159,6 +159,7 @@ export {
 } from './component'
 export {
   ComponentOptions,
+  ComponentOptionsMixin,
   ComponentOptionsWithoutProps,
   ComponentOptionsWithObjectProps,
   ComponentOptionsWithArrayProps,


### PR DESCRIPTION
The newly introduced `ComponentOptionsMixin` was not re-exported.

This is needed for VTU to support Vue `3.0.0-beta.15`.