### PR TITLE
feature/use-defineComponent-function-name-in-__DEV__

### DIFF
--- a/packages/runtime-core/src/apiDefineComponent.ts
+++ b/packages/runtime-core/src/apiDefineComponent.ts
@@ -205,5 +205,10 @@ export function defineComponent<
 
 // implementation, close to no-op
 export function defineComponent(options: unknown) {
+  if(__DEV__) {
+    return isFunction(options)
+      ? ((options.name != null) ? { setup: options, name: options.name } : { setup: options })
+      : options
+  }
   return isFunction(options) ? { setup: options } : options
 }

--- a/packages/runtime-core/src/apiDefineComponent.ts
+++ b/packages/runtime-core/src/apiDefineComponent.ts
@@ -205,10 +205,7 @@ export function defineComponent<
 
 // implementation, close to no-op
 export function defineComponent(options: unknown) {
-  if(__DEV__) {
-    return isFunction(options)
-      ? ((options.name != null) ? { setup: options, name: options.name } : { setup: options })
-      : options
-  }
-  return isFunction(options) ? { setup: options } : options
+  return isFunction(options)
+    ? ((options.name != null) ? { setup: options, name: options.name } : { setup: options })
+    : options
 }

--- a/packages/runtime-core/src/apiDefineComponent.ts
+++ b/packages/runtime-core/src/apiDefineComponent.ts
@@ -206,6 +206,6 @@ export function defineComponent<
 // implementation, close to no-op
 export function defineComponent(options: unknown) {
   return isFunction(options)
-    ? ((options.name != null) ? { setup: options, name: options.name } : { setup: options })
+    ? { setup: options, name: options.name }
     : options
 }


### PR DESCRIPTION
Continuing from [discussions about stateful functions as components](https://github.com/vuejs/vue-next/issues/1645#issuecomment-661111819) (#1645), I thought if it wouldn't help devtools and debugging experience to extract the name from the function when in `__DEV__` mode.
Using the file name makes sense in SFCs but in js/jsx/ts/tsx files you can define multiple small component.
Users can define name option property on object components but this tries to extract the name from a function provided instead.
It works when defining components like constants:
```tsx
const Counter = () => {
  const counter = ref(0)
  const increment = ()=>counter.value++
  return () => <button onClick={increment}>Counter: {counter.value}</button>
}
export default defineComponent(Counter)
```
or functions:
```tsx
export default defineComponent(function Counter() {
  const counter = ref(0)
  const increment = ()=>counter.value++
  return () => <button onClick={increment}>Counter: {counter.value}</button>
})
```
but this won't give any name (which is expected):
```tsx
export default defineComponent(() => {
  const counter = ref(0)
  const increment = ()=>counter.value++
  return () => <button onClick={increment}>Counter: {counter.value}</button>
})
```
nor this (can possibly be picked up by the dev bundler though):
```tsx
export const Counter = defineComponent(() => {
  const counter = ref(0)
  const increment = ()=>counter.value++
  return () => <button onClick={increment}>Counter: {counter.value}</button>
})
```

The alternative would be to look into Component.setup.name in the [formatComponentName function](https://github.com/vuejs/vue-next/blob/dabdc5e115514f98b5f8559a3819e96416939f43/packages/runtime-core/src/component.ts#L711), but I'm not sure about _when_ the name is supposed to be set in that case.