### PR TITLE
types(runtime-core): default `SetupContext` generic argument to `EmitsOptions`

### DIFF
--- a/packages/runtime-core/src/component.ts
+++ b/packages/runtime-core/src/component.ts
@@ -132,7 +132,7 @@ export const enum LifecycleHooks {
   ERROR_CAPTURED = 'ec'
 }
 
-export interface SetupContext<E = ObjectEmitsOptions> {
+export interface SetupContext<E = EmitsOptions> {
   attrs: Data
   slots: Slots
   emit: EmitFn<E>

--- a/test-dts/defineComponent.test-d.tsx
+++ b/test-dts/defineComponent.test-d.tsx
@@ -7,7 +7,9 @@ import {
   createApp,
   expectError,
   expectType,
-  ComponentPublicInstance
+  ComponentPublicInstance,
+  ComponentOptions,
+  SetupContext
 } from './index'
 
 describe('with object props', () => {
@@ -683,4 +685,11 @@ describe('emits', () => {
   const instance = {} as ComponentPublicInstance
   instance.$emit('test', 1)
   instance.$emit('test')
+})
+
+describe('componentOptions setup should be `SetupContext`', () => {
+  expect<ComponentOptions['setup']>({} as (
+    props: Record<string, any>,
+    ctx: SetupContext
+  ) => any)
 })


### PR DESCRIPTION
`vue-class-component` is broken https://github.com/vuejs/vue-next/pull/1498#issuecomment-658550984

The issue is caused by the default value of `SetupContext<ObjectEmitsOptions>` not being the same as the default on the ComponentOptions setup `SetupContext<EmitsOptions>`