### PR TITLE
fix(reactivity): `toRef` should not wrap a `ref`

### DIFF
--- a/packages/reactivity/__tests__/ref.spec.ts
+++ b/packages/reactivity/__tests__/ref.spec.ts
@@ -236,6 +236,10 @@ describe('reactivity/ref', () => {
     // mutating source should trigger effect using the proxy refs
     a.x = 4
     expect(dummyX).toBe(4)
+
+    // should keep ref
+    const r = { x: ref(1) }
+    expect(toRef(r, 'x')).toBe(r.x)
   })
 
   test('toRefs', () => {
@@ -292,12 +296,12 @@ describe('reactivity/ref', () => {
   test('toRefs reactive array', () => {
     const arr = reactive(['a', 'b', 'c'])
     const refs = toRefs(arr)
-    
+
     expect(Array.isArray(refs)).toBe(true)
-    
+
     refs[0].value = '1'
     expect(arr[0]).toBe('1')
-    
+
     arr[1] = '2'
     expect(refs[1].value).toBe('2')
   })

--- a/packages/reactivity/src/ref.ts
+++ b/packages/reactivity/src/ref.ts
@@ -168,7 +168,9 @@ export function toRef<T extends object, K extends keyof T>(
   object: T,
   key: K
 ): Ref<T[K]> {
-  return new ObjectRefImpl(object, key) as any
+  return isRef(object[key])
+    ? object[key]
+    : (new ObjectRefImpl(object, key) as any)
 }
 
 // corner case when use narrows type


### PR DESCRIPTION

```ts
const r = { x: ref(1) }
toRef(r,'x') // { value: { value: 1 } } 

// it should be 

toRef(r, 'x') // { value: 1}
```