### PR TITLE
perf: replace the native String() with a function toString which is f…

### DIFF
--- a/packages/compiler-core/src/transforms/transformElement.ts
+++ b/packages/compiler-core/src/transforms/transformElement.ts
@@ -25,7 +25,8 @@ import {
   PatchFlagNames,
   isSymbol,
   isOn,
-  isObject
+  isObject,
+  toString
 } from '@vue/shared'
 import { createCompilerError, ErrorCodes } from '../errors'
 import {
@@ -187,7 +188,7 @@ export const transformElement: NodeTransform = (node, context) => {
           vnodePatchFlag = patchFlag + ` /* ${flagNames} */`
         }
       } else {
-        vnodePatchFlag = String(patchFlag)
+        vnodePatchFlag = toString(patchFlag)
       }
       if (dynamicPropNames && dynamicPropNames.length) {
         vnodeDynamicProps = stringifyDynamicPropNames(dynamicPropNames)

--- a/packages/compiler-dom/src/transforms/stringifyStatic.ts
+++ b/packages/compiler-dom/src/transforms/stringifyStatic.ts
@@ -26,7 +26,8 @@ import {
   normalizeClass,
   normalizeStyle,
   stringifyStyle,
-  makeMap
+  makeMap,
+  toString
 } from '@vue/shared'
 
 export const enum StringifyThresholds {
@@ -84,7 +85,7 @@ export const stringifyStatic: HoistTransform = (children, context, parent) => {
         ),
         // the 2nd argument indicates the number of DOM nodes this static vnode
         // will insert / hydrate
-        String(currentChunk.length)
+        toString(currentChunk.length)
       ])
       // replace the first node's hoisted expression with the static vnode call
       replaceHoist(currentChunk[0], staticCall, context)

--- a/packages/runtime-core/src/vnode.ts
+++ b/packages/runtime-core/src/vnode.ts
@@ -8,7 +8,8 @@ import {
   normalizeClass,
   normalizeStyle,
   PatchFlags,
-  ShapeFlags
+  ShapeFlags,
+  toString
 } from '@vue/shared'
 import {
   ComponentInternalInstance,
@@ -502,7 +503,7 @@ export function normalizeVNode(child: VNodeChild): VNode {
     return child.el === null ? child : cloneVNode(child)
   } else {
     // strings and numbers
-    return createVNode(Text, null, String(child))
+    return createVNode(Text, null, toString(child))
   }
 }
 
@@ -538,7 +539,7 @@ export function normalizeChildren(vnode: VNode, children: unknown) {
     children = { default: children, _ctx: currentRenderingInstance }
     type = ShapeFlags.SLOTS_CHILDREN
   } else {
-    children = String(children)
+    children = toString(children as string | number)
     // force teleport children to array so it can be moved around
     if (shapeFlag & ShapeFlags.TELEPORT) {
       type = ShapeFlags.ARRAY_CHILDREN

--- a/packages/shared/src/codeframe.ts
+++ b/packages/shared/src/codeframe.ts
@@ -1,3 +1,4 @@
+import { toString } from '@vue/shared'
 const range: number = 2
 
 export function generateCodeFrame(
@@ -14,7 +15,9 @@ export function generateCodeFrame(
       for (let j = i - range; j <= i + range || end > count; j++) {
         if (j < 0 || j >= lines.length) continue
         const line = j + 1
-        res.push(`${line}${' '.repeat(3 - String(line).length)}|  ${lines[j]}`)
+        res.push(
+          `${line}${' '.repeat(3 - toString(line).length)}|  ${lines[j]}`
+        )
         const lineLength = lines[j].length
         if (j === i) {
           // push underline

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -122,3 +122,7 @@ export const toNumber = (val: any): any => {
   const n = parseFloat(val)
   return isNaN(n) ? val : n
 }
+
+//just use to change a variable as number or string to string
+export const toString = (val: number | string): string =>
+  val.constructor === String ? val : `${val}`


### PR DESCRIPTION
There are some occasions that use native function ' String() '  to change a number or string to string.  However, I find 'String()' has a low performance and use `${}`  to do it can be faster.  Here is my test demo in jsperf(https://jsperf.com/test-speed-of-and-string12/1) . In Chrome  ' String() '  is about  46% slower and even 98% slower in Firefox.  When we are certain that the type of variable is number or  string,  the result of  `${}`  is equal to 'String()'  and  I have passed all tests.  For readability,  I wrap a function named 'toString' in shared.