### PR TITLE
fix(compiler-core): should not prefix an object property key when val…

### DIFF
--- a/packages/compiler-core/__tests__/transforms/transformExpressions.spec.ts
+++ b/packages/compiler-core/__tests__/transforms/transformExpressions.spec.ts
@@ -306,14 +306,19 @@ describe('compiler: expression transform', () => {
       ]
     })
   })
-
   test('should not prefix an object property key', () => {
     const node = parseWithExpressionTransform(
-      `{{ { foo: () => {}, value: bar } }}`
+      `{{ { foo() { baz() }, value: bar } }}`
     ) as InterpolationNode
     expect(node.content).toMatchObject({
       type: NodeTypes.COMPOUND_EXPRESSION,
-      children: [`{ foo: () => {}, value: `, { content: `_ctx.bar` }, ` }`]
+      children: [
+        `{ foo() { `,
+        { content: `_ctx.baz` },
+        `() }, value: `,
+        { content: `_ctx.bar` },
+        ` }`
+      ]
     })
   })
 

--- a/packages/compiler-core/__tests__/transforms/transformExpressions.spec.ts
+++ b/packages/compiler-core/__tests__/transforms/transformExpressions.spec.ts
@@ -309,11 +309,11 @@ describe('compiler: expression transform', () => {
 
   test('should not prefix an object property key', () => {
     const node = parseWithExpressionTransform(
-      `{{ { foo: bar } }}`
+      `{{ { foo: () => {}, value: bar } }}`
     ) as InterpolationNode
     expect(node.content).toMatchObject({
       type: NodeTypes.COMPOUND_EXPRESSION,
-      children: [`{ foo: `, { content: `_ctx.bar` }, ` }`]
+      children: [`{ foo: () => {}, value: `, { content: `_ctx.bar` }, ` }`]
     })
   })
 

--- a/packages/compiler-core/src/transforms/transformExpression.ts
+++ b/packages/compiler-core/src/transforms/transformExpression.ts
@@ -271,7 +271,9 @@ const isFunction = (node: Node): node is Function =>
   /Function(Expression|Declaration)$/.test(node.type)
 
 const isStaticProperty = (node: Node): node is ObjectProperty =>
-  node && node.type === 'ObjectProperty' && !node.computed
+  node &&
+  (node.type === 'ObjectProperty' || node.type === 'ObjectMethod') &&
+  !node.computed
 
 const isPropertyShorthand = (node: Node, parent: Node) => {
   return (


### PR DESCRIPTION
…ue is function

fix #1373