### PR TITLE
fix(reactivity/ref): fix rawType is CollectionTypes[]

### DIFF
--- a/packages/reactivity/src/ref.ts
+++ b/packages/reactivity/src/ref.ts
@@ -2,7 +2,6 @@ import { track, trigger } from './effect'
 import { TrackOpTypes, TriggerOpTypes } from './operations'
 import { isArray, isObject, hasChanged } from '@vue/shared'
 import { reactive, isProxy, toRaw, isReactive } from './reactive'
-import { CollectionTypes } from './collectionHandlers'
 
 declare const RefSymbol: unique symbol
 
@@ -180,7 +179,6 @@ export type UnwrapRef<T> = T extends Ref<infer V>
 
 type UnwrapRefSimple<T> = T extends
   | Function
-  | CollectionTypes
   | BaseTypes
   | Ref
   | RefUnwrapBailTypes[keyof RefUnwrapBailTypes]


### PR DESCRIPTION
When ref's parameter type is `CollectionTypes[]`, TypeScript Type Inference is wrong.

[Reproduction link](https://codesandbox.io/s/ref-test-73ixr?file=/src/main.js)

![image](https://user-images.githubusercontent.com/11594438/90629579-33a70180-e252-11ea-8158-e5a23924b832.png)

