### PR TITLE
fix(runtime-core): register name for anonymous component in production

### DIFF
--- a/packages/runtime-core/src/helpers/resolveAssets.ts
+++ b/packages/runtime-core/src/helpers/resolveAssets.ts
@@ -1,7 +1,12 @@
 import { currentRenderingInstance } from '../componentRenderUtils'
-import { currentInstance, Component, FunctionalComponent } from '../component'
+import {
+  currentInstance,
+  Component,
+  FunctionalComponent,
+  ComponentOptions
+} from '../component'
 import { Directive } from '../directives'
-import { camelize, capitalize, isString } from '@vue/shared'
+import { camelize, capitalize, isString, isObject } from '@vue/shared'
 import { warn } from '../warning'
 
 const COMPONENTS = 'components'
@@ -77,14 +82,21 @@ function resolveAsset(
         res = self
       }
     }
-    if (__DEV__ && warnMissing && !res) {
-      warn(
-        `Failed to resolve ${type.slice(0, -1)}: ${name}` +
-          (type === COMPONENTS
-            ? `\nFor recursive components, make sure to provide the "name" option.`
-            : '')
-      )
+
+    // infer anonymous component's name based on registered name
+    if (
+      res &&
+      type === COMPONENTS &&
+      isObject(res) &&
+      !(res as ComponentOptions).name
+    ) {
+      ;(res as ComponentOptions).name = name
     }
+
+    if (__DEV__ && warnMissing && !res) {
+      warn(`Failed to resolve ${type.slice(0, -1)}: ${name}`)
+    }
+
     return res
   } else if (__DEV__) {
     warn(

--- a/packages/runtime-core/src/helpers/resolveAssets.ts
+++ b/packages/runtime-core/src/helpers/resolveAssets.ts
@@ -1,12 +1,7 @@
 import { currentRenderingInstance } from '../componentRenderUtils'
-import {
-  currentInstance,
-  Component,
-  FunctionalComponent,
-  ComponentOptions
-} from '../component'
+import { currentInstance, Component, FunctionalComponent } from '../component'
 import { Directive } from '../directives'
-import { camelize, capitalize, isString, isObject } from '@vue/shared'
+import { camelize, capitalize, isString } from '@vue/shared'
 import { warn } from '../warning'
 
 const COMPONENTS = 'components'
@@ -82,19 +77,13 @@ function resolveAsset(
         res = self
       }
     }
-    if (__DEV__) {
-      if (res) {
-        // in dev, infer anonymous component's name based on registered name
-        if (
-          type === COMPONENTS &&
-          isObject(res) &&
-          !(res as ComponentOptions).name
-        ) {
-          ;(res as ComponentOptions).name = name
-        }
-      } else if (warnMissing) {
-        warn(`Failed to resolve ${type.slice(0, -1)}: ${name}`)
-      }
+    if (__DEV__ && warnMissing && !res) {
+      warn(
+        `Failed to resolve ${type.slice(0, -1)}: ${name}` +
+          (type === COMPONENTS
+            ? `\nFor recursive components, make sure to provide the "name" option.`
+            : '')
+      )
     }
     return res
   } else if (__DEV__) {


### PR DESCRIPTION
fix #1418

### Solution 1
 Keep behavior as same as v2. 
### Solution 2(Break change with v2)
Register name for anonymous component in production.

I think solution2 is better,maybe it will cost some performance but look like it will benefit for the user.