### PR TITLE
types(runtime-core): HTMLAttributes should extends Events

### DIFF
--- a/packages/runtime-dom/types/jsx.d.ts
+++ b/packages/runtime-dom/types/jsx.d.ts
@@ -734,7 +734,7 @@ export interface WebViewHTMLAttributes extends HTMLAttributes {
   webpreferences?: string
 }
 
-export interface SVGAttributes extends AriaAttributes {
+export interface SVGAttributes extends AriaAttributes, EventHandlers<Events> {
   innerHTML?: string
 
   /**

--- a/packages/runtime-dom/types/jsx.d.ts
+++ b/packages/runtime-dom/types/jsx.d.ts
@@ -245,7 +245,7 @@ interface AriaAttributes {
   'aria-valuetext'?: string
 }
 
-export interface HTMLAttributes extends AriaAttributes {
+export interface HTMLAttributes extends AriaAttributes, EventHandlers<Events> {
   innerHTML?: string
 
   class?: any
@@ -1322,7 +1322,7 @@ type ReservedProps = {
     | ((ref: Element | RuntimeCore.ComponentInternalInstance | null) => void)
 }
 
-type ElementAttrs<T> = T & EventHandlers<Events> & ReservedProps
+type ElementAttrs<T> = T & ReservedProps
 
 type NativeElements = {
   [K in StringKeyOf<IntrinsicElementAttributes>]: ElementAttrs<


### PR DESCRIPTION
```tsx
interface AProps extends HTMLAttributes {

}

const A = (props: AProps) => {
  return <span {...props} />
}

<A onClick={xx} />
```

It's not necessary to define `onClick` or `onXxx` again.

