### PR TITLE
fix(runtime-core): use correct container for patch Teleport when toggle disabled

### DIFF
--- a/packages/runtime-core/src/components/Teleport.ts
+++ b/packages/runtime-core/src/components/Teleport.ts
@@ -157,7 +157,7 @@ export const TeleportImpl = {
           // move into main container
           moveTeleport(
             n2,
-            container,
+            mainAnchor.parentNode,
             mainAnchor,
             internals,
             TeleportMoveTypes.TOGGLE


### PR DESCRIPTION
fix the #1690 