### PR TITLE
chore(shared):menuitem tag has been deprecated

### DIFF
--- a/packages/shared/src/domTagConfig.ts
+++ b/packages/shared/src/domTagConfig.ts
@@ -11,7 +11,7 @@ const HTML_TAGS =
   'time,u,var,wbr,area,audio,map,track,video,embed,object,param,source,' +
   'canvas,script,noscript,del,ins,caption,col,colgroup,table,thead,tbody,td,' +
   'th,tr,button,datalist,fieldset,form,input,label,legend,meter,optgroup,' +
-  'option,output,progress,select,textarea,details,dialog,menu,menuitem,' +
+  'option,output,progress,select,textarea,details,dialog,menu,' +
   'summary,content,template,blockquote,iframe,tfoot'
 
 // https://developer.mozilla.org/en-US/docs/Web/SVG/Element


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/menuitem