### PR TITLE
fix(reactivity): make items in a readonly&reactive map trigger effects

### DIFF
--- a/packages/reactivity/__tests__/readonly.spec.ts
+++ b/packages/reactivity/__tests__/readonly.spec.ts
@@ -205,6 +205,21 @@ describe('reactivity/readonly', () => {
         ).toHaveBeenWarned()
       })
 
+      test('should allow trigger effect for values in a readonly&reactive map ', () => {
+        const originMap = reactive(new Collection())
+        const readonlyMap = readonly(originMap)
+        const key = {}
+        let dummy
+        effect(() => {
+          dummy = readonlyMap.get(key)
+        })
+        expect(dummy).toBeUndefined()
+        originMap.set(key, 1)
+        expect(dummy).toBe(1)
+        originMap.set(key, 2)
+        expect(dummy).toBe(2)
+      })
+
       if (Collection === Map) {
         test('should retrieve readonly values on iteration', () => {
           const key1 = {}

--- a/packages/reactivity/__tests__/readonly.spec.ts
+++ b/packages/reactivity/__tests__/readonly.spec.ts
@@ -206,18 +206,16 @@ describe('reactivity/readonly', () => {
       })
 
       test('should allow trigger effect for values in a readonly&reactive map ', () => {
-        const originMap = reactive(new Collection())
+        const key = 'default'
+        const originMap = reactive(new Map([[key, { name: 'value' }]]))
         const readonlyMap = readonly(originMap)
-        const key = {}
-        let dummy
+        let name
         effect(() => {
-          dummy = readonlyMap.get(key)
+          name = readonlyMap.get(key)!.name
         })
-        expect(dummy).toBeUndefined()
-        originMap.set(key, 1)
-        expect(dummy).toBe(1)
-        originMap.set(key, 2)
-        expect(dummy).toBe(2)
+        expect(name).toBe('value')
+        originMap.get(key)!.name = 'new value'
+        expect(name).toBe('new value')
       })
 
       if (Collection === Map) {

--- a/packages/reactivity/src/collectionHandlers.ts
+++ b/packages/reactivity/src/collectionHandlers.ts
@@ -1,4 +1,10 @@
-import { toRaw, reactive, readonly, ReactiveFlags } from './reactive'
+import {
+  toRaw,
+  reactive,
+  readonly,
+  ReactiveFlags,
+  isReactive
+} from './reactive'
 import { track, trigger, ITERATE_KEY, MAP_KEY_ITERATE_KEY } from './effect'
 import { TrackOpTypes, TriggerOpTypes } from './operations'
 import {
@@ -254,7 +260,11 @@ const shallowInstrumentations: Record<string, Function> = {
 
 const readonlyInstrumentations: Record<string, Function> = {
   get(this: MapTypes, key: unknown) {
-    return get(this, key, toReadonly)
+    return get(
+      this,
+      key,
+      isReactive(this) ? value => toReadonly(toReactive(value)) : toReadonly
+    )
   },
   get size() {
     return size((this as unknown) as IterableCollections)


### PR DESCRIPTION
fixed the problem:
assume that a map has two proxies, one of which is readonly and the other is reactive, if we modify items in the map by the reactive one proxy, watcher callbacks on the readonly one won't work, as discussed in #1772, which can be a very common usage scenario for map.

however changed the strategy on handling a reactive and readonly map at the same time.