### PR TITLE
fix(runtime-core): correctly track dynamic nodes in renderSlot

### DIFF
--- a/packages/runtime-core/src/helpers/renderSlot.ts
+++ b/packages/runtime-core/src/helpers/renderSlot.ts
@@ -10,7 +10,7 @@ import {
 import { PatchFlags, SlotFlags } from '@vue/shared'
 import { warn } from '../warning'
 
-export let templateSlotRendering = 0
+export let shouldTrackInSlotRendering = 0
 
 /**
  * Compiler runtime helper for rendering `<slot/>`
@@ -39,7 +39,7 @@ export function renderSlot(
   // invocation interfering with template-based block tracking, but in
   // `renderSlot` we can be sure that it's template-based so we can force
   // enable it.
-  templateSlotRendering++
+  shouldTrackInSlotRendering++
   const rendered = (openBlock(),
   createBlock(
     Fragment,
@@ -49,6 +49,6 @@ export function renderSlot(
       ? PatchFlags.STABLE_FRAGMENT
       : PatchFlags.BAIL
   ))
-  templateSlotRendering--
+  shouldTrackInSlotRendering--
   return rendered
 }

--- a/packages/runtime-core/src/helpers/renderSlot.ts
+++ b/packages/runtime-core/src/helpers/renderSlot.ts
@@ -10,7 +10,15 @@ import {
 import { PatchFlags, SlotFlags } from '@vue/shared'
 import { warn } from '../warning'
 
-export let isRenderingTemplateSlot = false
+export let templateSlotRendering = 0
+
+function setTemplateSlotRendering() {
+  templateSlotRendering++
+}
+
+function resetTemplateSlotRendering() {
+  templateSlotRendering--
+}
 
 /**
  * Compiler runtime helper for rendering `<slot/>`
@@ -39,7 +47,7 @@ export function renderSlot(
   // invocation interfering with template-based block tracking, but in
   // `renderSlot` we can be sure that it's template-based so we can force
   // enable it.
-  isRenderingTemplateSlot = true
+  setTemplateSlotRendering()
   const rendered = (openBlock(),
   createBlock(
     Fragment,
@@ -49,6 +57,6 @@ export function renderSlot(
       ? PatchFlags.STABLE_FRAGMENT
       : PatchFlags.BAIL
   ))
-  isRenderingTemplateSlot = false
+  resetTemplateSlotRendering()
   return rendered
 }

--- a/packages/runtime-core/src/helpers/renderSlot.ts
+++ b/packages/runtime-core/src/helpers/renderSlot.ts
@@ -12,14 +12,6 @@ import { warn } from '../warning'
 
 export let templateSlotRendering = 0
 
-function setTemplateSlotRendering() {
-  templateSlotRendering++
-}
-
-function resetTemplateSlotRendering() {
-  templateSlotRendering--
-}
-
 /**
  * Compiler runtime helper for rendering `<slot/>`
  * @private
@@ -47,7 +39,7 @@ export function renderSlot(
   // invocation interfering with template-based block tracking, but in
   // `renderSlot` we can be sure that it's template-based so we can force
   // enable it.
-  setTemplateSlotRendering()
+  templateSlotRendering++
   const rendered = (openBlock(),
   createBlock(
     Fragment,
@@ -57,6 +49,6 @@ export function renderSlot(
       ? PatchFlags.STABLE_FRAGMENT
       : PatchFlags.BAIL
   ))
-  resetTemplateSlotRendering()
+  templateSlotRendering--
   return rendered
 }

--- a/packages/runtime-core/src/vnode.ts
+++ b/packages/runtime-core/src/vnode.ts
@@ -36,7 +36,7 @@ import { currentRenderingInstance } from './componentRenderUtils'
 import { RendererNode, RendererElement } from './renderer'
 import { NULL_DYNAMIC_COMPONENT } from './helpers/resolveAssets'
 import { hmrDirtyComponents } from './hmr'
-import { isRenderingTemplateSlot } from './helpers/renderSlot'
+import { templateSlotRendering } from './helpers/renderSlot'
 
 export const Fragment = (Symbol(__DEV__ ? 'Fragment' : undefined) as any) as {
   __isFragment: true
@@ -403,7 +403,7 @@ function _createVNode(
   normalizeChildren(vnode, children)
 
   if (
-    (shouldTrack > 0 || isRenderingTemplateSlot) &&
+    (shouldTrack > 0 || templateSlotRendering > 0) &&
     // avoid a block node from tracking itself
     !isBlockNode &&
     // has current parent block

--- a/packages/runtime-core/src/vnode.ts
+++ b/packages/runtime-core/src/vnode.ts
@@ -36,7 +36,7 @@ import { currentRenderingInstance } from './componentRenderUtils'
 import { RendererNode, RendererElement } from './renderer'
 import { NULL_DYNAMIC_COMPONENT } from './helpers/resolveAssets'
 import { hmrDirtyComponents } from './hmr'
-import { templateSlotRendering } from './helpers/renderSlot'
+import { shouldTrackInSlotRendering } from './helpers/renderSlot'
 
 export const Fragment = (Symbol(__DEV__ ? 'Fragment' : undefined) as any) as {
   __isFragment: true
@@ -403,7 +403,7 @@ function _createVNode(
   normalizeChildren(vnode, children)
 
   if (
-    (shouldTrack > 0 || templateSlotRendering > 0) &&
+    (shouldTrack > 0 || shouldTrackInSlotRendering > 0) &&
     // avoid a block node from tracking itself
     !isBlockNode &&
     // has current parent block


### PR DESCRIPTION
Fix: #1909 