### PR TITLE
fix(reactivity): trigger Map custom has correctly

### DIFF
--- a/packages/reactivity/__tests__/collections/Map.spec.ts
+++ b/packages/reactivity/__tests__/collections/Map.spec.ts
@@ -437,7 +437,7 @@ describe('reactivity/collections', () => {
       expect(spy).toHaveBeenCalledTimes(3)
     })
 
-    it('should trigger Map custom has correctly', () => {
+    it('should trigger has only once for non-reactive keys', () => {
       const map = new Map()
       const spy = jest.fn()
       map.has = spy
@@ -446,17 +446,6 @@ describe('reactivity/collections', () => {
       proxy.has('k')
 
       expect(spy).toBeCalledTimes(1)
-    })
-
-    it('should trigger WeakMap custom has correctly', () => {
-      const map = new WeakMap()
-      const spy = jest.fn()
-      map.has = spy
-
-      let proxy = reactive(map)
-      proxy.has(reactive({}))
-
-      expect(spy).toBeCalledTimes(2)
     })
   })
 })

--- a/packages/reactivity/__tests__/collections/Map.spec.ts
+++ b/packages/reactivity/__tests__/collections/Map.spec.ts
@@ -436,5 +436,27 @@ describe('reactivity/collections', () => {
       map.set('b', 1)
       expect(spy).toHaveBeenCalledTimes(3)
     })
+
+    it('should trigger Map custom has correctly', () => {
+      const map = new Map()
+      const spy = jest.fn()
+      map.has = spy
+
+      let proxy = reactive(map)
+      proxy.has('k')
+
+      expect(spy).toBeCalledTimes(1)
+    })
+
+    it('should trigger WeakMap custom has correctly', () => {
+      const map = new WeakMap()
+      const spy = jest.fn()
+      map.has = spy
+
+      let proxy = reactive(map)
+      proxy.has(reactive({}))
+
+      expect(spy).toBeCalledTimes(2)
+    })
   })
 })

--- a/packages/reactivity/src/collectionHandlers.ts
+++ b/packages/reactivity/src/collectionHandlers.ts
@@ -59,7 +59,11 @@ function has(this: CollectionTypes, key: unknown, isReadonly = false): boolean {
     !isReadonly && track(rawTarget, TrackOpTypes.HAS, key)
   }
   !isReadonly && track(rawTarget, TrackOpTypes.HAS, rawKey)
-  return target.has(key) || target.has(rawKey)
+  const hasKey = target.has(key)
+  if (key === rawKey) {
+    return hasKey
+  }
+  return hasKey || target.has(rawKey)
 }
 
 function size(target: IterableCollections, isReadonly = false) {

--- a/packages/reactivity/src/collectionHandlers.ts
+++ b/packages/reactivity/src/collectionHandlers.ts
@@ -59,11 +59,9 @@ function has(this: CollectionTypes, key: unknown, isReadonly = false): boolean {
     !isReadonly && track(rawTarget, TrackOpTypes.HAS, key)
   }
   !isReadonly && track(rawTarget, TrackOpTypes.HAS, rawKey)
-  const hasKey = target.has(key)
-  if (key === rawKey) {
-    return hasKey
-  }
-  return hasKey || target.has(rawKey)
+  return key === rawKey
+    ? target.has(key)
+    : target.has(key) || target.has(rawKey)
 }
 
 function size(target: IterableCollections, isReadonly = false) {


### PR DESCRIPTION
### Fix the following situation:
```js
let map = new Map()
map.has = function(key) {
  console.log('trigger has')
  return Map.prototype.has.call(map, key)
}

let proxy = reactive(map)
proxy.has('k')  // print 'trigger has' twice
```

### btw, I am not sure if the following situation is as expected: (this PR did not affect this)
```js
let map = new WeakMap()
map.has = function(key) {
  console.log('trigger has')
  return WeakMap.prototype.has.call(map, key)
}

let proxy = reactive(map)
proxy.has(reactive({}))  // print 'trigger has' twice
```