### PR TITLE
chore(shared): Although browsers and email clients may still support …

### DIFF
--- a/packages/shared/src/domAttrConfig.ts
+++ b/packages/shared/src/domAttrConfig.ts
@@ -68,7 +68,7 @@ export const isNoUnitNumericStyleProp = /*#__PURE__*/ makeMap(
  */
 export const isKnownAttr = /*#__PURE__*/ makeMap(
   `accept,accept-charset,accesskey,action,align,allow,alt,async,` +
-    `autocapitalize,autocomplete,autofocus,autoplay, background-image,bgcolor,` +
+    `autocapitalize,autocomplete,autofocus,autoplay,background-image,bgcolor,` +
     `border,buffered,capture,challenge,charset,checked,cite,class,code,` +
     `codebase,color,cols,colspan,content,contenteditable,contextmenu,controls,` +
     `coords,crossorigin,csp,data,datetime,decoding,default,defer,dir,dirname,` +

--- a/packages/shared/src/domAttrConfig.ts
+++ b/packages/shared/src/domAttrConfig.ts
@@ -68,7 +68,7 @@ export const isNoUnitNumericStyleProp = /*#__PURE__*/ makeMap(
  */
 export const isKnownAttr = /*#__PURE__*/ makeMap(
   `accept,accept-charset,accesskey,action,align,allow,alt,async,` +
-    `autocapitalize,autocomplete,autofocus,autoplay,background,bgcolor,` +
+    `autocapitalize,autocomplete,autofocus,autoplay, background-image,bgcolor,` +
     `border,buffered,capture,challenge,charset,checked,cite,class,code,` +
     `codebase,color,cols,colspan,content,contenteditable,contextmenu,controls,` +
     `coords,crossorigin,csp,data,datetime,decoding,default,defer,dir,dirname,` +


### PR DESCRIPTION
Although browsers and email clients may still support 'background' attribute, it is obsolete. Use CSS background-image instead;   https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes