### PR TITLE
feat(watcher): introduce 'final' flush mode

### DIFF
--- a/packages/runtime-core/src/apiWatch.ts
+++ b/packages/runtime-core/src/apiWatch.ts
@@ -29,7 +29,7 @@ import {
   callWithErrorHandling,
   callWithAsyncErrorHandling
 } from './errorHandling'
-import { queuePostRenderEffect } from './renderer'
+import { queueFinalRenderEffect, queuePostRenderEffect } from './renderer'
 import { warn } from './warning'
 
 export type WatchEffect = (onInvalidate: InvalidateCbRegistrator) => void
@@ -59,7 +59,7 @@ type MapOldSources<T, Immediate> = {
 type InvalidateCbRegistrator = (cb: () => void) => void
 
 export interface WatchOptionsBase {
-  flush?: 'pre' | 'post' | 'sync'
+  flush?: 'pre' | 'post' | 'sync' | 'final'
   onTrack?: ReactiveEffectOptions['onTrack']
   onTrigger?: ReactiveEffectOptions['onTrigger']
 }
@@ -269,6 +269,9 @@ function doWatch(
         job()
       }
     }
+  } else if (flush === 'final') {
+    scheduler = job =>
+      queueFinalRenderEffect(job, instance && instance.suspense)
   } else {
     scheduler = job => queuePostRenderEffect(job, instance && instance.suspense)
   }

--- a/packages/runtime-core/src/hydration.ts
+++ b/packages/runtime-core/src/hydration.ts
@@ -16,7 +16,7 @@ import { RendererInternals, invokeVNodeHook, setRef } from './renderer'
 import {
   SuspenseImpl,
   SuspenseBoundary,
-  queueEffectWithSuspense
+  queuePostEffectWithSuspense
 } from './components/Suspense'
 import { TeleportImpl } from './components/Teleport'
 
@@ -271,7 +271,7 @@ export function createHydrationFunctions(
         invokeDirectiveHook(vnode, null, parentComponent, 'beforeMount')
       }
       if ((vnodeHooks = props && props.onVnodeMounted) || dirs) {
-        queueEffectWithSuspense(() => {
+        queuePostEffectWithSuspense(() => {
           vnodeHooks && invokeVNodeHook(vnodeHooks, parentComponent, vnode)
           dirs && invokeDirectiveHook(vnode, null, parentComponent, 'mounted')
         }, parentSuspense)

--- a/packages/runtime-core/src/renderer.ts
+++ b/packages/runtime-core/src/renderer.ts
@@ -41,7 +41,8 @@ import {
   queueJob,
   queuePostFlushCb,
   flushPostFlushCbs,
-  invalidateJob
+  invalidateJob,
+  queueFinalFlushCb
 } from './scheduler'
 import { effect, stop, ReactiveEffectOptions, isRef } from '@vue/reactivity'
 import { updateProps } from './componentProps'
@@ -50,8 +51,9 @@ import { pushWarningContext, popWarningContext, warn } from './warning'
 import { createAppAPI, CreateAppFunction } from './apiCreateApp'
 import {
   SuspenseBoundary,
-  queueEffectWithSuspense,
-  SuspenseImpl
+  queuePostEffectWithSuspense,
+  SuspenseImpl,
+  queueFinalEffectWithSuspense
 } from './components/Suspense'
 import { TeleportImpl } from './components/Teleport'
 import { isKeepAlive, KeepAliveContext } from './components/KeepAlive'
@@ -269,8 +271,12 @@ function createDevEffectOptions(
 }
 
 export const queuePostRenderEffect = __FEATURE_SUSPENSE__
-  ? queueEffectWithSuspense
+  ? queuePostEffectWithSuspense
   : queuePostFlushCb
+
+export const queueFinalRenderEffect = __FEATURE_SUSPENSE__
+  ? queueFinalEffectWithSuspense
+  : queueFinalFlushCb
 
 export const setRef = (
   rawRef: VNodeNormalizedRef,


### PR DESCRIPTION
In this PR the 'final' WatcherOptions flush mode is added.

'final' flush mode executes the watcher callbacks after all other effects (with multiple iterations).

Why is this necessary?

```javascript
  it('multi-iteration reactivity: post', async () => {
    const count = ref(0)
    const count2 = ref(0)
    const count3 = ref(0)

    watchEffect(() => {
      count2.value = count.value * 2
    })

    watchEffect(() => {
      count3.value = count2.value * 2
    })

    const results: number[] = []
    const assertion = jest.fn(() => {
      const c1 = count.value
      const c2 = count2.value
      const c3 = count3.value
      results.push(c1 + 10 * c2 + 100 * c3)
    })

    watchEffect(
      () => {
        assertion()
      },
      {
        flush: 'post'
      }
    )

    expect(assertion).toHaveBeenCalledTimes(1)

    count.value++
    await nextTick()

    expect(results).toEqual([0, 21, 421])
    expect(assertion).toHaveBeenCalledTimes(3)
  })
```

`assertion` is executed double (3 times in total because of the initial call).

The reason is that value it watches may have inter-dependencies, triggering each other in multi-iteration `flushPostQueue` runs. In every iteration `assertion` may be added and invoked.

We have a real world use case. We have a component that creates some div elements with scrollbars. You can change the `zoom` value, which in turn changes the `visibleRange` using a `watchEffects`. Another part of the application watches `zoom` and `visibleRangeX` (and more) to finally draw stuff in a canvas. We noticed this draw function being called multiple times because of the issue described by @jods4. The draw function is very expensive so we don't want that to happen.

Although the recent commit https://github.com/vuejs/vue-next/commit/165068dbc295bb70fdec9ae56dfcaac17d2f977c (see https://github.com/vuejs/vue-next/issues/1595) mitigates the problem somewhat by checking if the effect was still on the queue (and it has not been run yet), it can still go wrong when watchers that have multi-level dependencies, or when the effect was already executed in the pending PostFlushCbs.

This PR addresses this problem by providing a way of postponing the effect until everything else has been processed. This allows you to make sure that an expensive watcher is run only once in multi-iteration flushes.