### PR TITLE
fix(compiler-core): prevent generate empty key value for vBind

### DIFF
--- a/packages/compiler-core/__tests__/transforms/vBind.spec.ts
+++ b/packages/compiler-core/__tests__/transforms/vBind.spec.ts
@@ -83,7 +83,8 @@ describe('compiler: transform v-bind', () => {
 
   test('should error if no expression', () => {
     const onError = jest.fn()
-    parseWithVBind(`<div v-bind:arg />`, { onError })
+    const node = parseWithVBind(`<div v-bind:arg />`, { onError })
+    const props = (node.codegenNode as VNodeCall).props as ObjectExpression
     expect(onError.mock.calls[0][0]).toMatchObject({
       code: ErrorCodes.X_V_BIND_NO_EXPRESSION,
       loc: {
@@ -95,6 +96,16 @@ describe('compiler: transform v-bind', () => {
           line: 1,
           column: 16
         }
+      }
+    })
+    expect(props.properties[0]).toMatchObject({
+      key: {
+        content: `arg`,
+        isStatic: true
+      },
+      value: {
+        content: ``,
+        isStatic: true
       }
     })
   })

--- a/packages/compiler-core/src/transforms/vBind.ts
+++ b/packages/compiler-core/src/transforms/vBind.ts
@@ -25,7 +25,10 @@ export const transformBind: DirectiveTransform = (dir, node, context) => {
     }
   }
 
-  if (!exp || (exp.type === NodeTypes.SIMPLE_EXPRESSION && !exp.content)) {
+  if (
+    !exp ||
+    (exp.type === NodeTypes.SIMPLE_EXPRESSION && !exp.content.trim())
+  ) {
     context.onError(createCompilerError(ErrorCodes.X_V_BIND_NO_EXPRESSION, loc))
     return {
       props: [createObjectProperty(arg!, createSimpleExpression('', true, loc))]

--- a/packages/compiler-core/src/transforms/vBind.ts
+++ b/packages/compiler-core/src/transforms/vBind.ts
@@ -10,9 +10,6 @@ import { CAMELIZE } from '../runtimeHelpers'
 export const transformBind: DirectiveTransform = (dir, node, context) => {
   const { exp, modifiers, loc } = dir
   const arg = dir.arg!
-  if (!exp || (exp.type === NodeTypes.SIMPLE_EXPRESSION && !exp.content)) {
-    context.onError(createCompilerError(ErrorCodes.X_V_BIND_NO_EXPRESSION, loc))
-  }
   // .prop is no longer necessary due to new patch behavior
   // .sync is replaced by v-model:arg
   if (modifiers.includes('camel')) {
@@ -27,9 +24,15 @@ export const transformBind: DirectiveTransform = (dir, node, context) => {
       arg.children.push(`)`)
     }
   }
+
+  if (!exp || (exp.type === NodeTypes.SIMPLE_EXPRESSION && !exp.content)) {
+    context.onError(createCompilerError(ErrorCodes.X_V_BIND_NO_EXPRESSION, loc))
+    return {
+      props: [createObjectProperty(arg!, createSimpleExpression('', true, loc))]
+    }
+  }
+
   return {
-    props: [
-      createObjectProperty(arg!, exp || createSimpleExpression('', true, loc))
-    ]
+    props: [createObjectProperty(arg!, exp)]
   }
 }


### PR DESCRIPTION
Prevent ` { id:  }` experssion generate.

### Input
` <div v-bind:id=""></div>`

### Output
` return (_openBlock(), _createBlock("div", { id:  }, null, 8 /* PROPS */, ["id"]))`