### PR TITLE
feat(compiler-ssr): support dynamic components that resolve to element(fix: #1508)

### DIFF
--- a/packages/compiler-core/src/ast.ts
+++ b/packages/compiler-core/src/ast.ts
@@ -143,7 +143,8 @@ export interface ComponentNode extends BaseElementNode {
     | VNodeCall
     | CacheExpression // when cached by v-once
     | undefined
-  ssrCodegenNode?: CallExpression
+  ssrCodegenNode?: CallExpression | SequenceExpression | BlockStatement
+  asStatement?: boolean
 }
 
 export interface SlotOutletNode extends BaseElementNode {
@@ -380,7 +381,7 @@ export interface TemplateLiteral extends Node {
 
 export interface IfStatement extends Node {
   type: NodeTypes.JS_IF_STATEMENT
-  test: ExpressionNode
+  test: ExpressionNode | CallExpression
   consequent: BlockStatement
   alternate: IfStatement | BlockStatement | ReturnStatement | undefined
 }

--- a/packages/compiler-ssr/__tests__/ssrComponent.spec.ts
+++ b/packages/compiler-ssr/__tests__/ssrComponent.spec.ts
@@ -21,20 +21,34 @@ describe('ssr: components', () => {
     expect(compile(`<component is="foo" prop="b" />`).code)
       .toMatchInlineSnapshot(`
       "const { resolveDynamicComponent: _resolveDynamicComponent, mergeProps: _mergeProps } = require(\\"vue\\")
-      const { ssrRenderComponent: _ssrRenderComponent } = require(\\"@vue/server-renderer\\")
+      const { ssrIsComponent: _ssrIsComponent, ssrRenderComponent: _ssrRenderComponent, ssrRenderVNode: _ssrRenderVNode } = require(\\"@vue/server-renderer\\")
 
       return function ssrRender(_ctx, _push, _parent, _attrs) {
-        _push(_ssrRenderComponent(_resolveDynamicComponent(\\"foo\\"), _mergeProps({ prop: \\"b\\" }, _attrs), null, _parent))
+        let _temp0
+
+        _temp0 = _resolveDynamicComponent(\\"foo\\")
+        if (_ssrIsComponent(_temp0)) {
+          _push(_ssrRenderComponent(_temp0, _mergeProps({ prop: \\"b\\" }, _attrs), null, _parent))
+        } else {
+          _ssrRenderVNode(_temp0, _mergeProps({ prop: \\"b\\" }, _attrs), null, _push, _parent)
+        }
       }"
     `)
 
     expect(compile(`<component :is="foo" prop="b" />`).code)
       .toMatchInlineSnapshot(`
       "const { resolveDynamicComponent: _resolveDynamicComponent, mergeProps: _mergeProps } = require(\\"vue\\")
-      const { ssrRenderComponent: _ssrRenderComponent } = require(\\"@vue/server-renderer\\")
+      const { ssrIsComponent: _ssrIsComponent, ssrRenderComponent: _ssrRenderComponent, ssrRenderVNode: _ssrRenderVNode } = require(\\"@vue/server-renderer\\")
 
       return function ssrRender(_ctx, _push, _parent, _attrs) {
-        _push(_ssrRenderComponent(_resolveDynamicComponent(_ctx.foo), _mergeProps({ prop: \\"b\\" }, _attrs), null, _parent))
+        let _temp0
+
+        _temp0 = _resolveDynamicComponent(_ctx.foo)
+        if (_ssrIsComponent(_temp0)) {
+          _push(_ssrRenderComponent(_temp0, _mergeProps({ prop: \\"b\\" }, _attrs), null, _parent))
+        } else {
+          _ssrRenderVNode(_temp0, _mergeProps({ prop: \\"b\\" }, _attrs), null, _push, _parent)
+        }
       }"
     `)
   })

--- a/packages/compiler-ssr/src/runtimeHelpers.ts
+++ b/packages/compiler-ssr/src/runtimeHelpers.ts
@@ -1,7 +1,9 @@
 import { registerRuntimeHelpers } from '@vue/compiler-dom'
 
 export const SSR_INTERPOLATE = Symbol(`ssrInterpolate`)
+export const SSR_RENDER_VNODE = Symbol(`ssrRenderVNode`)
 export const SSR_RENDER_COMPONENT = Symbol(`ssrRenderComponent`)
+export const SSR_IS_COMPONENT = Symbol(`ssrIsComponent`)
 export const SSR_RENDER_SLOT = Symbol(`ssrRenderSlot`)
 export const SSR_RENDER_CLASS = Symbol(`ssrRenderClass`)
 export const SSR_RENDER_STYLE = Symbol(`ssrRenderStyle`)
@@ -18,7 +20,9 @@ export const SSR_RENDER_SUSPENSE = Symbol(`ssrRenderSuspense`)
 
 export const ssrHelpers = {
   [SSR_INTERPOLATE]: `ssrInterpolate`,
+  [SSR_RENDER_VNODE]: `ssrRenderVNode`,
   [SSR_RENDER_COMPONENT]: `ssrRenderComponent`,
+  [SSR_IS_COMPONENT]: `ssrIsComponent`,
   [SSR_RENDER_SLOT]: `ssrRenderSlot`,
   [SSR_RENDER_CLASS]: `ssrRenderClass`,
   [SSR_RENDER_STYLE]: `ssrRenderStyle`,

--- a/packages/compiler-ssr/src/ssrCodegenTransform.ts
+++ b/packages/compiler-ssr/src/ssrCodegenTransform.ts
@@ -11,7 +11,8 @@ import {
   CompilerOptions,
   IfStatement,
   CallExpression,
-  isText
+  isText,
+  AssignmentExpression
 } from '@vue/compiler-dom'
 import { isString, escapeHtml } from '@vue/shared'
 import { SSR_INTERPOLATE, ssrHelpers } from './runtimeHelpers'
@@ -85,7 +86,9 @@ function createSSRTransformContext(
         bufferedElements.push(part)
       }
     },
-    pushStatement(statement: IfStatement | CallExpression) {
+    pushStatement(
+      statement: IfStatement | CallExpression | AssignmentExpression
+    ) {
       // close current string
       currentString = null
       body.push(statement)

--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -84,7 +84,8 @@ export {
 export {
   resolveComponent,
   resolveDirective,
-  resolveDynamicComponent
+  resolveDynamicComponent,
+  NULL_DYNAMIC_COMPONENT
 } from './helpers/resolveAssets'
 // For integration with runtime compiler
 export { registerRuntimeCompiler } from './component'

--- a/packages/server-renderer/src/helpers/ssrRenderComponent.ts
+++ b/packages/server-renderer/src/helpers/ssrRenderComponent.ts
@@ -1,4 +1,11 @@
-import { Component, ComponentInternalInstance, createVNode, Slots } from 'vue'
+import {
+  Component,
+  ComponentInternalInstance,
+  createVNode,
+  Slots,
+  resolveDynamicComponent,
+  NULL_DYNAMIC_COMPONENT
+} from 'vue'
 import { Props, renderComponentVNode, SSRBuffer } from '../render'
 import { SSRSlots } from './ssrRenderSlot'
 
@@ -12,4 +19,10 @@ export function ssrRenderComponent(
     createVNode(comp, props, children),
     parentComponent
   )
+}
+
+export function ssrIsComponent(
+  comp: ReturnType<typeof resolveDynamicComponent>
+) {
+  return typeof comp !== 'string' && comp !== NULL_DYNAMIC_COMPONENT
 }

--- a/packages/server-renderer/src/helpers/ssrRenderVNode.ts
+++ b/packages/server-renderer/src/helpers/ssrRenderVNode.ts
@@ -1,0 +1,17 @@
+import {
+  ComponentInternalInstance,
+  createVNode,
+  NULL_DYNAMIC_COMPONENT
+} from 'vue'
+import { Props, renderVNode, PushFn } from '../render'
+
+// for dynamic components that resolve to normal element
+export function ssrRenderVNode(
+  tag: string | typeof NULL_DYNAMIC_COMPONENT,
+  props: Props | null = null,
+  children: unknown = null,
+  push: PushFn,
+  parentComponent: ComponentInternalInstance
+) {
+  renderVNode(push, createVNode(tag, props, children), parentComponent)
+}

--- a/packages/server-renderer/src/render.ts
+++ b/packages/server-renderer/src/render.ts
@@ -142,7 +142,7 @@ function renderComponentSubTree(
   return getBuffer()
 }
 
-function renderVNode(
+export function renderVNode(
   push: PushFn,
   vnode: VNode,
   parentComponent: ComponentInternalInstance


### PR DESCRIPTION
For template:

```html
<component
  :is="multiline ? 'textarea' : 'input'"
  a=b
/>
```

Before:

```js
import { resolveDynamicComponent as _resolveDynamicComponent, mergeProps as _mergeProps } from "vue"
import { ssrRenderComponent as _ssrRenderComponent } from "@vue/server-renderer"

export function ssrRender(_ctx, _push, _parent, _attrs) {
  _push(_ssrRenderComponent(_resolveDynamicComponent(_ctx.multiline ? 'textarea' : 'input'), _mergeProps({ a: "b" }, _attrs), null, _parent))
}
```

Now:

```js
import { resolveDynamicComponent as _resolveDynamicComponent, mergeProps as _mergeProps } from "vue"
import { ssrIsComponent as _ssrIsComponent, ssrRenderComponent as _ssrRenderComponent, ssrRenderVNode as _ssrRenderVNode } from "@vue/server-renderer"

export function ssrRender(_ctx, _push, _parent, _attrs) {
  let _temp0

  _temp0 = _resolveDynamicComponent(_ctx.multiline ? 'textarea' : 'input')
  if (_ssrIsComponent(_temp0)) {
    _push(_ssrRenderComponent(_temp0, _mergeProps({ a: "b" }, _attrs), null, _parent))
  } else {
    _ssrRenderVNode(_temp0, _mergeProps({ a: "b" }, _attrs), null, _push, _parent)
  }
}
```

I think this can work?