### PR TITLE
types(runtime-core): make `this` void in emits validator

### DIFF
--- a/packages/runtime-core/src/componentOptions.ts
+++ b/packages/runtime-core/src/componentOptions.ts
@@ -106,7 +106,7 @@ export interface ComponentOptionsBase<
   components?: Record<string, PublicAPIComponent>
   directives?: Record<string, Directive>
   inheritAttrs?: boolean
-  emits?: E | EE[]
+  emits?: (E | EE[]) & ThisType<void>
 
   // Internal ------------------------------------------------------------------
 

--- a/test-dts/defineComponent.test-d.tsx
+++ b/test-dts/defineComponent.test-d.tsx
@@ -710,6 +710,17 @@ describe('emits', () => {
   const instance = {} as ComponentPublicInstance
   instance.$emit('test', 1)
   instance.$emit('test')
+
+  // `this` should be void inside of emits validators
+  defineComponent({
+    props: ['bar'],
+    emits: {
+      foo(): boolean {
+        // @ts-expect-error
+        return this.bar === 3
+      }
+    }
+  })
 })
 
 describe('componentOptions setup should be `SetupContext`', () => {


### PR DESCRIPTION
Right now, it seems like `emits` validators cannot access `this` (for example, to validate event arguments based on the value of a prop). However, the typing doesn't reflect the fact that `this` isn't available.

I came across this because I wasn't sure if I could access `this` in `emits`, but accessing `this.propName` didn't give me a type error, so I thought it would probably work.
