### PR TITLE
chore(shared):menuitem tag has been deprecated

### DIFF
--- a/packages/runtime-dom/types/jsx.d.ts
+++ b/packages/runtime-dom/types/jsx.d.ts
@@ -1071,7 +1071,6 @@ interface IntrinsicElementAttributes {
   map: MapHTMLAttributes
   mark: HTMLAttributes
   menu: MenuHTMLAttributes
-  menuitem: HTMLAttributes
   meta: MetaHTMLAttributes
   meter: MeterHTMLAttributes
   nav: HTMLAttributes


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/menuitem