### PR TITLE
fix(runtime-core): normalize empty extra props to null for `cloneVnode`

### DIFF
--- a/packages/runtime-core/src/vnode.ts
+++ b/packages/runtime-core/src/vnode.ts
@@ -427,6 +427,9 @@ export function cloneVNode<T, U>(
   vnode: VNode<T, U>,
   extraProps?: Data & VNodeProps | null
 ): VNode<T, U> {
+  if (extraProps && Object.keys(extraProps).length === 0) {
+    extraProps = null
+  }
   // This is intentionally NOT using spread or extend to avoid the runtime
   // key enumeration cost.
   const { props, patchFlag } = vnode


### PR DESCRIPTION
fix #1704

This pr fix empty extra props, this will change `patchFlag`(this can fix the issue).
But the real reason with this issue is here.
https://github.com/vuejs/vue-next/blob/5c74243211495e33319218584993177c9d2e2c80/packages/runtime-core/src/componentRenderUtils.ts#L250-L252
The pushed vnode will cause error when patch this(there are block node and previous block tree maybe hasn't this node)