### PR TITLE
test(types): add prop validator test

### DIFF
--- a/test-dts/defineComponent.test-d.tsx
+++ b/test-dts/defineComponent.test-d.tsx
@@ -27,6 +27,7 @@ describe('with object props', () => {
     eee: () => { a: string }
     fff: (a: number, b: string) => { a: boolean }
     hhh: boolean
+    validated?: string
   }
 
   type GT = string & { __brand: unknown }
@@ -75,6 +76,10 @@ describe('with object props', () => {
       hhh: {
         type: Boolean,
         required: true
+      },
+      validated: {
+        type: String,
+        validator: (val: unknown) => val !== ''
       }
     },
     setup(props) {
@@ -92,6 +97,7 @@ describe('with object props', () => {
       expectType<ExpectedProps['eee']>(props.eee)
       expectType<ExpectedProps['fff']>(props.fff)
       expectType<ExpectedProps['hhh']>(props.hhh)
+      expectType<ExpectedProps['validated']>(props.validated)
 
       // @ts-expect-error props should be readonly
       expectError((props.a = 1))


### PR DESCRIPTION
Due to the limitation of TS, prop validator must be fully annotated. 

`defineComponent` will produce prop type `unknown` in setup method because of contextual typing of object literal.

```ts
defineCopmonent({
  props: {
    validated: {
      type: String,
      validator(val) {
        return val !== ''
      }
    }
  },
  setup(props) {  
    props.validated // error, props is unknown
  }
})
```
The fix now is to add explicit annotation to the validator function to suppress contextual typing.

This pull request adds an example test for this.
refer to https://github.com/microsoft/TypeScript/issues/38623
