### PR TITLE
style(compiler-sfc): tweak api and types export

### DIFF
--- a/packages/compiler-sfc/src/index.ts
+++ b/packages/compiler-sfc/src/index.ts
@@ -4,6 +4,7 @@ export { compileTemplate } from './compileTemplate'
 export { compileStyle, compileStyleAsync } from './compileStyle'
 export { compileScript, analyzeScriptBindings } from './compileScript'
 export { rewriteDefault } from './rewriteDefault'
+export { generateCodeFrame } from '@vue/compiler-core'
 
 // Types
 export {
@@ -28,6 +29,5 @@ export { SFCScriptCompileOptions } from './compileScript'
 export {
   CompilerOptions,
   CompilerError,
-  BindingMetadata,
-  generateCodeFrame
+  BindingMetadata
 } from '@vue/compiler-core'


### PR DESCRIPTION
`generateCodeFrame` should be placed at "API" group