### PR TITLE
fix(runtime-core): set ref in the post-render queue

### DIFF
--- a/packages/runtime-core/src/renderer.ts
+++ b/packages/runtime-core/src/renderer.ts
@@ -319,14 +319,16 @@ export const setRef = (
   }
 
   if (isString(ref)) {
-    refs[ref] = value
-    if (hasOwn(setupState, ref)) {
-      queuePostRenderEffect(() => {
+    queuePostRenderEffect(() => {
+      refs[ref] = value
+      if (hasOwn(setupState, ref)) {
         setupState[ref] = value
-      }, parentSuspense)
-    }
+      }
+    }, parentSuspense)
   } else if (isRef(ref)) {
-    ref.value = value
+    queuePostRenderEffect(() => {
+      ref.value = value
+    }, parentSuspense)
   } else if (isFunction(ref)) {
     callWithErrorHandling(ref, parentComponent, ErrorCodes.FUNCTION_REF, [
       value,

--- a/packages/runtime-core/src/renderer.ts
+++ b/packages/runtime-core/src/renderer.ts
@@ -319,16 +319,27 @@ export const setRef = (
   }
 
   if (isString(ref)) {
-    queuePostRenderEffect(() => {
+    // Unset ref synchronously and reset ref in the post-render queue
+    if (value) {
+      queuePostRenderEffect(() => {
+        refs[ref] = value
+      }, parentSuspense)
+    } else {
       refs[ref] = value
-      if (hasOwn(setupState, ref)) {
+    }
+    if (hasOwn(setupState, ref)) {
+      queuePostRenderEffect(() => {
         setupState[ref] = value
-      }
-    }, parentSuspense)
+      }, parentSuspense)
+    }
   } else if (isRef(ref)) {
-    queuePostRenderEffect(() => {
+    if (value) {
+      queuePostRenderEffect(() => {
+        ref.value = value
+      }, parentSuspense)
+    } else {
       ref.value = value
-    }, parentSuspense)
+    }
   } else if (isFunction(ref)) {
     callWithErrorHandling(ref, parentComponent, ErrorCodes.FUNCTION_REF, [
       value,


### PR DESCRIPTION
Fix #1834
Fix #1789 .

Unresolved question: when `ref` is a function, keep the current behavior?