### PR TITLE
chore(share):element tag and shadow tag is deprecated

### DIFF
--- a/packages/shared/src/domTagConfig.ts
+++ b/packages/shared/src/domTagConfig.ts
@@ -12,7 +12,7 @@ const HTML_TAGS =
   'canvas,script,noscript,del,ins,caption,col,colgroup,table,thead,tbody,td,' +
   'th,tr,button,datalist,fieldset,form,input,label,legend,meter,optgroup,' +
   'option,output,progress,select,textarea,details,dialog,menu,menuitem,' +
-  'summary,content,element,shadow,template,blockquote,iframe,tfoot'
+  'summary,content,template,blockquote,iframe,tfoot'
 
 // https://developer.mozilla.org/en-US/docs/Web/SVG/Element
 const SVG_TAGS =


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/element
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/shadow