### PR TITLE
fix(compiler-sfc): user-defined options.data of scss should be respected

### DIFF
--- a/packages/compiler-sfc/__tests__/compileStyle.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileStyle.spec.ts
@@ -337,10 +337,10 @@ describe('SFC style preprocessors', () => {
     ])
   })
 
-  test('scss respect user-defined options.data', () => {
+  test('scss respect user-defined options.additionalData', () => {
     const res = compileStyle({
       preprocessOptions: {
-        data: `
+        additionalData: `
           @mixin square($size) {
             width: $size;
             height: $size;

--- a/packages/compiler-sfc/__tests__/compileStyle.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileStyle.spec.ts
@@ -336,4 +336,26 @@ describe('SFC style preprocessors', () => {
       path.join(__dirname, './fixture/import.scss')
     ])
   })
+
+  test('scss respect user-defined options.data', () => {
+    const res = compileStyle({
+      preprocessOptions: {
+        data: `
+          @mixin square($size) {
+            width: $size;
+            height: $size;
+          }`
+      },
+      source: `
+        .square {
+          @include square(100px);
+        }
+      `,
+      filename: path.resolve(__dirname, './fixture/test.scss'),
+      id: '',
+      preprocessLang: 'scss'
+    })
+
+    expect(res.errors.length).toBe(0)
+  })
 })

--- a/packages/compiler-sfc/src/stylePreprocessors.ts
+++ b/packages/compiler-sfc/src/stylePreprocessors.ts
@@ -24,7 +24,7 @@ const scss: StylePreprocessor = (source, map, options, load = require) => {
   const nodeSass = load('sass')
   const finalOptions = {
     ...options,
-    data: (options.data || '') + source,
+    data: (options.additionalData || '') + source,
     file: options.filename,
     outFile: options.filename,
     sourceMap: !!map

--- a/packages/compiler-sfc/src/stylePreprocessors.ts
+++ b/packages/compiler-sfc/src/stylePreprocessors.ts
@@ -24,7 +24,7 @@ const scss: StylePreprocessor = (source, map, options, load = require) => {
   const nodeSass = load('sass')
   const finalOptions = {
     ...options,
-    data: source,
+    data: (options.data || '') + source,
     file: options.filename,
     outFile: options.filename,
     sourceMap: !!map


### PR DESCRIPTION
vite 1.0.0-beta.9+ accepts `cssPreprocessOptions` but this ignores [`data` option](https://github.com/sass/node-sass#data) of scss/sass in `vite.config.ts`

This PR fix the issue
