### PR TITLE
types(runtime-core): make `this` void in prop validators and default factories

### DIFF
--- a/packages/runtime-core/src/componentOptions.ts
+++ b/packages/runtime-core/src/componentOptions.ts
@@ -217,7 +217,7 @@ export type ComponentOptionsWithObjectProps<
   EE extends string = string,
   Props = Readonly<ExtractPropTypes<PropsOptions>>
 > = ComponentOptionsBase<Props, RawBindings, D, C, M, Mixin, Extends, E, EE> & {
-  props: PropsOptions
+  props: PropsOptions & ThisType<void>
 } & ThisType<
     CreateComponentPublicInstance<
       Props,

--- a/test-dts/defineComponent.test-d.tsx
+++ b/test-dts/defineComponent.test-d.tsx
@@ -196,6 +196,27 @@ describe('with object props', () => {
   )
   // @ts-expect-error
   expectError(<MyComponent b="foo" dd={{ n: 'string' }} ddd={['foo']} />)
+
+  // `this` should be void inside of prop validators and prop default factories
+  defineComponent({
+    props: {
+      myProp: {
+        type: Number,
+        validator(val: unknown): boolean {
+          // @ts-expect-error
+          return val !== this.otherProp
+        },
+        default(): number {
+          // @ts-expect-error
+          return this.otherProp + 1
+        }
+      },
+      otherProp: {
+        type: Number,
+        required: true
+      }
+    }
+  })
 })
 
 // describe('type inference w/ optional props declaration', () => {


### PR DESCRIPTION
Same as #1842, except for `validator`s and `default` factories in `props`. The typing currently doesn't reflect the fact that `this` isn't available in these functions.