### PR TITLE
fix(runtime-dom): add JSX.IntrinsicAttributes definition(#1516)

### DIFF
--- a/packages/runtime-dom/types/jsx.d.ts
+++ b/packages/runtime-dom/types/jsx.d.ts
@@ -1334,6 +1334,7 @@ declare global {
       // @ts-ignore supress ts:2374 = Duplicate string index signature.
       [name: string]: any
     }
+    interface IntrinsicAttributes extends ReservedProps {}
   }
 }
 

--- a/test-dts/functionalComponent.test-d.tsx
+++ b/test-dts/functionalComponent.test-d.tsx
@@ -5,6 +5,8 @@ const Foo = (props: { foo: number }) => props.foo
 
 // TSX
 expectType<JSX.Element>(<Foo foo={1} />)
+expectType<JSX.Element>(<Foo foo={1} key="1" />)
+expectType<JSX.Element>(<Foo foo={1} ref="ref" />)
 // @ts-expect-error
 expectError(<Foo />)
 //  @ts-expect-error


### PR DESCRIPTION
`JSX.IntrinsicAttributes` represents common attributes of components.
Props of functional components are determined by type of first argument and this type.