### PR TITLE
types(runtime-core): make `FunctionalComponent` emit string[] compatible with `Component`

### DIFF
--- a/packages/runtime-core/src/component.ts
+++ b/packages/runtime-core/src/component.ts
@@ -110,7 +110,7 @@ export interface ClassComponent {
   __vccOpts: ComponentOptions
 }
 
-export type Component = ComponentOptions | FunctionalComponent<any>
+export type Component = ComponentOptions | FunctionalComponent<any, any>
 
 // A type used in public APIs where a component type is expected.
 // The constructor type is an artificial type returned by defineComponent().

--- a/test-dts/functionalComponent.test-d.tsx
+++ b/test-dts/functionalComponent.test-d.tsx
@@ -1,4 +1,9 @@
-import { FunctionalComponent, expectError, expectType } from './index'
+import {
+  FunctionalComponent,
+  expectError,
+  expectType,
+  Component
+} from './index'
 
 // simple function signature
 const Foo = (props: { foo: number }) => props.foo
@@ -51,3 +56,10 @@ expectError(<Foo />)
 expectError(<Bar foo="bar" />)
 //  @ts-expect-error
 expectError(<Foo baz="bar" />)
+
+const Baz: FunctionalComponent<{}, string[]> = (props, { emit }) => {
+  expectType<{}>(props)
+  expectType<(event: string) => void>(emit)
+}
+
+expectType<Component>(Baz)


### PR DESCRIPTION
fix #1847