### PR TITLE
fix(compiler-sfc): use `filename` from options when compile styl prep…

### DIFF
--- a/packages/compiler-sfc/src/stylePreprocessors.ts
+++ b/packages/compiler-sfc/src/stylePreprocessors.ts
@@ -110,7 +110,7 @@ const styl: StylePreprocessor = (source, map, options, load = require) => {
     // stylus output path is relative path
     const dependencies = getAbsolutePaths(
       ref.deps(),
-      path.dirname(options.fileName)
+      path.dirname(options.filename)
     )
     if (map) {
       return {


### PR DESCRIPTION
…rocessor

fix #https://github.com/vitejs/vite/issues/577