### PR TITLE
fix(compiler-core): process `key` expression form `template v-for`

### DIFF
--- a/packages/compiler-core/src/compile.ts
+++ b/packages/compiler-core/src/compile.ts
@@ -29,7 +29,6 @@ export function getBaseTransformPreset(
     [
       transformOnce,
       transformIf,
-      transformFor,
       ...(!__BROWSER__ && prefixIdentifiers
         ? [
             // order is important
@@ -39,6 +38,7 @@ export function getBaseTransformPreset(
         : __BROWSER__ && __DEV__
           ? [transformExpression]
           : []),
+      transformFor,
       transformSlotOutlet,
       transformElement,
       trackSlotScopes,


### PR DESCRIPTION
fix #2085