### PR TITLE
fix(v-model): keep the same behavior as `v-model` with `undefined`value with 2.x

### DIFF
--- a/packages/runtime-dom/__tests__/directives/vModel.spec.ts
+++ b/packages/runtime-dom/__tests__/directives/vModel.spec.ts
@@ -48,6 +48,7 @@ describe('vModel', () => {
 
     const input = root.querySelector('input')!
     const data = root._vnode.component.data
+    expect(input.value).toEqual('')
 
     input.value = 'foo'
     triggerEvent('input', input)
@@ -57,6 +58,10 @@ describe('vModel', () => {
     data.value = 'bar'
     await nextTick()
     expect(input.value).toEqual('bar')
+
+    data.value = undefined
+    await nextTick()
+    expect(input.value).toEqual('')
   })
 
   it('should work with multiple listeners', async () => {

--- a/packages/runtime-dom/src/directives/vModel.ts
+++ b/packages/runtime-dom/src/directives/vModel.ts
@@ -47,7 +47,7 @@ export const vModelText: ModelDirective<
   HTMLInputElement | HTMLTextAreaElement
 > = {
   beforeMount(el, { value, modifiers: { lazy, trim, number } }, vnode) {
-    el.value = value
+    if (value !== undefined && value !== null) el.value = value
     el._assign = getModelAssigner(vnode)
     const castToNumber = number || el.type === 'number'
     addEventListener(el, lazy ? 'change' : 'input', e => {
@@ -85,6 +85,7 @@ export const vModelText: ModelDirective<
         return
       }
     }
+    if (value === undefined || value === null) value = ''
     el.value = value
   }
 }

--- a/packages/runtime-dom/src/directives/vModel.ts
+++ b/packages/runtime-dom/src/directives/vModel.ts
@@ -47,7 +47,7 @@ export const vModelText: ModelDirective<
   HTMLInputElement | HTMLTextAreaElement
 > = {
   beforeMount(el, { value, modifiers: { lazy, trim, number } }, vnode) {
-    if (value !== undefined && value !== null) el.value = value
+    el.value = value == null ? '' : value
     el._assign = getModelAssigner(vnode)
     const castToNumber = number || el.type === 'number'
     addEventListener(el, lazy ? 'change' : 'input', e => {
@@ -85,8 +85,7 @@ export const vModelText: ModelDirective<
         return
       }
     }
-    if (value === undefined || value === null) value = ''
-    el.value = value
+    el.value = value == null ? '' : value
   }
 }
 


### PR DESCRIPTION
fix #1528