### PR TITLE
fix(BaseTransition): collect correct children with `Transition` slot

### DIFF
--- a/packages/runtime-core/src/components/BaseTransition.ts
+++ b/packages/runtime-core/src/components/BaseTransition.ts
@@ -137,7 +137,8 @@ const BaseTransitionImpl = {
 
     return () => {
       const children = getTransitionRawChildren(
-        slots.default ? slots.default() : []
+        slots.default ? slots.default() : [],
+        true
       )
       if (!children || !children.length) {
         return
@@ -421,16 +422,24 @@ export function setTransitionHooks(vnode: VNode, hooks: TransitionHooks) {
   }
 }
 
-export function getTransitionRawChildren(children: VNode[]): VNode[] {
+export function getTransitionRawChildren(
+  children: VNode[],
+  keepComment: boolean = false
+): VNode[] {
   let ret: VNode[] = []
   for (let i = 0; i < children.length; i++) {
     const child = children[i]
     // handle fragment children case, e.g. v-for
     if (child.type === Fragment) {
-      ret = ret.concat(getTransitionRawChildren(child.children as VNode[]))
+      ret = ret.concat(
+        getTransitionRawChildren(child.children as VNode[], keepComment)
+      )
     }
     // comment placeholders should be skipped, e.g. v-if
-    else if (child.type !== Comment) {
+    else if (
+      child.type !== Comment ||
+      (child.type === Comment && keepComment)
+    ) {
       ret.push(child)
     }
   }

--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -91,7 +91,8 @@ export { registerRuntimeCompiler } from './component'
 export {
   useTransitionState,
   resolveTransitionHooks,
-  setTransitionHooks
+  setTransitionHooks,
+  getTransitionRawChildren
 } from './components/BaseTransition'
 
 // Types -----------------------------------------------------------------------

--- a/packages/runtime-dom/src/components/TransitionGroup.ts
+++ b/packages/runtime-dom/src/components/TransitionGroup.ts
@@ -9,7 +9,6 @@ import {
 } from './Transition'
 import {
   Fragment,
-  Comment,
   VNode,
   warn,
   resolveTransitionHooks,
@@ -22,6 +21,7 @@ import {
 } from '@vue/runtime-core'
 import { toRaw } from '@vue/reactivity'
 import { extend } from '@vue/shared'
+import { getTransitionRawChildren } from '../../../runtime-core/src/components/BaseTransition'
 
 interface Position {
   top: number
@@ -127,22 +127,6 @@ const TransitionGroupImpl = {
       return createVNode(tag, null, slotChildren)
     }
   }
-}
-
-function getTransitionRawChildren(children: VNode[]): VNode[] {
-  let ret: VNode[] = []
-  for (let i = 0; i < children.length; i++) {
-    const child = children[i]
-    // handle fragment children case, e.g. v-for
-    if (child.type === Fragment) {
-      ret = ret.concat(getTransitionRawChildren(child.children as VNode[]))
-    }
-    // comment placeholders should be skipped, e.g. v-if
-    else if (child.type !== Comment) {
-      ret.push(child)
-    }
-  }
-  return ret
 }
 
 // remove mode props as TransitionGroup doesn't support it

--- a/packages/runtime-dom/src/components/TransitionGroup.ts
+++ b/packages/runtime-dom/src/components/TransitionGroup.ts
@@ -13,6 +13,7 @@ import {
   warn,
   resolveTransitionHooks,
   useTransitionState,
+  getTransitionRawChildren,
   getCurrentInstance,
   setTransitionHooks,
   createVNode,
@@ -21,7 +22,6 @@ import {
 } from '@vue/runtime-core'
 import { toRaw } from '@vue/reactivity'
 import { extend } from '@vue/shared'
-import { getTransitionRawChildren } from '../../../runtime-core/src/components/BaseTransition'
 
 interface Position {
   top: number


### PR DESCRIPTION
fix #1455