### PR TITLE
fix(compiler-sfc): custom blocks sourcemap

### DIFF
--- a/packages/compiler-sfc/__tests__/parse.spec.ts
+++ b/packages/compiler-sfc/__tests__/parse.spec.ts
@@ -33,6 +33,20 @@ describe('compiler:sfc', () => {
         expect(mapping.originalLine - mapping.generatedLine).toBe(padding)
       })
     })
+
+    test('custom block', () => {
+      const padding = Math.round(Math.random() * 10)
+      const custom = parse(
+        `${'\n'.repeat(padding)}<i18n>\n{\n  "greeting": "hello"\n}\n</i18n>\n`
+      ).descriptor.customBlocks[0]
+
+      expect(custom!.map).not.toBeUndefined()
+
+      const consumer = new SourceMapConsumer(custom!.map!)
+      consumer.eachMapping(mapping => {
+        expect(mapping.originalLine - mapping.generatedLine).toBe(padding)
+      })
+    })
   })
 
   test('pad content', () => {
@@ -45,11 +59,16 @@ export default {}
 </script>
 <style>
 h1 { color: red }
-</style>`
+</style>
+<i18n>
+{ "greeting": "hello" }
+</i18n>
+`
     const padFalse = parse(content.trim(), { pad: false }).descriptor
     expect(padFalse.template!.content).toBe('\n<div></div>\n')
     expect(padFalse.script!.content).toBe('\nexport default {}\n')
     expect(padFalse.styles[0].content).toBe('\nh1 { color: red }\n')
+    expect(padFalse.customBlocks[0].content).toBe('\n{ "greeting": "hello" }\n')
 
     const padTrue = parse(content.trim(), { pad: true }).descriptor
     expect(padTrue.script!.content).toBe(
@@ -58,6 +77,9 @@ h1 { color: red }
     expect(padTrue.styles[0].content).toBe(
       Array(6 + 1).join('\n') + '\nh1 { color: red }\n'
     )
+    expect(padTrue.customBlocks[0].content).toBe(
+      Array(9 + 1).join('\n') + '\n{ "greeting": "hello" }\n'
+    )
 
     const padLine = parse(content.trim(), { pad: 'line' }).descriptor
     expect(padLine.script!.content).toBe(
@@ -65,6 +87,9 @@ h1 { color: red }
     )
     expect(padLine.styles[0].content).toBe(
       Array(6 + 1).join('\n') + '\nh1 { color: red }\n'
+    )
+    expect(padLine.customBlocks[0].content).toBe(
+      Array(9 + 1).join('\n') + '\n{ "greeting": "hello" }\n'
     )
 
     const padSpace = parse(content.trim(), { pad: 'space' }).descriptor
@@ -77,6 +102,12 @@ h1 { color: red }
         /./g,
         ' '
       ) + '\nh1 { color: red }\n'
+    )
+    expect(padSpace.customBlocks[0].content).toBe(
+      `<template>\n<div></div>\n</template>\n<script>\nexport default {}\n</script>\n<style>\nh1 { color: red }\n</style>\n<i18n>`.replace(
+        /./g,
+        ' '
+      ) + '\n{ "greeting": "hello" }\n'
     )
   })
 

--- a/packages/compiler-sfc/src/parse.ts
+++ b/packages/compiler-sfc/src/parse.ts
@@ -204,6 +204,7 @@ export function parse(
     genMap(descriptor.template)
     genMap(descriptor.script)
     descriptor.styles.forEach(genMap)
+    descriptor.customBlocks.forEach(genMap)
   }
 
   const result = {


### PR DESCRIPTION
There are cases in which we need the sourcemap of the content in custom blocks.
In the case of vue-i18n, when is compiling i18n resources from custom blocks to JS codes, we need the sourcemap to support DX.

In `vue-loader@next`, it does pass the sourcemap, but vue-i18n-loader can't receive it.
https://github.com/vuejs/vue-loader/blob/next/src/select.ts#L46