### PR TITLE
fix: output line more than 3 digits

### DIFF
--- a/packages/shared/src/codeframe.ts
+++ b/packages/shared/src/codeframe.ts
@@ -14,7 +14,7 @@ export function generateCodeFrame(
       for (let j = i - range; j <= i + range || end > count; j++) {
         if (j < 0 || j >= lines.length) continue
         const line = j + 1
-        res.push(`${line}${' '.repeat(3 - String(line).length)}|  ${lines[j]}`)
+        res.push(`${line}${' '.repeat(Math.abs(3 - String(line).length))}|  ${lines[j]}`)
         const lineLength = lines[j].length
         if (j === i) {
           // push underline


### PR DESCRIPTION
When `String(line).length` is bigger than `3`, then calculation is negative and `repeat` will fail