### PR TITLE
types(runtime-core): handling PropType<Function>

### DIFF
--- a/packages/runtime-core/src/componentProps.ts
+++ b/packages/runtime-core/src/componentProps.ts
@@ -40,7 +40,7 @@ export type ComponentObjectPropsOptions<P = Data> = {
   [K in keyof P]: Prop<P[K]> | null
 }
 
-export type Prop<T, D = T> = PropOptions<T, D> | PropType<T>
+export type Prop<T, D = T> = PropOptions<T, D> | PropType<T> | {}
 
 type DefaultFactory<T> = (props: Data) => T | null | undefined
 

--- a/packages/runtime-core/src/componentProps.ts
+++ b/packages/runtime-core/src/componentProps.ts
@@ -40,14 +40,14 @@ export type ComponentObjectPropsOptions<P = Data> = {
   [K in keyof P]: Prop<P[K]> | null
 }
 
-export type Prop<T, D = T> = PropOptions<T, D> | PropType<T> | {}
+export type Prop<T, D = T> = PropOptions<T, D> | PropType<T>
 
 type DefaultFactory<T> = (props: Data) => T | null | undefined
 
 interface PropOptions<T = any, D = T> {
   type?: PropType<T> | true | null
   required?: boolean
-  default?: D | DefaultFactory<D> | null | undefined
+  default?: D | DefaultFactory<D> | null | undefined | {}
   validator?(value: unknown): boolean
 }
 

--- a/packages/runtime-core/src/componentProps.ts
+++ b/packages/runtime-core/src/componentProps.ts
@@ -47,7 +47,7 @@ type DefaultFactory<T> = (props: Data) => T | null | undefined
 interface PropOptions<T = any, D = T> {
   type?: PropType<T> | true | null
   required?: boolean
-  default?: D | DefaultFactory<D> | null | undefined | {}
+  default?: D | DefaultFactory<D> | null | undefined | object
   validator?(value: unknown): boolean
 }
 

--- a/test-dts/defineComponent.test-d.tsx
+++ b/test-dts/defineComponent.test-d.tsx
@@ -29,6 +29,7 @@ describe('with object props', () => {
     fff: (a: number, b: string) => { a: boolean }
     hhh: boolean
     ggg: 'foo' | 'bar'
+    ffff: (a: number, b: string) => { a: boolean }
     validated?: string
   }
 
@@ -89,6 +90,11 @@ describe('with object props', () => {
         type: String as PropType<'foo' | 'bar'>,
         default: 'foo'
       },
+      // default + function
+      ffff: {
+        type: Function as PropType<(a: number, b: string) => { a: boolean }>,
+        default: (a: number, b: string) => ({ a: true })
+      },
       validated: {
         type: String,
         // validator requires explicit annotation
@@ -112,6 +118,7 @@ describe('with object props', () => {
       expectType<ExpectedProps['fff']>(props.fff)
       expectType<ExpectedProps['hhh']>(props.hhh)
       expectType<ExpectedProps['ggg']>(props.ggg)
+      expectType<ExpectedProps['ffff']>(props.ffff)
       expectType<ExpectedProps['validated']>(props.validated)
 
       // @ts-expect-error props should be readonly


### PR DESCRIPTION
fix #1891

Honestly don't know why adding `| {}` works here 🤔 