### PR TITLE
types(runtime-core): expose PublicAPIComponent

### DIFF
--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -48,7 +48,7 @@ export { defineAsyncComponent } from './apiAsyncComponent'
 
 // For getting a hold of the internal instance in setup() - useful for advanced
 // plugins
-export { getCurrentInstance } from './component'
+export { getCurrentInstance, PublicAPIComponent } from './component'
 
 // For raw render function users
 export { h } from './h'

--- a/test-dts/defineComponent.test-d.tsx
+++ b/test-dts/defineComponent.test-d.tsx
@@ -11,6 +11,8 @@ import {
   ComponentOptions,
   SetupContext
 } from './index'
+import { PublicAPIComponent } from '@vue/vue/src'
+import { PublicAPIComponent } from '@vue/vue/src'
 
 describe('with object props', () => {
   interface ExpectedProps {
@@ -161,6 +163,8 @@ describe('with object props', () => {
       return null
     }
   })
+
+  expectType<PublicAPIComponent>(MyComponent)
 
   // Test TSX
   expectType<JSX.Element>(
@@ -727,6 +731,8 @@ describe('emits', () => {
       }
     }
   })
+
+  expectType<PublicAPIComponent>(instance)
 })
 
 describe('componentOptions setup should be `SetupContext`', () => {

--- a/test-dts/defineComponent.test-d.tsx
+++ b/test-dts/defineComponent.test-d.tsx
@@ -8,11 +8,10 @@ import {
   expectError,
   expectType,
   ComponentPublicInstance,
+  PublicAPIComponent,
   ComponentOptions,
   SetupContext
 } from './index'
-import { PublicAPIComponent } from '@vue/vue/src'
-import { PublicAPIComponent } from '@vue/vue/src'
 
 describe('with object props', () => {
   interface ExpectedProps {

--- a/test-dts/defineComponent.test-d.tsx
+++ b/test-dts/defineComponent.test-d.tsx
@@ -190,6 +190,17 @@ describe('with object props', () => {
     />
   )
 
+  expectType<PublicAPIComponent>(
+    <MyComponent
+      b="b"
+      dd={{ n: 1 }}
+      ddd={['ddd']}
+      eee={() => ({ a: 'eee' })}
+      fff={(a, b) => ({ a: a > +b })}
+      hhh={false}
+    />
+  )
+
   // @ts-expect-error missing required props
   expectError(<MyComponent />)
 


### PR DESCRIPTION
Allow user land to have access to the component type

relates https://github.com/vuejs/vue-router-next/pull/421 