### PR TITLE
fix(compiler-sfc): use correct importer with `useCssVars`

### DIFF
--- a/packages/compiler-sfc/__tests__/__snapshots__/compileScript.spec.ts.snap
+++ b/packages/compiler-sfc/__tests__/__snapshots__/compileScript.spec.ts.snap
@@ -107,7 +107,7 @@ export default __define__({
 
 exports[`SFC compile <script setup> CSS vars injection <script> w/ default export 1`] = `
 "const __default__ = { setup() {} }
-import { useCSSVars as __useCSSVars__ } from 'vue'
+import { useCssVars as __useCssVars__ } from 'vue'
 const __injectCSSVars__ = () => {
 __useCssVars__(_ctx => ({ color: _ctx.color }))
 }
@@ -123,7 +123,7 @@ exports[`SFC compile <script setup> CSS vars injection <script> w/ default expor
           // export default {}
           const __default__ = {}
         
-import { useCSSVars as __useCSSVars__ } from 'vue'
+import { useCssVars as __useCssVars__ } from 'vue'
 const __injectCSSVars__ = () => {
 __useCssVars__(_ctx => ({ color: _ctx.color }))
 }
@@ -137,7 +137,7 @@ export default __default__"
 exports[`SFC compile <script setup> CSS vars injection <script> w/ no default export 1`] = `
 "const a = 1
 const __default__ = {}
-import { useCSSVars as __useCSSVars__ } from 'vue'
+import { useCssVars as __useCssVars__ } from 'vue'
 const __injectCSSVars__ = () => {
 __useCssVars__(_ctx => ({ color: _ctx.color }))
 }

--- a/packages/compiler-sfc/src/compileScript.ts
+++ b/packages/compiler-sfc/src/compileScript.ts
@@ -555,7 +555,7 @@ export function compileScript(
     returned = `Object.assign(\n  ${returned}\n)`
   }
 
-  // inject `useCSSVars` calls
+  // inject `useCssVars` calls
   if (hasCssVars) {
     s.prepend(`import { useCssVars as __useCssVars__ } from 'vue'\n`)
     for (const style of styles) {

--- a/packages/compiler-sfc/src/genCssVars.ts
+++ b/packages/compiler-sfc/src/genCssVars.ts
@@ -65,7 +65,7 @@ export function injectCssVarsCalls(
 
   return (
     script +
-    `\nimport { useCSSVars as __useCSSVars__ } from 'vue'\n` +
+    `\nimport { useCssVars as __useCssVars__ } from 'vue'\n` +
     `const __injectCSSVars__ = () => {\n${calls}}\n` +
     `const __setup__ = __default__.setup\n` +
     `__default__.setup = __setup__\n` +


### PR DESCRIPTION
fix #https://github.com/vitejs/vite/issues/578