### PR TITLE
chore(reactivity): use key of ReactiveFlags instead of `__v_properties`

### DIFF
--- a/packages/reactivity/src/baseHandlers.ts
+++ b/packages/reactivity/src/baseHandlers.ts
@@ -42,16 +42,16 @@ const arrayInstrumentations: Record<string, Function> = {}
 
 function createGetter(isReadonly = false, shallow = false) {
   return function get(target: object, key: string | symbol, receiver: object) {
-    if (key === ReactiveFlags.IsReactive) {
+    if (key === ReactiveFlags.IS_REACTIVE) {
       return !isReadonly
-    } else if (key === ReactiveFlags.IsReadonly) {
+    } else if (key === ReactiveFlags.IS_READONLY) {
       return isReadonly
     } else if (
-      key === ReactiveFlags.Raw &&
+      key === ReactiveFlags.RAW &&
       receiver ===
         (isReadonly
-          ? (target as any)[ReactiveFlags.Readonly]
-          : (target as any)[ReactiveFlags.Reactive])
+          ? (target as any)[ReactiveFlags.READONLY]
+          : (target as any)[ReactiveFlags.REACTIVE])
     ) {
       return target
     }

--- a/packages/reactivity/src/baseHandlers.ts
+++ b/packages/reactivity/src/baseHandlers.ts
@@ -42,16 +42,16 @@ const arrayInstrumentations: Record<string, Function> = {}
 
 function createGetter(isReadonly = false, shallow = false) {
   return function get(target: object, key: string | symbol, receiver: object) {
-    if (key === ReactiveFlags.isReactive) {
+    if (key === ReactiveFlags.IsReactive) {
       return !isReadonly
-    } else if (key === ReactiveFlags.isReadonly) {
+    } else if (key === ReactiveFlags.IsReadonly) {
       return isReadonly
     } else if (
-      key === ReactiveFlags.raw &&
+      key === ReactiveFlags.Raw &&
       receiver ===
         (isReadonly
-          ? (target as any)[ReactiveFlags.readonly]
-          : (target as any)[ReactiveFlags.reactive])
+          ? (target as any)[ReactiveFlags.Readonly]
+          : (target as any)[ReactiveFlags.Reactive])
     ) {
       return target
     }

--- a/packages/reactivity/src/baseHandlers.ts
+++ b/packages/reactivity/src/baseHandlers.ts
@@ -50,8 +50,8 @@ function createGetter(isReadonly = false, shallow = false) {
       key === ReactiveFlags.raw &&
       receiver ===
         (isReadonly
-          ? (target as any).__v_readonly
-          : (target as any).__v_reactive)
+          ? (target as any)[ReactiveFlags.readonly]
+          : (target as any)[ReactiveFlags.reactive])
     ) {
       return target
     }

--- a/packages/reactivity/src/collectionHandlers.ts
+++ b/packages/reactivity/src/collectionHandlers.ts
@@ -282,11 +282,11 @@ function createInstrumentationGetter(isReadonly: boolean, shallow: boolean) {
     key: string | symbol,
     receiver: CollectionTypes
   ) => {
-    if (key === ReactiveFlags.isReactive) {
+    if (key === ReactiveFlags.IsReactive) {
       return !isReadonly
-    } else if (key === ReactiveFlags.isReadonly) {
+    } else if (key === ReactiveFlags.IsReadonly) {
       return isReadonly
-    } else if (key === ReactiveFlags.raw) {
+    } else if (key === ReactiveFlags.Raw) {
       return target
     }
 

--- a/packages/reactivity/src/collectionHandlers.ts
+++ b/packages/reactivity/src/collectionHandlers.ts
@@ -282,11 +282,11 @@ function createInstrumentationGetter(isReadonly: boolean, shallow: boolean) {
     key: string | symbol,
     receiver: CollectionTypes
   ) => {
-    if (key === ReactiveFlags.IsReactive) {
+    if (key === ReactiveFlags.IS_REACTIVE) {
       return !isReadonly
-    } else if (key === ReactiveFlags.IsReadonly) {
+    } else if (key === ReactiveFlags.IS_READONLY) {
       return isReadonly
-    } else if (key === ReactiveFlags.Raw) {
+    } else if (key === ReactiveFlags.RAW) {
       return target
     }
 

--- a/packages/reactivity/src/reactive.ts
+++ b/packages/reactivity/src/reactive.ts
@@ -13,21 +13,21 @@ import {
 import { UnwrapRef, Ref } from './ref'
 
 export const enum ReactiveFlags {
-  skip = '__v_skip',
-  isReactive = '__v_isReactive',
-  isReadonly = '__v_isReadonly',
-  raw = '__v_raw',
-  reactive = '__v_reactive',
-  readonly = '__v_readonly'
+  Skip = '__v_skip',
+  IsReactive = '__v_isReactive',
+  IsReadonly = '__v_isReadonly',
+  Raw = '__v_raw',
+  Reactive = '__v_reactive',
+  Readonly = '__v_readonly'
 }
 
 interface Target {
-  [ReactiveFlags.skip]?: boolean
-  [ReactiveFlags.isReactive]?: boolean
-  [ReactiveFlags.isReadonly]?: boolean
-  [ReactiveFlags.raw]?: any
-  [ReactiveFlags.reactive]?: any
-  [ReactiveFlags.readonly]?: any
+  [ReactiveFlags.Skip]?: boolean
+  [ReactiveFlags.IsReactive]?: boolean
+  [ReactiveFlags.IsReadonly]?: boolean
+  [ReactiveFlags.Raw]?: any
+  [ReactiveFlags.Reactive]?: any
+  [ReactiveFlags.Readonly]?: any
 }
 
 const collectionTypes = new Set<Function>([Set, Map, WeakMap, WeakSet])
@@ -37,7 +37,7 @@ const isObservableType = /*#__PURE__*/ makeMap(
 
 const canObserve = (value: Target): boolean => {
   return (
-    !value[ReactiveFlags.skip] &&
+    !value[ReactiveFlags.Skip] &&
     isObservableType(toRawType(value)) &&
     !Object.isFrozen(value)
   )
@@ -49,7 +49,7 @@ type UnwrapNestedRefs<T> = T extends Ref ? T : UnwrapRef<T>
 export function reactive<T extends object>(target: T): UnwrapNestedRefs<T>
 export function reactive(target: object) {
   // if trying to observe a readonly proxy, return the readonly version.
-  if (target && (target as Target)[ReactiveFlags.isReadonly]) {
+  if (target && (target as Target)[ReactiveFlags.IsReadonly]) {
     return target
   }
   return createReactiveObject(
@@ -113,18 +113,18 @@ function createReactiveObject(
   // target is already a Proxy, return it.
   // exception: calling readonly() on a reactive object
   if (
-    target[ReactiveFlags.raw] &&
-    !(isReadonly && target[ReactiveFlags.isReactive])
+    target[ReactiveFlags.Raw] &&
+    !(isReadonly && target[ReactiveFlags.IsReactive])
   ) {
     return target
   }
   // target already has corresponding Proxy
   if (
-    hasOwn(target, isReadonly ? ReactiveFlags.readonly : ReactiveFlags.reactive)
+    hasOwn(target, isReadonly ? ReactiveFlags.Readonly : ReactiveFlags.Reactive)
   ) {
     return isReadonly
-      ? target[ReactiveFlags.readonly]
-      : target[ReactiveFlags.reactive]
+      ? target[ReactiveFlags.Readonly]
+      : target[ReactiveFlags.Reactive]
   }
   // only a whitelist of value types can be observed.
   if (!canObserve(target)) {
@@ -136,7 +136,7 @@ function createReactiveObject(
   )
   def(
     target,
-    isReadonly ? ReactiveFlags.readonly : ReactiveFlags.reactive,
+    isReadonly ? ReactiveFlags.Readonly : ReactiveFlags.Reactive,
     observed
   )
   return observed
@@ -144,13 +144,13 @@ function createReactiveObject(
 
 export function isReactive(value: unknown): boolean {
   if (isReadonly(value)) {
-    return isReactive((value as Target)[ReactiveFlags.raw])
+    return isReactive((value as Target)[ReactiveFlags.Raw])
   }
-  return !!(value && (value as Target)[ReactiveFlags.isReactive])
+  return !!(value && (value as Target)[ReactiveFlags.IsReactive])
 }
 
 export function isReadonly(value: unknown): boolean {
-  return !!(value && (value as Target)[ReactiveFlags.isReadonly])
+  return !!(value && (value as Target)[ReactiveFlags.IsReadonly])
 }
 
 export function isProxy(value: unknown): boolean {
@@ -159,11 +159,11 @@ export function isProxy(value: unknown): boolean {
 
 export function toRaw<T>(observed: T): T {
   return (
-    (observed && toRaw((observed as Target)[ReactiveFlags.raw])) || observed
+    (observed && toRaw((observed as Target)[ReactiveFlags.Raw])) || observed
   )
 }
 
 export function markRaw<T extends object>(value: T): T {
-  def(value, ReactiveFlags.skip, true)
+  def(value, ReactiveFlags.Skip, true)
   return value
 }

--- a/packages/reactivity/src/reactive.ts
+++ b/packages/reactivity/src/reactive.ts
@@ -13,21 +13,21 @@ import {
 import { UnwrapRef, Ref } from './ref'
 
 export const enum ReactiveFlags {
-  Skip = '__v_skip',
-  IsReactive = '__v_isReactive',
-  IsReadonly = '__v_isReadonly',
-  Raw = '__v_raw',
-  Reactive = '__v_reactive',
-  Readonly = '__v_readonly'
+  SKIP = '__v_skip',
+  IS_REACTIVE = '__v_isReactive',
+  IS_READONLY = '__v_isReadonly',
+  RAW = '__v_raw',
+  REACTIVE = '__v_reactive',
+  READONLY = '__v_readonly'
 }
 
 interface Target {
-  [ReactiveFlags.Skip]?: boolean
-  [ReactiveFlags.IsReactive]?: boolean
-  [ReactiveFlags.IsReadonly]?: boolean
-  [ReactiveFlags.Raw]?: any
-  [ReactiveFlags.Reactive]?: any
-  [ReactiveFlags.Readonly]?: any
+  [ReactiveFlags.SKIP]?: boolean
+  [ReactiveFlags.IS_REACTIVE]?: boolean
+  [ReactiveFlags.IS_READONLY]?: boolean
+  [ReactiveFlags.RAW]?: any
+  [ReactiveFlags.REACTIVE]?: any
+  [ReactiveFlags.READONLY]?: any
 }
 
 const collectionTypes = new Set<Function>([Set, Map, WeakMap, WeakSet])
@@ -37,7 +37,7 @@ const isObservableType = /*#__PURE__*/ makeMap(
 
 const canObserve = (value: Target): boolean => {
   return (
-    !value[ReactiveFlags.Skip] &&
+    !value[ReactiveFlags.SKIP] &&
     isObservableType(toRawType(value)) &&
     !Object.isFrozen(value)
   )
@@ -49,7 +49,7 @@ type UnwrapNestedRefs<T> = T extends Ref ? T : UnwrapRef<T>
 export function reactive<T extends object>(target: T): UnwrapNestedRefs<T>
 export function reactive(target: object) {
   // if trying to observe a readonly proxy, return the readonly version.
-  if (target && (target as Target)[ReactiveFlags.IsReadonly]) {
+  if (target && (target as Target)[ReactiveFlags.IS_READONLY]) {
     return target
   }
   return createReactiveObject(
@@ -113,18 +113,18 @@ function createReactiveObject(
   // target is already a Proxy, return it.
   // exception: calling readonly() on a reactive object
   if (
-    target[ReactiveFlags.Raw] &&
-    !(isReadonly && target[ReactiveFlags.IsReactive])
+    target[ReactiveFlags.RAW] &&
+    !(isReadonly && target[ReactiveFlags.IS_REACTIVE])
   ) {
     return target
   }
   // target already has corresponding Proxy
   if (
-    hasOwn(target, isReadonly ? ReactiveFlags.Readonly : ReactiveFlags.Reactive)
+    hasOwn(target, isReadonly ? ReactiveFlags.READONLY : ReactiveFlags.REACTIVE)
   ) {
     return isReadonly
-      ? target[ReactiveFlags.Readonly]
-      : target[ReactiveFlags.Reactive]
+      ? target[ReactiveFlags.READONLY]
+      : target[ReactiveFlags.REACTIVE]
   }
   // only a whitelist of value types can be observed.
   if (!canObserve(target)) {
@@ -136,7 +136,7 @@ function createReactiveObject(
   )
   def(
     target,
-    isReadonly ? ReactiveFlags.Readonly : ReactiveFlags.Reactive,
+    isReadonly ? ReactiveFlags.READONLY : ReactiveFlags.REACTIVE,
     observed
   )
   return observed
@@ -144,13 +144,13 @@ function createReactiveObject(
 
 export function isReactive(value: unknown): boolean {
   if (isReadonly(value)) {
-    return isReactive((value as Target)[ReactiveFlags.Raw])
+    return isReactive((value as Target)[ReactiveFlags.RAW])
   }
-  return !!(value && (value as Target)[ReactiveFlags.IsReactive])
+  return !!(value && (value as Target)[ReactiveFlags.IS_REACTIVE])
 }
 
 export function isReadonly(value: unknown): boolean {
-  return !!(value && (value as Target)[ReactiveFlags.IsReadonly])
+  return !!(value && (value as Target)[ReactiveFlags.IS_READONLY])
 }
 
 export function isProxy(value: unknown): boolean {
@@ -159,11 +159,11 @@ export function isProxy(value: unknown): boolean {
 
 export function toRaw<T>(observed: T): T {
   return (
-    (observed && toRaw((observed as Target)[ReactiveFlags.Raw])) || observed
+    (observed && toRaw((observed as Target)[ReactiveFlags.RAW])) || observed
   )
 }
 
 export function markRaw<T extends object>(value: T): T {
-  def(value, ReactiveFlags.Skip, true)
+  def(value, ReactiveFlags.SKIP, true)
   return value
 }

--- a/packages/reactivity/src/reactive.ts
+++ b/packages/reactivity/src/reactive.ts
@@ -22,12 +22,12 @@ export const enum ReactiveFlags {
 }
 
 interface Target {
-  __v_skip?: boolean
-  __v_isReactive?: boolean
-  __v_isReadonly?: boolean
-  __v_raw?: any
-  __v_reactive?: any
-  __v_readonly?: any
+  [ReactiveFlags.skip]?: boolean
+  [ReactiveFlags.isReactive]?: boolean
+  [ReactiveFlags.isReadonly]?: boolean
+  [ReactiveFlags.raw]?: any
+  [ReactiveFlags.reactive]?: any
+  [ReactiveFlags.readonly]?: any
 }
 
 const collectionTypes = new Set<Function>([Set, Map, WeakMap, WeakSet])

--- a/packages/runtime-core/src/componentProxy.ts
+++ b/packages/runtime-core/src/componentProxy.ts
@@ -212,7 +212,7 @@ export const PublicInstanceProxyHandlers: ProxyHandler<any> = {
     } = instance
 
     // let @vue/reatvitiy know it should never observe Vue public instances.
-    if (key === ReactiveFlags.skip) {
+    if (key === ReactiveFlags.Skip) {
       return true
     }
 

--- a/packages/runtime-core/src/componentProxy.ts
+++ b/packages/runtime-core/src/componentProxy.ts
@@ -212,7 +212,7 @@ export const PublicInstanceProxyHandlers: ProxyHandler<any> = {
     } = instance
 
     // let @vue/reatvitiy know it should never observe Vue public instances.
-    if (key === ReactiveFlags.Skip) {
+    if (key === ReactiveFlags.SKIP) {
       return true
     }
 


### PR DESCRIPTION
rename key to follow the naming conventions of enums