### PR TITLE
fix(runtime-core): look up prop value from `props`.

### DIFF
--- a/packages/runtime-core/src/componentProxy.ts
+++ b/packages/runtime-core/src/componentProxy.ts
@@ -242,12 +242,7 @@ export const PublicInstanceProxyHandlers: ProxyHandler<any> = {
       } else if (data !== EMPTY_OBJ && hasOwn(data, key)) {
         accessCache![key] = AccessTypes.DATA
         return data[key]
-      } else if (
-        // only cache other properties when instance has declared (thus stable)
-        // props
-        type.props &&
-        hasOwn(normalizePropsOptions(type)[0]!, key)
-      ) {
+      } else if (props !== EMPTY_OBJ && hasOwn(props, key)) {
         accessCache![key] = AccessTypes.PROPS
         return props![key]
       } else if (ctx !== EMPTY_OBJ && hasOwn(ctx, key)) {
@@ -311,12 +306,12 @@ export const PublicInstanceProxyHandlers: ProxyHandler<any> = {
     key: string,
     value: any
   ): boolean {
-    const { data, setupState, ctx } = instance
+    const { data, setupState, ctx, props } = instance
     if (setupState !== EMPTY_OBJ && hasOwn(setupState, key)) {
       setupState[key] = value
     } else if (data !== EMPTY_OBJ && hasOwn(data, key)) {
       data[key] = value
-    } else if (key in instance.props) {
+    } else if (props !== EMPTY_OBJ && hasOwn(props, key)) {
       __DEV__ &&
         warn(
           `Attempting to mutate prop "${key}". Props are readonly.`,
@@ -348,7 +343,7 @@ export const PublicInstanceProxyHandlers: ProxyHandler<any> = {
 
   has(
     {
-      _: { data, setupState, accessCache, ctx, type, appContext }
+      _: { data, setupState, accessCache, props, ctx, appContext }
     }: ComponentRenderContext,
     key: string
   ) {
@@ -356,7 +351,7 @@ export const PublicInstanceProxyHandlers: ProxyHandler<any> = {
       accessCache![key] !== undefined ||
       (data !== EMPTY_OBJ && hasOwn(data, key)) ||
       (setupState !== EMPTY_OBJ && hasOwn(setupState, key)) ||
-      (type.props && hasOwn(normalizePropsOptions(type)[0]!, key)) ||
+      (props !== EMPTY_OBJ && hasOwn(props, key)) ||
       hasOwn(ctx, key) ||
       hasOwn(publicPropertiesMap, key) ||
       hasOwn(appContext.config.globalProperties, key)


### PR DESCRIPTION
fix #1236

> It fixed in 3.0.0-beta.15 development build. But it doesn't work in 3.0.0-beta.15 production build.

###Bug Description
In dev can be look up successful, because expose props into ctx by `exposePropsOnRenderContext`.
Other, it will not exist `type.props` when extend `props` from mixin.
So, we need look up the prop values from `props`.