### PR TITLE
feat(compilerOption): handle undefined delimiter

### DIFF
--- a/packages/runtime-core/src/component.ts
+++ b/packages/runtime-core/src/component.ts
@@ -607,7 +607,8 @@ function finishComponentSetup(
         startMeasure(instance, `compile`)
       }
       Component.render = compile(Component.template, {
-        isCustomElement: instance.appContext.config.isCustomElement || NO
+        isCustomElement: instance.appContext.config.isCustomElement || NO,
+        delimiters: Component.delimiters
       })
       if (__DEV__) {
         endMeasure(instance, `compile`)

--- a/packages/runtime-core/src/component.ts
+++ b/packages/runtime-core/src/component.ts
@@ -606,10 +606,16 @@ function finishComponentSetup(
       if (__DEV__) {
         startMeasure(instance, `compile`)
       }
-      Component.render = compile(Component.template, {
-        isCustomElement: instance.appContext.config.isCustomElement || NO,
-        delimiters: Component.delimiters
-      })
+
+      let options: CompilerOptions = {
+        isCustomElement: instance.appContext.config.isCustomElement || NO
+      }
+
+      if (Component.delimiters) {
+        options.delimiters = Component.delimiters
+      }
+
+      Component.render = compile(Component.template, options)
       if (__DEV__) {
         endMeasure(instance, `compile`)
       }

--- a/packages/runtime-core/src/componentOptions.ts
+++ b/packages/runtime-core/src/componentOptions.ts
@@ -321,6 +321,9 @@ interface LegacyOptions<
   renderTracked?: DebuggerHook
   renderTriggered?: DebuggerHook
   errorCaptured?: ErrorCapturedHook
+
+  // runtime compile only
+  delimiters?: [string, string]
 }
 
 export type OptionTypesKeys = 'P' | 'B' | 'D' | 'C' | 'M'


### PR DESCRIPTION
If we don't make this protect, `delimiters` will be merged as `undefined`. 

// options.delimiters is merge as undefined
https://github.com/vuejs/vue-next/blob/c219cbfb01207a3645e4b66b2887a5b678098261/packages/compiler-core/src/parse.ts#L93

// exception
https://github.com/vuejs/vue-next/blob/c219cbfb01207a3645e4b66b2887a5b678098261/packages/compiler-core/src/parse.ts#L119

