### PR TITLE
chore:  add depsMap?.size to check should trigger

### DIFF
--- a/packages/reactivity/src/effect.ts
+++ b/packages/reactivity/src/effect.ts
@@ -171,7 +171,7 @@ export function trigger(
   oldTarget?: Map<unknown, unknown> | Set<unknown>
 ) {
   const depsMap = targetMap.get(target)
-  if (!(depsMap?.size)) {
+  if (!depsMap || !depsMap.size) {
     // never been tracked
     return
   }

--- a/packages/reactivity/src/effect.ts
+++ b/packages/reactivity/src/effect.ts
@@ -171,7 +171,7 @@ export function trigger(
   oldTarget?: Map<unknown, unknown> | Set<unknown>
 ) {
   const depsMap = targetMap.get(target)
-  if (!depsMap) {
+  if (!(depsMap?.size)) {
     // never been tracked
     return
   }


### PR DESCRIPTION
[Map.prototype.size](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/size) is a integer , and it should be 0 or bigger than 0.

if the size is 0, should not trigger too, and avoid unnecessary operation.

```ts
// ...
const depsMap = targetMap.get(target)
  if (!(depsMap?.size)) {
    // never been tracked
    return
  }
// ...
```