### PR TITLE
fix(slots): filter out compiler marker from resolved slots

### DIFF
--- a/packages/runtime-core/src/componentSlots.ts
+++ b/packages/runtime-core/src/componentSlots.ts
@@ -104,7 +104,12 @@ export const initSlots = (
     if ((children as RawSlots)._ === 1) {
       const slots: InternalSlots = (instance.slots = {})
       for (const key in children as RawSlots) {
-        if (key !== '_') slots[key] = (children as Slots)[key]
+        Object.defineProperty(slots, key, {
+          configurable: true,
+          value: (children as Slots)[key],
+          enumerable: key !== '_',
+          writable: true
+        })
       }
     } else {
       normalizeObjectSlots(children as RawSlots, (instance.slots = {}))


### PR DESCRIPTION
fix #1470

### Bug Reason
It caused by #1451. The pre fix filter out the '_' marker caused the patchflags to PatchFlags.BAIL (fragment with`BaseComponent`) -> the pre `dynamicChildren` is null. 
```
slots._ ? PatchFlags.STABLE_FRAGMENT : PatchFlags.BAIL
```
``` in patch
if (n2.patchFlag === PatchFlags.BAIL) {
      optimized = false
      n2.dynamicChildren = null
    }
```