### PR TITLE
fix(runtime-core): don't clone a new VNode when used with scopeid

### DIFF
--- a/packages/runtime-core/src/componentRenderUtils.ts
+++ b/packages/runtime-core/src/componentRenderUtils.ts
@@ -11,10 +11,11 @@ import {
   cloneVNode,
   Fragment,
   VNodeArrayChildren,
-  isVNode
+  isVNode,
+  mergeProps
 } from './vnode'
 import { handleError, ErrorCodes } from './errorHandling'
-import { PatchFlags, ShapeFlags, isOn } from '@vue/shared'
+import { PatchFlags, ShapeFlags, isOn, extend } from '@vue/shared'
 import { warn } from './warning'
 import { isHmrUpdating } from './hmr'
 
@@ -157,7 +158,11 @@ export function renderComponentRoot(
       const extras: Data = {}
       if (scopeId) extras[scopeId] = ''
       if (slotScopeId) extras[slotScopeId] = ''
-      root = cloneVNode(root, extras)
+
+      const props = root.props
+        ? mergeProps(root.props, extras)
+        : extend({}, extras)
+      root.props = props
     }
 
     // inherit directives


### PR DESCRIPTION
fix: #1511 