### PR TITLE
refactor(runtime-core): remove the deactivated branch in unmountCompo…

### DIFF
--- a/packages/runtime-core/__tests__/components/KeepAlive.spec.ts
+++ b/packages/runtime-core/__tests__/components/KeepAlive.spec.ts
@@ -347,21 +347,33 @@ describe('KeepAlive', () => {
     })
 
     test('max', async () => {
-      const spyA = jest.fn()
-      const spyB = jest.fn()
-      const spyC = jest.fn()
-      const spyAD = jest.fn()
-      const spyBD = jest.fn()
-      const spyCD = jest.fn()
+      const spyAC = jest.fn()
+      const spyBC = jest.fn()
+      const spyCC = jest.fn()
+      const spyAA = jest.fn()
+      const spyBA = jest.fn()
+      const spyCA = jest.fn()
+      const spyADA = jest.fn()
+      const spyBDA = jest.fn()
+      const spyCDA = jest.fn()
+      const spyAUM = jest.fn()
+      const spyBUM = jest.fn()
+      const spyCUM = jest.fn()
 
       function assertCount(calls: number[]) {
         expect([
-          spyA.mock.calls.length,
-          spyAD.mock.calls.length,
-          spyB.mock.calls.length,
-          spyBD.mock.calls.length,
-          spyC.mock.calls.length,
-          spyCD.mock.calls.length
+          spyAC.mock.calls.length,
+          spyAA.mock.calls.length,
+          spyADA.mock.calls.length,
+          spyAUM.mock.calls.length,
+          spyBC.mock.calls.length,
+          spyBA.mock.calls.length,
+          spyBDA.mock.calls.length,
+          spyBUM.mock.calls.length,
+          spyCC.mock.calls.length,
+          spyCA.mock.calls.length,
+          spyCDA.mock.calls.length,
+          spyCUM.mock.calls.length
         ]).toEqual(calls)
       }
 
@@ -369,18 +381,24 @@ describe('KeepAlive', () => {
       const views: Record<string, ComponentOptions> = {
         a: {
           render: () => `one`,
-          created: spyA,
-          unmounted: spyAD
+          created: spyAC,
+          activated: spyAA,
+          deactivated: spyADA,
+          unmounted: spyAUM
         },
         b: {
           render: () => `two`,
-          created: spyB,
-          unmounted: spyBD
+          created: spyBC,
+          activated: spyBA,
+          deactivated: spyBDA,
+          unmounted: spyBUM
         },
         c: {
           render: () => `three`,
-          created: spyC,
-          unmounted: spyCD
+          created: spyCC,
+          activated: spyCA,
+          deactivated: spyCDA,
+          unmounted: spyCUM
         }
       }
 
@@ -392,26 +410,26 @@ describe('KeepAlive', () => {
         }
       }
       render(h(App), root)
-      assertCount([1, 0, 0, 0, 0, 0])
+      assertCount([1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
 
       viewRef.value = 'b'
       await nextTick()
-      assertCount([1, 0, 1, 0, 0, 0])
+      assertCount([1, 1, 1, 0, 1, 1, 0, 0, 0, 0, 0, 0])
 
       viewRef.value = 'c'
       await nextTick()
       // should prune A because max cache reached
-      assertCount([1, 1, 1, 0, 1, 0])
+      assertCount([1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 0, 0])
 
       viewRef.value = 'b'
       await nextTick()
       // B should be reused, and made latest
-      assertCount([1, 1, 1, 0, 1, 0])
+      assertCount([1, 1, 1, 1, 1, 2, 1, 0, 1, 1, 1, 0])
 
       viewRef.value = 'a'
       await nextTick()
       // C should be pruned because B was used last so C is the oldest cached
-      assertCount([2, 1, 1, 0, 1, 1])
+      assertCount([2, 2, 1, 1, 1, 2, 2, 0, 1, 1, 1, 1])
     })
   })
 

--- a/packages/runtime-core/src/renderer.ts
+++ b/packages/runtime-core/src/renderer.ts
@@ -2053,7 +2053,7 @@ function baseCreateRenderer(
       unregisterHMR(instance)
     }
 
-    const { bum, effects, update, subTree, um, da, isDeactivated } = instance
+    const { bum, effects, update, subTree, um } = instance
     // beforeUnmount hook
     if (bum) {
       invokeArrayFns(bum)
@@ -2072,14 +2072,6 @@ function baseCreateRenderer(
     // unmounted hook
     if (um) {
       queuePostRenderEffect(um, parentSuspense)
-    }
-    // deactivated hook
-    if (
-      da &&
-      !isDeactivated &&
-      instance.vnode.shapeFlag & ShapeFlags.COMPONENT_SHOULD_KEEP_ALIVE
-    ) {
-      queuePostRenderEffect(da, parentSuspense)
     }
     queuePostRenderEffect(() => {
       instance.isUnmounted = true


### PR DESCRIPTION
```typescript
// deactivated hook
if (
  da &&
  !isDeactivated &&
  instance.vnode.shapeFlag & ShapeFlags.COMPONENT_SHOULD_KEEP_ALIVE
) {
  queuePostRenderEffect(da, parentSuspense)
}
```
`queuePostRenderEffect(da, parentSuspense)`永远都不会被执行，
因为在`unmount`函数中已经处理过`instance.vnode.shapeFlag & ShapeFlags.COMPONENT_SHOULD_KEEP_ALIVE`为true的情况，
如下为函数`unmount`中的代码：
```typescript
if (shapeFlag & ShapeFlags.COMPONENT_SHOULD_KEEP_ALIVE) {
  ;(parentComponent!.ctx as KeepAliveContext).deactivate(vnode)
  return
}
```