### PR TITLE
feat: comments parser option

### DIFF
--- a/packages/compiler-core/__tests__/parse.spec.ts
+++ b/packages/compiler-core/__tests__/parse.spec.ts
@@ -374,6 +374,16 @@ describe('compiler: parse', () => {
         }
       })
     })
+
+    test('comments option', () => {
+      __DEV__ = false
+      const astNoComment = baseParse('<!--abc-->')
+      const astWithComments = baseParse('<!--abc-->', { comments: true })
+      __DEV__ = true
+
+      expect(astNoComment.children).toHaveLength(0)
+      expect(astWithComments.children).toHaveLength(1)
+    })
   })
 
   describe('Element', () => {

--- a/packages/compiler-core/src/options.ts
+++ b/packages/compiler-core/src/options.ts
@@ -49,6 +49,10 @@ export interface ParserOptions {
    */
   decodeEntities?: (rawText: string, asAttr: boolean) => string
   onError?: (error: CompilerError) => void
+  /**
+   * Keep comments in the templates AST, even in production
+   */
+  comments?: boolean
 }
 
 export type HoistTransform = (

--- a/packages/compiler-core/src/parse.ts
+++ b/packages/compiler-core/src/parse.ts
@@ -50,7 +50,8 @@ export const defaultParserOptions: MergedParserOptions = {
   isCustomElement: NO,
   decodeEntities: (rawText: string): string =>
     rawText.replace(decodeRE, (_, p1) => decodeMap[p1]),
-  onError: defaultOnError
+  onError: defaultOnError,
+  comments: false
 }
 
 export const enum TextModes {
@@ -228,7 +229,11 @@ function parseChildren(
           } else {
             node.content = node.content.replace(/[\t\r\n\f ]+/g, ' ')
           }
-        } else if (!__DEV__ && node.type === NodeTypes.COMMENT) {
+        } else if (
+          !__DEV__ &&
+          node.type === NodeTypes.COMMENT &&
+          !context.options.comments
+        ) {
           // remove comment nodes in prod
           removedWhitespace = true
           nodes[i] = null as any


### PR DESCRIPTION
To force keep HTML comments in production when parsing a template

closes #1853