### PR TITLE
feat(compiler-core): add onContextCreated option to CodegenOptions

### DIFF
--- a/packages/compiler-core/src/codegen.ts
+++ b/packages/compiler-core/src/codegen.ts
@@ -180,9 +180,12 @@ function createCodegenContext(
 
 export function generate(
   ast: RootNode,
-  options: CodegenOptions = {}
+  options: CodegenOptions & {
+    onContextCreated?: (context: CodegenContext) => void
+  } = {}
 ): CodegenResult {
   const context = createCodegenContext(ast, options)
+  if (options.onContextCreated) options.onContextCreated(context)
   const {
     mode,
     push,


### PR DESCRIPTION
I haven't added to  `onContextCreated` to `CodegenOptions` to avoid circular dependency as it is defined in `options.ts` and `CodegenContext` is  in `codegen.ts`.