### PR TITLE
chore: better comment hovers preview

### DIFF
--- a/packages/compiler-core/src/options.ts
+++ b/packages/compiler-core/src/options.ts
@@ -10,19 +10,19 @@ import { ParserPlugin } from '@babel/parser'
 
 export interface ParserOptions {
   /**
-   * e.g. platform native elements, e.g. <div> for browsers
+   * e.g. platform native elements, e.g. `<div>` for browsers
    */
   isNativeTag?: (tag: string) => boolean
   /**
-   * e.g. native elements that can self-close, e.g. <img>, <br>, <hr>
+   * e.g. native elements that can self-close, e.g. `<img>`, `<br>`, `<hr>`
    */
   isVoidTag?: (tag: string) => boolean
   /**
-   * e.g. elements that should preserve whitespace inside, e.g. <pre>
+   * e.g. elements that should preserve whitespace inside, e.g. `<pre>`
    */
   isPreTag?: (tag: string) => boolean
   /**
-   * Platform-specific built-in components e.g. <Transition>
+   * Platform-specific built-in components e.g. `<Transition>`
    */
   isBuiltInComponent?: (tag: string) => symbol | void
   /**
@@ -127,7 +127,7 @@ export interface TransformOptions {
    */
   ssr?: boolean
   /**
-   * SFC <style vars> injection string
+   * SFC `<style vars>` injection string
    * needed to render inline CSS variables on component root
    */
   ssrCssVars?: string

--- a/packages/compiler-sfc/src/compileScript.ts
+++ b/packages/compiler-sfc/src/compileScript.ts
@@ -876,7 +876,7 @@ function genRuntimeEmits(emits: Set<string>) {
 }
 
 /**
- * export default {} inside <script setup> cannot access variables declared
+ * export default {} inside `<script setup>` cannot access variables declared
  * inside since it's hoisted. Walk and check to make sure.
  */
 function checkDefaultExport(

--- a/packages/runtime-core/src/helpers/renderSlot.ts
+++ b/packages/runtime-core/src/helpers/renderSlot.ts
@@ -11,7 +11,7 @@ import { PatchFlags, SlotFlags } from '@vue/shared'
 import { warn } from '../warning'
 
 /**
- * Compiler runtime helper for rendering <slot/>
+ * Compiler runtime helper for rendering `<slot/>`
  * @private
  */
 export function renderSlot(

--- a/packages/shared/src/slotFlags.ts
+++ b/packages/shared/src/slotFlags.ts
@@ -12,7 +12,7 @@ export const enum SlotFlags {
    */
   DYNAMIC = 2,
   /**
-   * <slot/> being forwarded into a child component. Whether the parent needs
+   * `<slot/>` being forwarded into a child component. Whether the parent needs
    * to update the child is dependent on what kind of slots the parent itself
    * received. This has to be refined at runtime, when the child's vnode
    * is being created (in `normalizeChildren`)


### PR DESCRIPTION
The markdown parser of VSCode explicitly disables html tags.

<!--
maybe related microsoft/vscode#40607
-->

Before
![Screen Shot 2020-07-17 at 4 51 29 PM](https://user-images.githubusercontent.com/18554747/87767805-c74d7280-c84d-11ea-8fea-206021637834.png)

After
![Screen Shot 2020-07-17 at 4 50 45 PM](https://user-images.githubusercontent.com/18554747/87767744-ae44c180-c84d-11ea-84f7-3c57ce47688a.png)
