### PR TITLE
feat(runtime-core): check if the key is string

### DIFF
--- a/packages/runtime-core/__tests__/componentProxy.spec.ts
+++ b/packages/runtime-core/__tests__/componentProxy.spec.ts
@@ -217,4 +217,24 @@ describe('component: proxy', () => {
       `was accessed during render but is not defined`
     ).not.toHaveBeenWarned()
   })
+
+  test('should allow symbol to access on render', () => {
+    const Comp = {
+      render() {
+        if ((this as any)[Symbol.unscopables]) {
+          return '1'
+        }
+        return '2'
+      }
+    }
+
+    const app = createApp(Comp)
+    app.mount(nodeOps.createElement('div'))
+
+    expect(
+      `Property ${JSON.stringify(
+        Symbol.unscopables
+      )} was accessed during render ` + `but is not defined on instance.`
+    ).toHaveBeenWarned()
+  })
 })

--- a/packages/runtime-core/src/componentProxy.ts
+++ b/packages/runtime-core/src/componentProxy.ts
@@ -6,7 +6,8 @@ import {
   hasOwn,
   isGloballyWhitelisted,
   NOOP,
-  extend
+  extend,
+  isString
 } from '@vue/shared'
 import {
   ReactiveEffect,
@@ -286,9 +287,10 @@ export const PublicInstanceProxyHandlers: ProxyHandler<any> = {
     } else if (
       __DEV__ &&
       currentRenderingInstance &&
-      // #1091 avoid internal isRef/isVNode checks on component instance leading
-      // to infinite warning loop
-      key.indexOf('__v') !== 0
+      (!isString(key) ||
+        // #1091 avoid internal isRef/isVNode checks on component instance leading
+        // to infinite warning loop
+        key.indexOf('__v') !== 0)
     ) {
       if (data !== EMPTY_OBJ && key[0] === '$' && hasOwn(data, key)) {
         warn(


### PR DESCRIPTION
On the `rc.5` I started getting errors because a `symbol` was used during render, because `indexOf` is not available on symbol.

This test is not representative on you will get this problem, but rather a way to trigger it.

The "errors" can be found [CI build here](https://app.circleci.com/pipelines/github/pikax/vue-composable/1810/workflows/027e25cb-27f0-4232-8d9b-929723f22dd3/jobs/1791) (the first error is not related to this particular case) but [exception is not being bubble up](https://github.com/vuejs/vue-next/pull/987)

after manually disabling the recursive `vue-next` log error:

```log
    TypeError: key.indexOf is not a function

      at Object.get (node_modules/@vue/runtime-core/dist/runtime-core.cjs.js:5422:17)
      at Proxy.render (eval at compileToFunction (packages/vue-composable/__tests__/utils.ts:85:18), <anonymous>:12:13)
      at renderComponentRoot (node_modules/@vue/runtime-core/dist/runtime-core.cjs.js:481:44)
      at componentEffect (node_modules/@vue/runtime-core/dist/runtime-core.cjs.js:4040:53)
      at reactiveEffect (node_modules/@vue/reactivity/dist/reactivity.cjs.js:46:24)
      at Object.effect (node_modules/@vue/reactivity/dist/reactivity.cjs.js:21:9)
      at setupRenderEffect (node_modules/@vue/runtime-core/dist/runtime-core.cjs.js:4032:38)
      at mountComponent (node_modules/@vue/runtime-core/dist/runtime-core.cjs.js:3990:9)
      at processComponent (node_modules/@vue/runtime-core/dist/runtime-core.cjs.js:3947:17)
      at patch (node_modules/@vue/runtime-core/dist/runtime-core.cjs.js:3607:21)
      at render (node_modules/@vue/runtime-core/dist/runtime-core.cjs.js:4675:13)
      at mount (node_modules/@vue/runtime-core/dist/runtime-core.cjs.js:3106:25)
      at Object.app.mount (node_modules/@vue/runtime-dom/dist/runtime-dom.cjs.js:1197:23)
      at Object.mount (packages/vue-composable/__tests__/utils.ts:115:16)
      at Object.<anonymous> (packages/vue-composable/__tests__/misc/vmodel.spec.ts:87:8)
```

Code causing the issue
```ts

// composable
export function useVModel<TProps, PropName extends keyof TProps>(
  props: TProps,
  name: PropName
): Ref<TProps[PropName]>;
export function useVModel(props: Record<string, any>, name: string): Ref<any> {
  const instance = getCurrentInstance();
  if (!instance) {
    return ref() as any;
  }
  return computed({
    get() {
      return props[name];
    },
    set(v) {
      instance.emit(`update:${name}`, v);
    }
  });
}


// test using the composable , just checking if parent does get the actual update when using `test.value ='mounted'`

it("should replace prop", async () => {
    const comp1 = {
      props: {
        test: String
      },
      setup(props: { test: string }) {
        const test = useVModel(props, "test");

        onMounted(() => {
          test.value = "mounted";
        });

        return {
          test
        };
      },
      template: `<p>{{test}}</p>`
    };

    const test = ref("propTest");

    const vm = createVue({
      components: {
        comp1
      },
      template: `<comp1 v-model:test="test" />`,
      setup() {
        return {
          test
        };
      }
    });

    expect(test.value).toBe("propTest");
    vm.mount();
    await nextTick();

    expect(test.value).toBe("mounted");
  });

```