### PR TITLE
chore: convert to records

### DIFF
--- a/packages/compiler-dom/src/decodeHtml.ts
+++ b/packages/compiler-dom/src/decodeHtml.ts
@@ -102,7 +102,7 @@ export const decodeHtml: ParserOptions['decodeEntities'] = (
 }
 
 // https://html.spec.whatwg.org/multipage/parsing.html#numeric-character-reference-end-state
-const CCR_REPLACEMENTS: { [key: number]: number | undefined } = {
+const CCR_REPLACEMENTS: Record<number, number | undefined> = {
   0x80: 0x20ac,
   0x82: 0x201a,
   0x83: 0x0192,

--- a/packages/runtime-core/src/component.ts
+++ b/packages/runtime-core/src/component.ts
@@ -51,7 +51,7 @@ import {
 import { startMeasure, endMeasure } from './profiling'
 import { componentAdded } from './devtools'
 
-export type Data = { [key: string]: unknown }
+export type Data = Record<string, unknown>
 
 // Note: can't mark this whole interface internal because some public interfaces
 // extend it.

--- a/packages/runtime-core/src/componentProps.ts
+++ b/packages/runtime-core/src/componentProps.ts
@@ -80,7 +80,7 @@ type InferPropType<T> = T extends null
   : T extends { type: null | true }
     ? any // As TS issue https://github.com/Microsoft/TypeScript/issues/14829 // somehow `ObjectConstructor` when inferred from { (): T } becomes `any` // `BooleanConstructor` when inferred from PropConstructor(with PropMethod) becomes `Boolean`
     : T extends ObjectConstructor | { type: ObjectConstructor }
-      ? { [key: string]: any }
+      ? Record<string, any>
       : T extends BooleanConstructor | { type: BooleanConstructor }
         ? boolean
         : T extends Prop<infer V> ? V : T

--- a/packages/runtime-core/src/devtools.ts
+++ b/packages/runtime-core/src/devtools.ts
@@ -6,7 +6,7 @@ export interface AppRecord {
   id: number
   app: App
   version: string
-  types: { [key: string]: string | Symbol }
+  types: Record<string, string | Symbol>
 }
 
 enum DevtoolsHooks {

--- a/packages/runtime-core/src/vnode.ts
+++ b/packages/runtime-core/src/vnode.ts
@@ -204,7 +204,7 @@ export function setBlockTracking(value: number) {
  */
 export function createBlock(
   type: VNodeTypes | ClassComponent,
-  props?: { [key: string]: any } | null,
+  props?: Record<string, any> | null,
   children?: any,
   patchFlag?: number,
   dynamicProps?: string[]


### PR DESCRIPTION
Before:
`{ [key: string]: string }`

After:
`Record<string, string>`

Exactly the same for TypeScript, but more readable for human