### PR TITLE
fix(looseEqual): Non enumerable properties aren't checked

### DIFF
--- a/packages/shared/__tests__/looseEqual.spec.ts
+++ b/packages/shared/__tests__/looseEqual.spec.ts
@@ -134,6 +134,12 @@ describe('utils/looseEqual', () => {
     const obj5 = { ...obj4, z: 999 }
     const nestedObj1 = { ...obj1, bar: [{ ...obj1 }, { ...obj1 }] }
     const nestedObj2 = { ...obj1, bar: [{ ...obj1 }, { ...obj2 }] }
+    const emptyObject = {}
+    const nonEnumerableObject = {}
+    Object.defineProperty(nonEnumerableObject, 'foo', {
+      enumerable: false,
+      value: 'bar'
+    })
 
     // Identical object references
     expect(looseEqual(obj1, obj1)).toBe(true)
@@ -151,6 +157,9 @@ describe('utils/looseEqual', () => {
     expect(looseEqual(nestedObj1, { ...nestedObj1 })).toBe(true)
     // Object definitions with nested array (which has different order)
     expect(looseEqual(nestedObj1, nestedObj2)).toBe(false)
+    // Object with non enumerable properties
+    expect(looseEqual(obj1, nonEnumerableObject)).toBe(true)
+    expect(looseEqual(emptyObject, nonEnumerableObject)).toBe(false)
   })
 
   test('compares different types correctly', () => {


### PR DESCRIPTION
[`looseEqual`](https://github.com/vuejs/vue-next/blob/d63daaf9b6309b1f96131032b8436ff29b28fe98/packages/shared/src/looseEqual.ts#L31) currently uses [`Object.keys()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/keys) and the `in` operator to count and iterate over the properties of the objects to compare.
But both of them only return enumerable properties, which could cause issues.

This PR adds test to check for those cases and I could either add the fix to this PR or create a new one.

Question:
* Should a property be looseEqual if it is enumerable on one object and non-enumerable on the other?

PS:
This files seems to not be linted currently and the commit hook tried to lint it, which I had to prevent to keep the changes on topic.