### PR TITLE
feat(reactivity): `proxyRefs` method and `ShallowUnwrapRefs` type

### DIFF
--- a/packages/reactivity/src/index.ts
+++ b/packages/reactivity/src/index.ts
@@ -1,15 +1,17 @@
 export {
   ref,
-  unref,
   shallowRef,
   isRef,
   toRef,
   toRefs,
+  unref,
+  proxyRefs,
   customRef,
   triggerRef,
   Ref,
-  UnwrapRef,
   ToRefs,
+  UnwrapRef,
+  ShallowUnwrapRef,
   RefUnwrapBailTypes
 } from './ref'
 export {

--- a/packages/reactivity/src/ref.ts
+++ b/packages/reactivity/src/ref.ts
@@ -1,7 +1,7 @@
 import { track, trigger } from './effect'
 import { TrackOpTypes, TriggerOpTypes } from './operations'
 import { isObject, hasChanged } from '@vue/shared'
-import { reactive, isProxy, toRaw } from './reactive'
+import { reactive, isProxy, toRaw, isReactive } from './reactive'
 import { CollectionTypes } from './collectionHandlers'
 
 declare const RefSymbol: unique symbol
@@ -97,7 +97,9 @@ const shallowUnwrapHandlers: ProxyHandler<any> = {
 export function proxyRefs<T extends object>(
   objectWithRefs: T
 ): ShallowUnwrapRef<T> {
-  return new Proxy(objectWithRefs, shallowUnwrapHandlers)
+  return isReactive(objectWithRefs)
+    ? objectWithRefs
+    : new Proxy(objectWithRefs, shallowUnwrapHandlers)
 }
 
 export type CustomRefFactory<T> = (

--- a/packages/runtime-core/src/component.ts
+++ b/packages/runtime-core/src/component.ts
@@ -1,10 +1,10 @@
 import { VNode, VNodeChild, isVNode } from './vnode'
 import {
-  reactive,
   ReactiveEffect,
   pauseTracking,
   resetTracking,
-  shallowReadonly
+  shallowReadonly,
+  proxyRefs
 } from '@vue/reactivity'
 import {
   CreateComponentPublicInstance,
@@ -561,7 +561,7 @@ export function handleSetupResult(
     }
     // setup returned bindings.
     // assuming a render function compiled from template is present.
-    instance.setupState = reactive(setupResult)
+    instance.setupState = proxyRefs(setupResult)
     if (__DEV__) {
       exposeSetupStateOnRenderContext(instance)
     }

--- a/packages/runtime-core/src/componentProxy.ts
+++ b/packages/runtime-core/src/componentProxy.ts
@@ -10,12 +10,12 @@ import {
 } from '@vue/shared'
 import {
   ReactiveEffect,
-  UnwrapRef,
   toRaw,
   shallowReadonly,
   ReactiveFlags,
   track,
-  TrackOpTypes
+  TrackOpTypes,
+  ShallowUnwrapRef
 } from '@vue/reactivity'
 import {
   ExtractComputedReturns,
@@ -154,7 +154,7 @@ export type ComponentPublicInstance<
   $nextTick: typeof nextTick
   $watch: typeof instanceWatch
 } & P &
-  UnwrapRef<B> &
+  ShallowUnwrapRef<B> &
   D &
   ExtractComputedReturns<C> &
   M &

--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -8,6 +8,7 @@ export {
   readonly,
   // utilities
   unref,
+  proxyRefs,
   isRef,
   toRef,
   toRefs,
@@ -125,6 +126,7 @@ export {
   ComputedRef,
   WritableComputedRef,
   UnwrapRef,
+  ShallowUnwrapRef,
   WritableComputedOptions,
   ToRefs,
   DeepReadonly

--- a/test-dts/defineComponent.test-d.tsx
+++ b/test-dts/defineComponent.test-d.tsx
@@ -146,7 +146,7 @@ describe('with object props', () => {
 
       // assert setup context unwrapping
       expectType<number>(this.c)
-      expectType<string>(this.d.e)
+      expectType<string>(this.d.e.value)
       expectType<GT>(this.f.g)
 
       // setup context properties should be mutable


### PR DESCRIPTION
## BREAKING CHANGE

Template auto ref unwrapping for `setup()` return object is now applied only to the root level refs.

## Rationale

This change aims to ensure that non-ref values referenced in templates retain the same identity with the value declared inside `setup()`  regardless of whether it's wrapped with `reactive` or `readonly`.

Currently, the object returned from `setup()` is exposed to the template render context as a `reactive` proxy. This means all properties accessed from the template, even nested ones, will be reactive proxies as well. This has led to a edge cases that can be confusing:

```html
<div v-for="item in list">{{ isInList(item) }}</div>
```
```js
setup() {
  const list = [
    { foo: 1 },
    { bar: 2 }
  ]

  function isInList(item) {
    // item here is a proxy of the original!
    return list.includes(item)
  }

  return {
    list,
    isInList
  }
}
```

[live demo](https://jsfiddle.net/yyx990803/30621e5w/1/)

Before this change, the render result will be `false false` because the `item` accessed in the template are proxies and not strictly equal to the original items declared in `setup()`.

Another case involves class instances exposed to templates:

```html
{{ foo.getValue() }}
```
```js
class Foo {
  count = ref(1)
  getValue() {
    // `this` here is a proxy of the raw instance
    return this.count.value
  }
}

// ...
setup() {
  return {
    foo: new Foo()
  }
}
```

[live demo](https://jsfiddle.net/yyx990803/a4Lws958/3/)

Here, `this` would point to the proxy in `foo.getValue` because the `foo` in the template is a proxied version of the class instance, and this results in `this.count` being an already unwrapped number, and `this.count.value` will be `undefined` (hence the render reuslt will be blank). In other words, the behavior of the class becomes inconsistent based on whether it's accessed through the template or not.

We have went back-and-forth on this behavior during the alpha/beta phases. Previously, we felt we could encourage users to always explicitly wrap/mark returned objects with `markRaw`, `reactive` or `readonly` to avoid such problems, but it always feel like a potential footgun. Although we indicated that we are trying to avoid breaking changes during the RC phase, we feel this it is important to have this discussed before the final release.

## Breakage Details

The breaking case is that given the following:

```js
setup() {
  return {
    rootRef: ref(1),
    object: {
      nestedRef: ref(3)
    }
  }
}
```

After this change, `{{ rootRef }}` in the template will still render `1`, but `{{ object.nestedRef }}` will no longer be auto unwrapped as `3`.

> Note that if an object is a `reactive` or `readonly` proxy, they still come with deep ref unwrapping by themselves. This change only affects **plain** objects containing refs.

### Composition function returning plain object with refs

A common case where this could happen is returning an object of refs from a composition function:

```js
function useFeatureFoo() {
  const someValue = ref(0)
  const otherValue = ref(1)

  // composition function returning a plain object
  // intended to facilitate destructuring in setup()
  return {
    someValue,
    otherValue
  }
}

export default {
  setup() {
    return {
      // however the consuming component wants to use it as a nested object
      // and access features as {{ foo.someValue }} in the template
      foo: useFeatureFoo()
    }
  }
}
```

The fix is rather straightforward: wrap it with `reactive` to unwrap the refs:

```js
setup() {
  return {
    foo: reactive(useFeatureFoo())
  }
}
```

Another aspect of this is that users probably do this to avoid the trouble of destructuring and then returning the setup object, which can become tedious if there are many properties in the returned object:

```js
setup() {
  const { someValue, otherValue, ... } = useFeatureFoo()
  return {
    someValue,
    otherValue,
    ...
  }
}
```

which can be simplified in [`<script setup>`](https://github.com/vuejs/rfcs/blob/sfc-improvements/active-rfcs/0000-sfc-script-setup.md) as:

```html
<script setup>
export const { someValue, otherValue, ... } = useFeatureFoo()
</script>
```

### Setup returned properties are no longer reactive

Another minor breakage is that this also makes non-ref properties in the returned objects non-reactive:

```js
setup() {
  return {
    count: 0
  }
}
```

Mutating `count` from the template, e.g. with `<button @click="count++">` will no longer trigger updates.

/cc @jods4 @RobbinBaauw @basvanmeurs