### PR TITLE
types(runtime-core): better error message when trying to infer types using reactive

### DIFF
--- a/packages/reactivity/src/reactive.ts
+++ b/packages/reactivity/src/reactive.ts
@@ -61,6 +61,10 @@ function getTargetType(value: Target) {
 type UnwrapNestedRefs<T> = T extends Ref ? T : UnwrapRef<T>
 
 export function reactive<T extends object>(target: T): UnwrapNestedRefs<T>
+// to provide better error when trying to infer type #1930
+export function reactive<T extends object, R extends UnwrapNestedRefs<T>>(
+  target: T
+): R
 export function reactive(target: object) {
   // if trying to observe a readonly proxy, return the readonly version.
   if (target && (target as Target)[ReactiveFlags.IS_READONLY]) {

--- a/test-dts/reactivity.test-d.ts
+++ b/test-dts/reactivity.test-d.ts
@@ -1,4 +1,11 @@
-import { readonly, describe, expectError } from './index'
+import {
+  readonly,
+  describe,
+  expectError,
+  reactive,
+  computed,
+  ComputedRef
+} from './index'
 
 describe('should support DeepReadonly', () => {
   const r = readonly({ obj: { k: 'v' } })
@@ -6,4 +13,40 @@ describe('should support DeepReadonly', () => {
   expectError((r.obj = {}))
   // @ts-expect-error
   expectError((r.obj.k = 'x'))
+})
+
+// #1930
+describe('should unwrap the computed type', () => {
+  interface Foo {
+    position: number
+  }
+
+  interface Bar {
+    position: number
+    callback: (data: number) => void
+  }
+
+  const position: ComputedRef<number> = computed(() => 1)
+
+  expect<Foo>(
+    reactive({
+      position: position
+    })
+  )
+  expect<Bar>(
+    reactive({
+      position: position, // Issue happens here
+      callback: (v: any) => {
+        expect<any>(v)
+      }
+    })
+  )
+
+  expect<Bar>(
+    reactive({
+      position,
+      // @ts-ignore ignore implicit any
+      callback: _ => {}
+    })
+  )
 })


### PR DESCRIPTION
fix #1930


This only provides a better message when trying to infer the function argument type, not sure about this tbh