### PR TITLE
fix(reactivity): add NaN prop on Array should not trigger length dependency

### DIFF
--- a/packages/reactivity/__tests__/reactiveArray.spec.ts
+++ b/packages/reactivity/__tests__/reactiveArray.spec.ts
@@ -124,6 +124,8 @@ describe('reactivity/reactive/Array', () => {
     expect(fn).toHaveBeenCalledTimes(1)
     observed[-1] = 'x'
     expect(fn).toHaveBeenCalledTimes(1)
+    observed[NaN] = 'x'
+    expect(fn).toHaveBeenCalledTimes(1)
   })
 
   describe('Array methods w/ refs', () => {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -82,7 +82,10 @@ export const isPlainObject = (val: unknown): val is object =>
   toTypeString(val) === '[object Object]'
 
 export const isIntegerKey = (key: unknown) =>
-  isString(key) && key[0] !== '-' && '' + parseInt(key, 10) === key
+  isString(key) &&
+  key !== 'NaN' &&
+  key[0] !== '-' &&
+  '' + parseInt(key, 10) === key
 
 export const isReservedProp = /*#__PURE__*/ makeMap(
   'key,ref,' +


### PR DESCRIPTION
Fixed: 
``` 
const observed = reactive(new Array(3))
effect(() => {
  console.log(observed.length)
})
observed[NaN] = 1
```