### PR TITLE
feat(runtime-core): hydration internal flag

### DIFF
--- a/packages/runtime-core/__tests__/hydration.spec.ts
+++ b/packages/runtime-core/__tests__/hydration.spec.ts
@@ -699,4 +699,44 @@ describe('SSR hydration', () => {
       expect(`Hydration children mismatch`).toHaveBeenWarned()
     })
   })
+
+  test('sets and removes internal hydration flag', async () => {
+    const checkHydration = jest.fn()
+
+    const container = document.createElement('div')
+    container.innerHTML = '<div>foo</div>'
+
+    const visible = ref(true)
+    const component = defineComponent({
+      render: () => h('div', 'foo'),
+      created() {
+        checkHydration(this.$.isHydrating)
+      },
+      beforeMount() {
+        checkHydration(this.$.isHydrating)
+      },
+      mounted() {
+        checkHydration(this.$.isHydrating)
+      }
+    })
+    const app = createSSRApp({
+      render: () => (visible.value ? h(component) : null)
+    })
+
+    app.mount(container)
+
+    visible.value = false
+    await nextTick()
+    visible.value = true
+    await nextTick()
+
+    expect(checkHydration.mock.calls).toMatchObject([
+      [true],
+      [true],
+      [true],
+      [false],
+      [false],
+      [false]
+    ])
+  })
 })

--- a/packages/runtime-core/src/component.ts
+++ b/packages/runtime-core/src/component.ts
@@ -297,6 +297,7 @@ export interface ComponentInternalInstance {
   isMounted: boolean
   isUnmounted: boolean
   isDeactivated: boolean
+  isHydrating: boolean
   /**
    * @internal
    */
@@ -407,6 +408,7 @@ export function createComponentInstance(
     isMounted: false,
     isUnmounted: false,
     isDeactivated: false,
+    isHydrating: false,
     bc: null,
     c: null,
     bm: null,

--- a/packages/runtime-core/src/hydration.ts
+++ b/packages/runtime-core/src/hydration.ts
@@ -180,7 +180,8 @@ export function createHydrationFunctions(
               parentComponent,
               parentSuspense,
               isSVGContainer(container),
-              optimized
+              optimized,
+              true
             )
           }
           // async component

--- a/packages/runtime-core/src/renderer.ts
+++ b/packages/runtime-core/src/renderer.ts
@@ -232,7 +232,8 @@ export type MountComponentFn = (
   parentComponent: ComponentInternalInstance | null,
   parentSuspense: SuspenseBoundary | null,
   isSVG: boolean,
-  optimized: boolean
+  optimized: boolean,
+  hydrating?: boolean
 ) => void
 
 type ProcessTextOrCommentFn = (
@@ -1178,13 +1179,16 @@ function baseCreateRenderer(
     parentComponent,
     parentSuspense,
     isSVG,
-    optimized
+    optimized,
+    hydrating = false
   ) => {
     const instance: ComponentInternalInstance = (initialVNode.component = createComponentInstance(
       initialVNode,
       parentComponent,
       parentSuspense
     ))
+
+    instance.isHydrating = hydrating
 
     if (__DEV__ && instance.type.__hmrId) {
       registerHMR(instance)
@@ -1352,6 +1356,7 @@ function baseCreateRenderer(
         if ((vnodeHook = props && props.onVnodeMounted)) {
           queuePostRenderEffect(() => {
             invokeVNodeHook(vnodeHook!, parent, initialVNode)
+            instance.isHydrating = false
           }, parentSuspense)
         }
         // activated hook for keep-alive roots.


### PR DESCRIPTION
Adds an internal hydration flag for `created`, `beforeMount` and `mounted` lifecycle. Closes #1723 