### PR TITLE
chore: add missing `computed: true` for the effect option of computed

### DIFF
--- a/packages/reactivity/src/computed.ts
+++ b/packages/reactivity/src/computed.ts
@@ -47,6 +47,7 @@ export function computed<T>(
 
   const runner = effect(getter, {
     lazy: true,
+    computed: true,
     scheduler: () => {
       if (!dirty) {
         dirty = true


### PR DESCRIPTION
chore: add missing `computed: true` for the effect option of computed

https://github.com/vuejs/vue-next/blob/9152a8901653d7cef864a52a3c618afcc70d827d/packages/reactivity/src/effect.ts#L22-L29