### PR TITLE
Lazy load for components and directives

### DIFF
--- a/packages/runtime-core/src/apiCreateApp.ts
+++ b/packages/runtime-core/src/apiCreateApp.ts
@@ -4,7 +4,11 @@ import {
   validateComponentName,
   PublicAPIComponent
 } from './component'
-import { ComponentOptions } from './componentOptions'
+import {
+  ComponentOptions,
+  LazyComponentResolver,
+  LazyDirectiveResolver
+} from './componentOptions'
 import { ComponentPublicInstance } from './componentProxy'
 import { Directive, validateDirectiveName } from './directives'
 import { RootRenderFunction } from './renderer'
@@ -71,6 +75,8 @@ export interface AppContext {
   mixins: ComponentOptions[]
   components: Record<string, PublicAPIComponent>
   directives: Record<string, Directive>
+  getComponent?: LazyComponentResolver
+  getDirective?: LazyDirectiveResolver
   provides: Record<string | symbol, any>
   reload?: () => void // HMR only
 }
@@ -118,6 +124,8 @@ export function createAppAPI<HostElement>(
     }
 
     const context = createAppContext()
+    context.getComponent = (rootComponent as ComponentOptions).getComponent
+    context.getDirective = (rootComponent as ComponentOptions).getDirective
     const installedPlugins = new Set()
 
     let isMounted = false

--- a/packages/runtime-core/src/component.ts
+++ b/packages/runtime-core/src/component.ts
@@ -25,7 +25,12 @@ import { warn } from './warning'
 import { ErrorCodes, callWithErrorHandling } from './errorHandling'
 import { AppContext, createAppContext, AppConfig } from './apiCreateApp'
 import { Directive, validateDirectiveName } from './directives'
-import { applyOptions, ComponentOptions } from './componentOptions'
+import {
+  applyOptions,
+  ComponentOptions,
+  LazyComponentResolver,
+  LazyDirectiveResolver
+} from './componentOptions'
 import {
   EmitsOptions,
   ObjectEmitsOptions,
@@ -214,6 +219,12 @@ export interface ComponentInternalInstance {
    */
   directives: Record<string, Directive>
 
+  /**
+   * Functions for lazy loading os assets, only when they are required
+   */
+  getComponent: LazyComponentResolver | undefined
+  getDirective: LazyDirectiveResolver | undefined
+
   // the rest are only for stateful components ---------------------------------
 
   // main proxy that serves as the public instance (`this`)
@@ -366,6 +377,10 @@ export function createComponentInstance(
     // per-instance asset storage (mutable during options resolution)
     components: Object.create(appContext.components),
     directives: Object.create(appContext.directives),
+
+    // lazy asset resolvers
+    getComponent: appContext.getComponent,
+    getDirective: appContext.getDirective,
 
     // suspense related
     suspense,

--- a/packages/runtime-core/src/componentOptions.ts
+++ b/packages/runtime-core/src/componentOptions.ts
@@ -75,6 +75,16 @@ export interface ComponentCustomOptions {}
 
 export type RenderFunction = () => VNodeChild
 
+export type LazyComponentResolver = (
+  s: Object,
+  i: ComponentInternalInstance
+) => Component | undefined
+
+export type LazyDirectiveResolver = (
+  s: Object,
+  i: ComponentInternalInstance
+) => Directive | undefined
+
 export interface ComponentOptionsBase<
   Props,
   RawBindings,
@@ -104,6 +114,8 @@ export interface ComponentOptionsBase<
   render?: Function
   components?: Record<string, PublicAPIComponent>
   directives?: Record<string, Directive>
+  getComponent?: LazyComponentResolver
+  getDirective?: LazyDirectiveResolver
   inheritAttrs?: boolean
   inheritRef?: boolean
   emits?: E | EE[]

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -101,6 +101,20 @@ export const capitalize = cacheStringFunction(
   }
 )
 
+/**
+ * Get all variations of a identifier spelling.
+ */
+export const identifierSpellings = (str: string): Object => {
+  const camelized = camelize(str)
+  return {
+    raw: str,
+    hyphenated: hyphenate(str),
+    camelized: camelized,
+    PascalCase: capitalize(camelized),
+    toString: () => str
+  }
+}
+
 // compare whether a value has changed, accounting for NaN.
 export const hasChanged = (value: any, oldValue: any): boolean =>
   value !== oldValue && (value === value || oldValue === oldValue)


### PR DESCRIPTION
I know this type of change require _a lot_ of discussion. I'm submitting this for reference to whoever else needs this. I mantain a Vue 2.x fork with this feature which I use in many many sites and apps. This PR is the Vue 3 version of this feature.

I'll close this PR myself. All the reasoning is explained at length on the Vue 2 issue linked below.

- **Vue 3.x Fork:** https://github.com/arijs/vue-next/tree/lazy-load-assets

- **Vue 2.x Fork:** https://github.com/arijs/vue/tree/lazy-load-assets

- **Release on NPM:** https://www.npmjs.com/package/@arijs/vue

- **Vue 2.x PR:** https://github.com/vuejs/vue/pull/8807

- **Vue 2.x Issue:** https://github.com/vuejs/vue/issues/8106

About the merit of the actual implementation, I have done the absolute minimum for it to build and run a very simple test. I'm not an expert on Typescript, maybe the implementation could be improved and there are no tests yet, they still have to be written.

Here's my code I used to test it:

```html
<!DOCTYPE html>
<html lang="en">
<head>
	<meta charset="UTF-8">
	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
	<title>Vue 3 Lazy Load test</title>
</head>
<body>
	<div id="root">
		<div>
			{{ state.value }}
		</div>
		<shift-foo></shift-foo>
	</div>
	<script src="js/vendor/vue.global.js"></script>
	<script>

var appRoot = Vue.createApp({
	setup: function() {
		var state = Vue.reactive({
			value: 42
		});
		return {
			state: state
		};
	},
	getComponent: function(spellings, instance) {
		console.log('App GetComponent', spellings, instance);
		// example of spellings object:
		// {
		// 	"raw": "shift-foo",
		// 	"hyphenated": "shift-foo",
		// 	"camelized": "shiftFoo",
		// 	"PascalCase": "ShiftFoo"
		// }
		// In reality, you should return a component corresponding to the name in the object above
		return {
			template: '<div><p>She\'s like the {{state.shesLikeThe}}</p></div>',
			setup: function() {
				var state = Vue.reactive({
					shesLikeThe: 'wind'
				});
				return {
					state: state
				};
			}
		}
	}
}).mount('#root');

	</script>
</body>
</html>
```