### PR TITLE
fix(reactivity): process subtypes of collections properly

### DIFF
--- a/packages/reactivity/__tests__/reactive.spec.ts
+++ b/packages/reactivity/__tests__/reactive.spec.ts
@@ -44,6 +44,24 @@ describe('reactivity/reactive', () => {
     expect(isReactive(observed.array[0])).toBe(true)
   })
 
+  test('process subtypes of collections properly', () => {
+    class CustomMap extends Map {
+      count = 0
+
+      set(key: any, value: any): this {
+        super.set(key, value)
+        this.count++
+        return this
+      }
+    }
+
+    const testMap = new CustomMap()
+    const observed = reactive(testMap)
+    expect(observed.count).toBe(0)
+    observed.set('test', 'value')
+    expect(observed.count).toBe(1)
+  })
+
   test('observed value should proxy mutations to original (Object)', () => {
     const original: any = { foo: 1 }
     const observed = reactive(original)

--- a/packages/reactivity/src/reactive.ts
+++ b/packages/reactivity/src/reactive.ts
@@ -151,10 +151,16 @@ function createReactiveObject(
   if (!canObserve(target)) {
     return target
   }
-  const observed = new Proxy(
-    target,
-    collectionTypes.has(target.constructor) ? collectionHandlers : baseHandlers
-  )
+
+  let handler = baseHandlers
+  for (const collectionType of collectionTypes) {
+    if (target instanceof collectionType) {
+      handler = collectionHandlers
+      break
+    }
+  }
+
+  const observed = new Proxy(target, handler)
   def(target, reactiveFlag, observed)
   return observed
 }


### PR DESCRIPTION
Fixed usage scenarios using subtypes of collections: 
```javascript
  class CustomMap extends Map {
    get(key) {
      console.log(key)
      return super.get(key)
    }
  }

  class SMap extends CustomMap {
    set(key, value) {
      console.log(key, value) // or other actions
      return super.set(key, value)
    }
  }

  const a = reactive(new SMap())

  a.set('a', 'ok')

// Error:  TypeError: Method Map.prototype.set called on incompatible receiver [object Object] 
```