### PR TITLE
Revert "refactor(runtime-core): add @internal for instance.proxy"

### DIFF
--- a/packages/runtime-core/src/component.ts
+++ b/packages/runtime-core/src/component.ts
@@ -246,10 +246,7 @@ export interface ComponentInternalInstance {
 
   // the rest are only for stateful components ---------------------------------
 
-  /**
-   * main proxy that serves as the public instance (`this`)
-   * @internal
-   */
+  // main proxy that serves as the public instance (`this`)
   proxy: ComponentPublicInstance | null
 
   /**


### PR DESCRIPTION
Reverts vuejs/vue-next#1849.

More information at [#1849](https://github.com/vuejs/vue-next/pull/1849#issuecomment-683658875)