### PR TITLE
feat(computed): add readonly flag if no setter is provided

### DIFF
--- a/packages/reactivity/__tests__/computed.spec.ts
+++ b/packages/reactivity/__tests__/computed.spec.ts
@@ -4,7 +4,8 @@ import {
   effect,
   stop,
   ref,
-  WritableComputedRef
+  WritableComputedRef,
+  isReadonly
 } from '../src'
 import { mockWarn } from '@vue/shared'
 
@@ -176,5 +177,23 @@ describe('reactivity/computed', () => {
     expect(
       'Write operation failed: computed value is readonly'
     ).toHaveBeenWarnedLast()
+  })
+
+  it('should be readonly', () => {
+    let a = { a: 1 }
+    const x = computed(() => a)
+    expect(isReadonly(x)).toBe(true)
+    expect(isReadonly(x.value)).toBe(false)
+    expect(isReadonly(x.value.a)).toBe(false)
+    const z = computed<typeof a>({
+      get() {
+        return a
+      },
+      set(v) {
+        a = v
+      }
+    })
+    expect(isReadonly(z)).toBe(false)
+    expect(isReadonly(z.value.a)).toBe(false)
   })
 })

--- a/packages/reactivity/src/computed.ts
+++ b/packages/reactivity/src/computed.ts
@@ -2,6 +2,7 @@ import { effect, ReactiveEffect, trigger, track } from './effect'
 import { TriggerOpTypes, TrackOpTypes } from './operations'
 import { Ref } from './ref'
 import { isFunction, NOOP } from '@vue/shared'
+import { ReactiveFlags } from './reactive'
 
 export interface ComputedRef<T = any> extends WritableComputedRef<T> {
   readonly value: T
@@ -56,6 +57,9 @@ export function computed<T>(
   })
   computed = {
     __v_isRef: true,
+    [ReactiveFlags.IS_READONLY]:
+      isFunction(getterOrOptions) || !getterOrOptions.set,
+
     // expose effect so computed can be stopped
     effect: runner,
     get value() {


### PR DESCRIPTION
if `computed` has no `setter` `isReadonly` returns `true`

```ts
    const x = computed(() => 1)
    expect(isReadonly(x)).toBe(true)
    expect(isReadonly(x.value)).toBe(false)
```