### PR TITLE
docs: add indefinite article to bug fix sentence

### DIFF
--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -23,7 +23,7 @@ Hi! I'm really excited that you are interested in contributing to Vue.js. Before
   - Add accompanying test case.
   - Provide a convincing reason to add this feature. Ideally, you should open a suggestion issue first and have it approved before working on it.
 
-- If fixing bug:
+- If fixing a bug:
 
   - If you are resolving a special issue, add `(fix #xxxx[,#xxxx])` (#xxxx is the issue id) in your PR title for a better release log, e.g. `update entities encoding/decoding (fix #3899)`.
   - Provide a detailed description of the bug in the PR. Live demo preferred.


### PR DESCRIPTION
Just a tiny readability change I spotted a few times:

![image](https://user-images.githubusercontent.com/20028526/90412556-2bf62a00-e0a5-11ea-8791-cd85eaf86ea0.png)

Understand if it doesn't seem like a big enough deal to add the 'a' 🙂 
