### PR TITLE
fix: add beforeDestroy/destroyed lifecycle back to the options API

### DIFF
--- a/packages/runtime-core/src/componentOptions.ts
+++ b/packages/runtime-core/src/componentOptions.ts
@@ -635,15 +635,17 @@ export function applyOptions(
     onRenderTriggered(renderTriggered.bind(publicThis))
   }
   if (__DEV__ && beforeDestroy) {
-    warn(`\`beforeDestroy\` has been renamed to \`beforeUnmount\`.`)
-    onBeforeUnmount(beforeDestroy.bind(publicThis))
+    warn(
+      `\`beforeDestroy\` has been renamed to \`beforeUnmount\`.`
+    )
   }
   if (beforeUnmount) {
     onBeforeUnmount(beforeUnmount.bind(publicThis))
   }
   if (__DEV__ && destroyed) {
-    warn(`\`destroyed\` has been renamed to \`unmounted\`.`)
-    onUnmounted(destroyed.bind(publicThis))
+    warn(
+      `\`destroyed\` has been renamed to \`unmounted\`.`
+    )
   }
   if (unmounted) {
     onUnmounted(unmounted.bind(publicThis))

--- a/packages/runtime-core/src/componentOptions.ts
+++ b/packages/runtime-core/src/componentOptions.ts
@@ -634,13 +634,15 @@ export function applyOptions(
   if (renderTriggered) {
     onRenderTriggered(renderTriggered.bind(publicThis))
   }
-  if (beforeDestroy) {
+  if (__DEV__ && beforeDestroy) {
+    warn(`\`beforeDestroy\` has been renamed to \`beforeUnmount\`.`)
     onBeforeUnmount(beforeDestroy.bind(publicThis))
   }
   if (beforeUnmount) {
     onBeforeUnmount(beforeUnmount.bind(publicThis))
   }
-  if (destroyed) {
+  if (__DEV__ && destroyed) {
+    warn(`\`destroyed\` has been renamed to \`unmounted\`.`)
     onUnmounted(destroyed.bind(publicThis))
   }
   if (unmounted) {

--- a/packages/runtime-core/src/componentOptions.ts
+++ b/packages/runtime-core/src/componentOptions.ts
@@ -317,7 +317,11 @@ interface LegacyOptions<
   updated?(): void
   activated?(): void
   deactivated?(): void
+  /** @deprecated use `beforeUnmount` instead */
+  beforeDestroy?(): void
   beforeUnmount?(): void
+  /** @deprecated use `unmounted` instead */
+  destroyed?(): void
   unmounted?(): void
   renderTracked?: DebuggerHook
   renderTriggered?: DebuggerHook
@@ -394,7 +398,9 @@ export function applyOptions(
     updated,
     activated,
     deactivated,
+    beforeDestroy,
     beforeUnmount,
+    destroyed,
     unmounted,
     render,
     renderTracked,
@@ -628,8 +634,14 @@ export function applyOptions(
   if (renderTriggered) {
     onRenderTriggered(renderTriggered.bind(publicThis))
   }
+  if (beforeDestroy) {
+    onBeforeUnmount(beforeDestroy.bind(publicThis))
+  }
   if (beforeUnmount) {
     onBeforeUnmount(beforeUnmount.bind(publicThis))
+  }
+  if (destroyed) {
+    onUnmounted(destroyed.bind(publicThis))
   }
   if (unmounted) {
     onUnmounted(unmounted.bind(publicThis))


### PR DESCRIPTION
Fixes #1339

These lifecycle hooks were [mentioned in the RFC document](https://composition-api.vuejs.org/api.html#:~:text=beforeDestroy,onUnmounted)
and were implemented before.

But somehow dropped in this commit https://github.com/vuejs/vue-next/commit/81a31f79dc69dae1eac1b958af3f3a18bd1f67ac

Now that there's no mention of this breaking change in Vue 3 RFCs, I
think we need to support these legacy hooks.