### PR TITLE
feat(runtime-core): expose WritableComputedRef

### DIFF
--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -122,6 +122,7 @@ export {
   TriggerOpTypes,
   Ref,
   ComputedRef,
+  WritableComputedRef,
   UnwrapRef,
   WritableComputedOptions,
   ToRefs


### PR DESCRIPTION
Make `import { WritableComputedRef } from 'vue'` work