### PR TITLE
fix(codeframe): Added Math.max to prevent RangeError (#1806)

### DIFF
--- a/packages/shared/src/codeframe.ts
+++ b/packages/shared/src/codeframe.ts
@@ -14,7 +14,11 @@ export function generateCodeFrame(
       for (let j = i - range; j <= i + range || end > count; j++) {
         if (j < 0 || j >= lines.length) continue
         const line = j + 1
-        res.push(`${line}${' '.repeat(3 - String(line).length)}|  ${lines[j]}`)
+        res.push(
+          `${line}${' '.repeat(Math.max(3 - String(line).length, 0))}|  ${
+            lines[j]
+          }`
+        )
         const lineLength = lines[j].length
         if (j === i) {
           // push underline


### PR DESCRIPTION
When `String(line).length` (ie. when the source is >= 1000 lines), then `range` fails.

Closes #1806 
Related to #1804 except this PR uses a `max` rather than `abs`.
