### PR TITLE
perf(ref): improve ref performance

### DIFF
--- a/packages/reactivity/src/computed.ts
+++ b/packages/reactivity/src/computed.ts
@@ -1,6 +1,6 @@
 import { effect, ReactiveEffect, trigger, track } from './effect'
 import { TriggerOpTypes, TrackOpTypes } from './operations'
-import { Ref } from './ref'
+import { Ref, RefSymbol } from './ref'
 import { isFunction, NOOP } from '@vue/shared'
 import { ReactiveFlags } from './reactive'
 
@@ -18,6 +18,52 @@ export type ComputedSetter<T> = (v: T) => void
 export interface WritableComputedOptions<T> {
   get: ComputedGetter<T>
   set: ComputedSetter<T>
+}
+
+class _ComputedRef<T> implements ComputedRef<T> {
+  private _value!: T
+  private _dirty = true
+
+  public readonly effect: ReactiveEffect<T>;
+
+  public [ReactiveFlags.IS_READONLY]: boolean
+
+  constructor(
+    getter: ComputedGetter<T>,
+    private readonly _setter: ComputedSetter<T>,
+    isReadonly: boolean
+  ) {
+    this.effect = effect(getter, {
+      lazy: true,
+      scheduler: () => {
+        if (!this._dirty) {
+          this._dirty = true
+          trigger(this, TriggerOpTypes.SET, 'value')
+        }
+      }
+    })
+
+    this[ReactiveFlags.IS_READONLY] = isReadonly
+  }
+
+  [RefSymbol]: true
+
+  get value() {
+    if (this._dirty) {
+      this._value = this.effect()
+      this._dirty = false
+    }
+    track(this, TrackOpTypes.GET, 'value')
+    return this._value
+  }
+
+  set value(newValue: T) {
+    this._setter(newValue)
+  }
+
+  get __v_isRef() {
+    return true
+  }
 }
 
 export function computed<T>(getter: ComputedGetter<T>): ComputedRef<T>
@@ -42,37 +88,9 @@ export function computed<T>(
     setter = getterOrOptions.set
   }
 
-  let dirty = true
-  let value: T
-  let computed: ComputedRef<T>
-
-  const runner = effect(getter, {
-    lazy: true,
-    scheduler: () => {
-      if (!dirty) {
-        dirty = true
-        trigger(computed, TriggerOpTypes.SET, 'value')
-      }
-    }
-  })
-  computed = {
-    __v_isRef: true,
-    [ReactiveFlags.IS_READONLY]:
-      isFunction(getterOrOptions) || !getterOrOptions.set,
-
-    // expose effect so computed can be stopped
-    effect: runner,
-    get value() {
-      if (dirty) {
-        value = runner()
-        dirty = false
-      }
-      track(computed, TrackOpTypes.GET, 'value')
-      return value
-    },
-    set value(newValue: T) {
-      setter(newValue)
-    }
-  } as any
-  return computed
+  return new _ComputedRef(
+    getter,
+    setter,
+    isFunction(getterOrOptions) || !getterOrOptions.set
+  )
 }

--- a/packages/reactivity/src/computed.ts
+++ b/packages/reactivity/src/computed.ts
@@ -1,6 +1,6 @@
 import { effect, ReactiveEffect, trigger, track } from './effect'
 import { TriggerOpTypes, TrackOpTypes } from './operations'
-import { Ref, RefSymbol } from './ref'
+import { Ref } from './ref'
 import { isFunction, NOOP } from '@vue/shared'
 import { ReactiveFlags } from './reactive'
 
@@ -20,7 +20,7 @@ export interface WritableComputedOptions<T> {
   set: ComputedSetter<T>
 }
 
-class _ComputedRef<T> implements ComputedRef<T> {
+class _ComputedRef<T> {
   private _value!: T
   private _dirty = true
 
@@ -45,8 +45,6 @@ class _ComputedRef<T> implements ComputedRef<T> {
 
     this[ReactiveFlags.IS_READONLY] = isReadonly
   }
-
-  [RefSymbol]: true
 
   get value() {
     if (this._dirty) {
@@ -92,5 +90,5 @@ export function computed<T>(
     getter,
     setter,
     isFunction(getterOrOptions) || !getterOrOptions.set
-  )
+  ) as any
 }

--- a/packages/reactivity/src/ref.ts
+++ b/packages/reactivity/src/ref.ts
@@ -4,7 +4,7 @@ import { isArray, isObject, hasChanged } from '@vue/shared'
 import { reactive, isProxy, toRaw, isReactive } from './reactive'
 import { CollectionTypes } from './collectionHandlers'
 
-declare const RefSymbol: unique symbol
+export declare const RefSymbol: unique symbol
 
 export interface Ref<T = any> {
   /**
@@ -47,7 +47,7 @@ export function shallowRef(value?: unknown) {
 class _Ref<T> implements Ref<T> {
   private _value: T
 
-  constructor(private _rawValue: T, private _shallow = false) {
+  constructor(private _rawValue: T, private readonly _shallow = false) {
     this._value = _shallow ? _rawValue : convert(_rawValue)
   }
 
@@ -159,7 +159,7 @@ export function toRefs<T extends object>(object: T): ToRefs<T> {
 }
 
 class _ObjectRef<T extends object, K extends keyof T> implements Ref<T[K]> {
-  constructor(private _object: T, private _key: K) {}
+  constructor(private readonly _object: T, private readonly _key: K) {}
 
   get value() {
     return this._object[this._key]

--- a/packages/reactivity/src/ref.ts
+++ b/packages/reactivity/src/ref.ts
@@ -4,7 +4,7 @@ import { isArray, isObject, hasChanged } from '@vue/shared'
 import { reactive, isProxy, toRaw, isReactive } from './reactive'
 import { CollectionTypes } from './collectionHandlers'
 
-export declare const RefSymbol: unique symbol
+declare const RefSymbol: unique symbol
 
 export interface Ref<T = any> {
   /**
@@ -23,7 +23,7 @@ const convert = <T extends unknown>(val: T): T =>
 
 export function isRef<T>(r: Ref<T> | unknown): r is Ref<T>
 export function isRef(r: any): r is Ref {
-  return r ? r.__v_isRef === true : false
+  return Boolean(r && r.__v_isRef === true)
 }
 
 export function ref<T extends object>(
@@ -44,7 +44,7 @@ export function shallowRef(value?: unknown) {
   return createRef(value, true)
 }
 
-class _Ref<T> implements Ref<T> {
+class _Ref<T> {
   private _value: T
 
   constructor(private _rawValue: T, private readonly _shallow = false) {
@@ -63,8 +63,6 @@ class _Ref<T> implements Ref<T> {
       trigger(this, TriggerOpTypes.SET, 'value', newVal)
     }
   }
-
-  [RefSymbol]: true
 
   get __v_isRef() {
     return true
@@ -115,7 +113,7 @@ export type CustomRefFactory<T> = (
   set: (value: T) => void
 }
 
-class _CustomRef<T> implements Ref<T> {
+class _CustomRef<T> {
   private readonly _get: ReturnType<CustomRefFactory<T>>['get']
   private readonly _set: ReturnType<CustomRefFactory<T>>['set']
 
@@ -136,15 +134,13 @@ class _CustomRef<T> implements Ref<T> {
     this._set(newVal)
   }
 
-  [RefSymbol]: true
-
   get __v_isRef() {
     return true
   }
 }
 
 export function customRef<T>(factory: CustomRefFactory<T>): Ref<T> {
-  return new _CustomRef(factory)
+  return new _CustomRef(factory) as any
 }
 
 export function toRefs<T extends object>(object: T): ToRefs<T> {
@@ -158,7 +154,7 @@ export function toRefs<T extends object>(object: T): ToRefs<T> {
   return ret
 }
 
-class _ObjectRef<T extends object, K extends keyof T> implements Ref<T[K]> {
+class _ObjectRef<T extends object, K extends keyof T> {
   constructor(private readonly _object: T, private readonly _key: K) {}
 
   get value() {
@@ -169,8 +165,6 @@ class _ObjectRef<T extends object, K extends keyof T> implements Ref<T[K]> {
     this._object[this._key] = newVal
   }
 
-  [RefSymbol]: true
-
   get __v_isRef() {
     return true
   }
@@ -180,7 +174,7 @@ export function toRef<T extends object, K extends keyof T>(
   object: T,
   key: K
 ): Ref<T[K]> {
-  return new _ObjectRef(object, key)
+  return new _ObjectRef(object, key) as any
 }
 
 // corner case when use narrows type


### PR DESCRIPTION
### Why?
@jods4 and I noticed that `ref`s can be made much faster and more memory efficient by using classes (prototypes) instead of the current objects (https://github.com/vuejs/rfcs/issues/197#issuecomment-671119767 and onwards).

### What?
This changes the implementation of the following functions to a class internally. For each of the functions a benchmark is provided to show the increase in speed (typically between 70-100%). These benchmarks test pure get & set performance. There are no dependencies that need to be updated.
- `ref` & `shallowRef`, [bench](https://jsbench.me/0pkdrmjqfa)
-  `customRef`, [bench](https://jsbench.me/19kdvd1xkg)
- `toRef`, [bench](https://jsbench.me/a0kdvdb8e0)
- `computed`, [bench](https://jsbench.me/a7kdvevvpw)

Besides these, I also changed the implementation of `isRef` to a lazy implementation, improving performance by about 10-20%. Benchmark can be found [here](https://jsbench.me/cike1jpqnw).

Another argument to be made is the memory efficiency. I made a [small gist](https://gist.github.com/RobbinBaauw/4538bf492c85346d17e9732851205c2b) where I create 1 million refs. When comparing the amount of memory used, I get 70MB for the class implementation against 470MB for the current implementation.

### Real world
These were only tiny tests with little other computations, so one may wonder how this performs in a real world scenario.

I made small benchmark for this as well, using the `useValueSync` from [`vue-composable`](https://pikax.me/vue-composable/composable/state/valueSync.html). [This benchmark](https://jsbench.me/gcke1mmamh) also shows a 20-25% improvement in performance!

### Future
If this step is taken, we will continue our search for other occasions in which performance can be improved by converting something from an object to a class.
