### PR TITLE
fix(apiWatch): callback not called when using `flush:sync`

### DIFF
--- a/packages/runtime-core/__tests__/apiWatch.spec.ts
+++ b/packages/runtime-core/__tests__/apiWatch.spec.ts
@@ -611,4 +611,23 @@ describe('api: watch', () => {
       oldValue: 2
     })
   })
+
+  it('should work sync', () => {
+    const v = ref(1)
+    let calls = 0
+
+    watch(
+      v,
+      () => {
+        ++calls
+      },
+      {
+        flush: 'sync'
+      }
+    )
+
+    expect(calls).toBe(0)
+    v.value++
+    expect(calls).toBe(1)
+  })
 })

--- a/packages/runtime-core/src/apiWatch.ts
+++ b/packages/runtime-core/src/apiWatch.ts
@@ -71,8 +71,6 @@ export interface WatchOptions<Immediate = boolean> extends WatchOptionsBase {
 
 export type WatchStopHandle = () => void
 
-const invoke = (fn: Function) => fn()
-
 // Simple effect.
 export function watchEffect(
   effect: WatchEffect,
@@ -262,7 +260,7 @@ function doWatch(
 
   let scheduler: (job: () => any) => void
   if (flush === 'sync') {
-    scheduler = invoke
+    scheduler = job
   } else if (flush === 'pre') {
     // ensure it's queued before component updates (which have positive ids)
     job.id = -1


### PR DESCRIPTION
Fix #1636

This https://github.com/vuejs/vue-next/commit/341b30c961aa065fc59f0c2b592a11229cb6bd14 broke the `flush:sync` 

the job is not being called anymore, the `invoke` was calling the `getter` (aka the `cb`)