### PR TITLE
fix(runtime-core): add `FULL_PROPS` patch flags when cloned vnode has…

### DIFF
--- a/packages/runtime-core/src/vnode.ts
+++ b/packages/runtime-core/src/vnode.ts
@@ -448,7 +448,7 @@ export function cloneVNode<T, U>(
     // however we don't want block nodes to de-opt their children, so if the
     // vnode is a block node, we only add the FULL_PROPS flag to it.
     patchFlag: extraProps
-      ? vnode.dynamicChildren
+      ? vnode.dynamicChildren || vnode.patchFlag & PatchFlags.NEED_PATCH
         ? vnode.patchFlag | PatchFlags.FULL_PROPS
         : PatchFlags.BAIL
       : vnode.patchFlag,


### PR DESCRIPTION
… `NEED_PATCH` patch flags

fix #1665

## Bug Reson

The patch flags of `div.container` is changed by `cloneVnode`(NEED_PATCH -> BAIL). Caused the children diff and mount the children twice.