### PR TITLE
types(runtime-core): improve the props' type

### DIFF
--- a/packages/runtime-core/src/componentProps.ts
+++ b/packages/runtime-core/src/componentProps.ts
@@ -37,14 +37,14 @@ export type ComponentPropsOptions<P = Data> =
   | string[]
 
 export type ComponentObjectPropsOptions<P = Data> = {
-  [K in keyof P]: Prop<P[K], P[K]> | null
+  [K in keyof P]: Prop<P[K]> | null
 }
 
-export type Prop<T, D = any> = PropOptions<T, D> | PropType<T>
+export type Prop<T, D = T> = PropOptions<T, D> | PropType<T>
 
 type DefaultFactory<T> = () => T | null | undefined
 
-interface PropOptions<T = any, D = any> {
+interface PropOptions<T = any, D = T> {
   type?: PropType<T> | true | null
   required?: boolean
   default?: D | DefaultFactory<D> | null | undefined

--- a/packages/runtime-core/src/componentProps.ts
+++ b/packages/runtime-core/src/componentProps.ts
@@ -37,17 +37,17 @@ export type ComponentPropsOptions<P = Data> =
   | string[]
 
 export type ComponentObjectPropsOptions<P = Data> = {
-  [K in keyof P]: Prop<P[K]> | null
+  [K in keyof P]: Prop<P[K], P[K]> | null
 }
 
-export type Prop<T> = PropOptions<T> | PropType<T>
+export type Prop<T, D = any> = PropOptions<T, D> | PropType<T>
 
 type DefaultFactory<T> = () => T | null | undefined
 
-interface PropOptions<T = any> {
+interface PropOptions<T = any, D = any> {
   type?: PropType<T> | true | null
   required?: boolean
-  default?: T | DefaultFactory<T> | null | undefined
+  default?: D | DefaultFactory<D> | null | undefined
   validator?(value: unknown): boolean
 }
 
@@ -83,7 +83,7 @@ type InferPropType<T> = T extends null
       ? Record<string, any>
       : T extends BooleanConstructor | { type: BooleanConstructor }
         ? boolean
-        : T extends Prop<infer V> ? V : T
+        : T extends Prop<infer V, infer D> ? (unknown extends V ? D : V) : T
 
 export type ExtractPropTypes<
   O,

--- a/test-dts/defineComponent.test-d.tsx
+++ b/test-dts/defineComponent.test-d.tsx
@@ -27,6 +27,7 @@ describe('with object props', () => {
     eee: () => { a: string }
     fff: (a: number, b: string) => { a: boolean }
     hhh: boolean
+    ggg: 'foo' | 'bar'
     validated?: string
   }
 
@@ -77,6 +78,11 @@ describe('with object props', () => {
         type: Boolean,
         required: true
       },
+      // default + type casting
+      ggg: {
+        type: String as PropType<'foo' | 'bar'>,
+        default: 'foo'
+      },
       validated: {
         type: String,
         validator: (val: unknown) => val !== ''
@@ -97,6 +103,7 @@ describe('with object props', () => {
       expectType<ExpectedProps['eee']>(props.eee)
       expectType<ExpectedProps['fff']>(props.fff)
       expectType<ExpectedProps['hhh']>(props.hhh)
+      expectType<ExpectedProps['ggg']>(props.ggg)
       expectType<ExpectedProps['validated']>(props.validated)
 
       // @ts-expect-error props should be readonly
@@ -128,6 +135,7 @@ describe('with object props', () => {
       expectType<ExpectedProps['eee']>(props.eee)
       expectType<ExpectedProps['fff']>(props.fff)
       expectType<ExpectedProps['hhh']>(props.hhh)
+      expectType<ExpectedProps['ggg']>(props.ggg)
 
       // @ts-expect-error props should be readonly
       expectError((props.a = 1))
@@ -146,6 +154,7 @@ describe('with object props', () => {
       expectType<ExpectedProps['eee']>(this.eee)
       expectType<ExpectedProps['fff']>(this.fff)
       expectType<ExpectedProps['hhh']>(this.hhh)
+      expectType<ExpectedProps['ggg']>(this.ggg)
 
       // @ts-expect-error props on `this` should be readonly
       expectError((this.a = 1))
@@ -177,6 +186,7 @@ describe('with object props', () => {
       eee={() => ({ a: 'eee' })}
       fff={(a, b) => ({ a: a > +b })}
       hhh={false}
+      ggg="foo"
       // should allow class/style as attrs
       class="bar"
       style={{ color: 'red' }}
@@ -193,6 +203,10 @@ describe('with object props', () => {
   expectError(
     // @ts-expect-error wrong prop types
     <MyComponent a={'wrong type'} b="foo" dd={{ n: 1 }} ddd={['foo']} />
+  )
+  expectError(
+    // @ts-expect-error wrong prop types
+    <MyComponent ggg="baz" />
   )
   // @ts-expect-error
   expectError(<MyComponent b="foo" dd={{ n: 'string' }} ddd={['foo']} />)


### PR DESCRIPTION
Specifying the `default` value will affect the type inference of `props`:

![image](https://user-images.githubusercontent.com/14146560/90312147-ba976980-df34-11ea-9c7c-c9a99968004b.png)

This PR improves that:

![image](https://user-images.githubusercontent.com/14146560/90312132-8de35200-df34-11ea-88f4-867d492fff63.png)


