### PR TITLE
fix(runtime-core): Fixes RenderFunction typing

### DIFF
--- a/packages/runtime-core/src/componentOptions.ts
+++ b/packages/runtime-core/src/componentOptions.ts
@@ -74,7 +74,9 @@ import { VNodeChild } from './vnode'
  */
 export interface ComponentCustomOptions {}
 
-export type RenderFunction = () => VNodeChild
+export type RenderFunction = (
+  context: ComponentInternalInstance | object
+) => VNodeChild
 
 export interface ComponentOptionsBase<
   Props,


### PR DESCRIPTION
The exported `compile` function returns a RenderFunction.
The render function is supposed be called with at least one argument, `_ctx`.
The typings for RenderFunction does however not allow this.

This PR adds typings of `ComponentInternalInstance | object` for the first parameter, as a `ComponentInternalInstance` is what I've found render function to be called with elsewhere.

---

Perhaps it would be beneficial adding typings for the cache parameter, but I'm not too familiar with the caching in render functions, and chose to omit it for this PR.