### PR TITLE
fix: inherit `el` with hoisted nodes inside keyed `template` fragment

### DIFF
--- a/packages/runtime-core/src/renderer.ts
+++ b/packages/runtime-core/src/renderer.ts
@@ -1139,7 +1139,11 @@ function baseCreateRenderer(
           parentSuspense,
           isSVG
         )
-        traverseStaticChildren(n1, n2)
+        // #2080 if the stable fragment has a key, it's a <template v-for> that may
+        //  get moved around. Make sure all root level vnodes inherit el.
+        if (n2.key != null) {
+          traverseStaticChildren(n1, n2, true /* shallow */)
+        }
       } else {
         // keyed / unkeyed, or manual fragments.
         // for keyed & unkeyed, since they are compiler generated from v-for,
@@ -2155,7 +2159,7 @@ function baseCreateRenderer(
    * the children will always moved so that need inherit el form previous nodes
    * to ensure correct moved position.
    */
-  const traverseStaticChildren = (n1: VNode, n2: VNode) => {
+  const traverseStaticChildren = (n1: VNode, n2: VNode, shallow = false) => {
     const ch1 = n1.children
     const ch2 = n2.children
     if (isArray(ch1) && isArray(ch2)) {
@@ -2168,7 +2172,7 @@ function baseCreateRenderer(
           if (c2.patchFlag <= 0 || c2.patchFlag === PatchFlags.HYDRATE_EVENTS) {
             c2.el = c1.el
           }
-          traverseStaticChildren(c1, c2)
+          if (!shallow) traverseStaticChildren(c1, c2)
         }
         if (__DEV__ && c2.type === Comment) {
           c2.el = c1.el

--- a/packages/runtime-core/src/renderer.ts
+++ b/packages/runtime-core/src/renderer.ts
@@ -2170,7 +2170,7 @@ function baseCreateRenderer(
           }
           traverseStaticChildren(c1, c2)
         }
-        if (c2.type === Comment) {
+        if (__DEV__ && c2.type === Comment) {
           c2.el = c1.el
         }
       }

--- a/packages/runtime-core/src/renderer.ts
+++ b/packages/runtime-core/src/renderer.ts
@@ -1139,9 +1139,7 @@ function baseCreateRenderer(
           parentSuspense,
           isSVG
         )
-        if (__DEV__ && parentComponent && parentComponent.type.__hmrId) {
-          traverseStaticChildren(n1, n2)
-        }
+        traverseStaticChildren(n1, n2)
       } else {
         // keyed / unkeyed, or manual fragments.
         // for keyed & unkeyed, since they are compiler generated from v-for,
@@ -2152,7 +2150,10 @@ function baseCreateRenderer(
    * inside a block also inherit the DOM element from the previous tree so that
    * HMR updates (which are full updates) can retrieve the element for patching.
    *
-   * Dev only.
+   * #2080
+   * Inside keyed `template` fragment static children, if a fragment is moved,
+   * the children will always moved so that need inherit el form previous nodes
+   * to ensure correct moved position.
    */
   const traverseStaticChildren = (n1: VNode, n2: VNode) => {
     const ch1 = n1.children
@@ -2168,6 +2169,9 @@ function baseCreateRenderer(
             c2.el = c1.el
           }
           traverseStaticChildren(c1, c2)
+        }
+        if (c2.type === Comment) {
+          c2.el = c1.el
         }
       }
     }


### PR DESCRIPTION
fix #2080