### PR TITLE
fix(runtime-core): the Transition component should track dynamicChildren correctly

### DIFF
--- a/packages/runtime-core/src/components/BaseTransition.ts
+++ b/packages/runtime-core/src/components/BaseTransition.ts
@@ -18,6 +18,8 @@ import { callWithAsyncErrorHandling, ErrorCodes } from '../errorHandling'
 import { ShapeFlags, PatchFlags } from '@vue/shared'
 import { onBeforeUnmount, onMounted } from '../apiLifecycle'
 import { RendererElement } from '../renderer'
+import { RawSlots, Slots } from '../componentSlots'
+import { renderSlot } from '../helpers/renderSlot'
 
 export interface BaseTransitionProps<HostElement = RendererElement> {
   mode?: 'in-out' | 'out-in' | 'default'
@@ -139,7 +141,8 @@ const BaseTransitionImpl = {
 
     return () => {
       const children =
-        slots.default && getTransitionRawChildren(slots.default(), true)
+        slots.default &&
+        getTransitionRawChildren(getTransitionDefaultSlot(slots), true)
       if (!children || !children.length) {
         return
       }
@@ -433,6 +436,14 @@ export function setTransitionHooks(vnode: VNode, hooks: TransitionHooks) {
   } else {
     vnode.transition = hooks
   }
+}
+
+export function getTransitionDefaultSlot(slots: Slots) {
+  return (slots as RawSlots)._
+    ? // We need to use `renderSlot` to render the compiled slot,
+      // so that we can track the `dynamicChildren` correctly.
+      [renderSlot(slots, 'default')]
+    : slots.default!()
 }
 
 export function getTransitionRawChildren(

--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -91,7 +91,8 @@ export {
   useTransitionState,
   resolveTransitionHooks,
   setTransitionHooks,
-  getTransitionRawChildren
+  getTransitionRawChildren,
+  getTransitionDefaultSlot
 } from './components/BaseTransition'
 
 // For devtools

--- a/packages/runtime-dom/src/components/TransitionGroup.ts
+++ b/packages/runtime-dom/src/components/TransitionGroup.ts
@@ -14,6 +14,7 @@ import {
   resolveTransitionHooks,
   useTransitionState,
   getTransitionRawChildren,
+  getTransitionDefaultSlot,
   getCurrentInstance,
   setTransitionHooks,
   createVNode,
@@ -100,7 +101,9 @@ const TransitionGroupImpl = {
       const cssTransitionProps = resolveTransitionProps(rawProps)
       const tag = rawProps.tag || Fragment
       prevChildren = children
-      children = slots.default ? getTransitionRawChildren(slots.default()) : []
+      children = slots.default
+        ? getTransitionRawChildren(getTransitionDefaultSlot(slots))
+        : []
 
       for (let i = 0; i < children.length; i++) {
         const child = children[i]


### PR DESCRIPTION
Fix: #1918 