### PR TITLE
perf(reactivity): should not track `__v_isRef` and some methods in pr…

### DIFF
--- a/packages/reactivity/src/baseHandlers.ts
+++ b/packages/reactivity/src/baseHandlers.ts
@@ -63,7 +63,13 @@ function createGetter(isReadonly = false, shallow = false) {
 
     const res = Reflect.get(target, key, receiver)
 
-    if ((isSymbol(key) && builtInSymbols.has(key)) || key === '__proto__') {
+    if (
+      (isSymbol(key) && builtInSymbols.has(key)) ||
+      key === '__proto__' ||
+      key === '__v_isRef' ||
+      ((hasOwn(Object.prototype, key) || hasOwn(Array.prototype, key)) &&
+        !hasOwn(target, key))
+    ) {
       return res
     }
 

--- a/packages/reactivity/src/baseHandlers.ts
+++ b/packages/reactivity/src/baseHandlers.ts
@@ -64,11 +64,9 @@ function createGetter(isReadonly = false, shallow = false) {
     const res = Reflect.get(target, key, receiver)
 
     if (
-      (isSymbol(key) && builtInSymbols.has(key)) ||
-      key === '__proto__' ||
-      key === '__v_isRef' ||
-      ((hasOwn(Object.prototype, key) || hasOwn(Array.prototype, key)) &&
-        !hasOwn(target, key))
+      isSymbol(key)
+        ? builtInSymbols.has(key)
+        : key === `__proto__` || key === `__v_isRef`
     ) {
       return res
     }


### PR DESCRIPTION
…ototype.eg.`toString`

### Reproduction
```
 const App = {
    setup: () => {
      const data = reactive( {
        array: [1],
        object: {a: 1}
      } );

      return { data }
    },
    renderTracked(e) {
      console.log('key', e)
    },
    template: `
      <div  :literal="data.object" :obj="data.array.map((e) => e)"></div>
    `
  }

  let app = createApp(App);
  app.mount("#app");
```
### Current Behavior
![image](https://user-images.githubusercontent.com/14008915/84878020-d78df880-b0bb-11ea-84d2-17b7ffa39e0e.png)

### Changed Behavior
![image](https://user-images.githubusercontent.com/14008915/84878062-e5dc1480-b0bb-11ea-9989-60375032fd36.png)

I'm not sure for this.I think it is helpful for better performance.If you agree with me, I will add some test for it.