### PR TITLE
fix(runtime-dom): update the types related to innerHTML in jsx...

### DIFF
--- a/packages/runtime-dom/types/jsx.d.ts
+++ b/packages/runtime-dom/types/jsx.d.ts
@@ -737,6 +737,13 @@ export interface WebViewHTMLAttributes extends HTMLAttributes {
 export interface SVGAttributes extends AriaAttributes {
   innerHTML?: string
 
+  /**
+   * SVG Styling Attributes
+   * @see https://www.w3.org/TR/SVG/styling.html#ElementSpecificStyling
+   */
+  class?: any
+  style?: string | CSSProperties
+
   color?: string
   height?: number | string
   id?: string

--- a/packages/runtime-dom/types/jsx.d.ts
+++ b/packages/runtime-dom/types/jsx.d.ts
@@ -246,7 +246,7 @@ interface AriaAttributes {
 }
 
 export interface HTMLAttributes extends AriaAttributes {
-  domPropsInnerHTML?: string
+  innerHTML?: string
 
   class?: any
   style?: string | CSSProperties
@@ -735,7 +735,7 @@ export interface WebViewHTMLAttributes extends HTMLAttributes {
 }
 
 export interface SVGAttributes extends AriaAttributes {
-  domPropsInnerHTML?: string
+  innerHTML?: string
 
   color?: string
   height?: number | string


### PR DESCRIPTION
... and add types for svg styling attributes in jsx

fix https://github.com/vuejs/vue-next/issues/1810
