### PR TITLE
fix(runtime-core): don't inherit `el` if child is block node

### DIFF
--- a/packages/runtime-core/__tests__/components/Teleport.spec.ts
+++ b/packages/runtime-core/__tests__/components/Teleport.spec.ts
@@ -316,7 +316,7 @@ describe('renderer: teleport', () => {
       },
       render: compile(`
       <teleport :to="target" :disabled="disabled">
-        <div>teleported</div><span>{{ disabled }}</span>
+        <div>teleported</div><span v-if="disabled">{{ disabled }}</span>
       </teleport>
       <div>root</div>
       `)
@@ -326,7 +326,7 @@ describe('renderer: teleport', () => {
       `"<!--teleport start--><!--teleport end--><div>root</div>"`
     )
     expect(serializeInner(target)).toMatchInlineSnapshot(
-      `"<div>teleported</div><span>false</span>"`
+      `"<div>teleported</div><!--v-if-->"`
     )
 
     disabled.value = true
@@ -343,7 +343,7 @@ describe('renderer: teleport', () => {
       `"<!--teleport start--><!--teleport end--><div>root</div>"`
     )
     expect(serializeInner(target)).toMatchInlineSnapshot(
-      `"<div>teleported</div><span>false</span>"`
+      `"<div>teleported</div><!--v-if-->"`
     )
   })
 })

--- a/packages/runtime-core/src/components/Teleport.ts
+++ b/packages/runtime-core/src/components/Teleport.ts
@@ -146,6 +146,7 @@ export const TeleportImpl = {
           const oldChildren = n1.children as VNode[]
           const children = n2.children as VNode[]
           for (let i = 0; i < children.length; i++) {
+            if (n2.dynamicChildren.includes(children[i])) continue
             children[i].el = oldChildren[i].el
           }
         }


### PR DESCRIPTION
fix #1903