### PR TITLE
fix(computed): add computedRunners

### DIFF
--- a/packages/reactivity/src/computed.ts
+++ b/packages/reactivity/src/computed.ts
@@ -36,6 +36,7 @@ class ComputedRefImpl<T> {
   ) {
     this.effect = effect(getter, {
       lazy: true,
+      computed: true,
       scheduler: () => {
         if (!this._dirty) {
           this._dirty = true

--- a/packages/reactivity/src/effect.ts
+++ b/packages/reactivity/src/effect.ts
@@ -21,6 +21,7 @@ export interface ReactiveEffect<T = any> {
 
 export interface ReactiveEffectOptions {
   lazy?: boolean
+  computed?: true
   scheduler?: (job: ReactiveEffect) => void
   onTrack?: (event: DebuggerEvent) => void
   onTrigger?: (event: DebuggerEvent) => void
@@ -176,9 +177,16 @@ export function trigger(
   }
 
   const effects = new Set<ReactiveEffect>()
+  const computedRunners = new Set<ReactiveEffect>()
   const add = (effectsToAdd: Set<ReactiveEffect> | undefined) => {
     if (effectsToAdd) {
-      effectsToAdd.forEach(effect => effects.add(effect))
+      effectsToAdd.forEach(effect => {
+        if (effect.options.computed) {
+          computedRunners.add(effect)
+        } else {
+          effects.add(effect)
+        }
+      })
     }
   }
 
@@ -232,5 +240,6 @@ export function trigger(
     }
   }
 
+  computedRunners.forEach(run)
   effects.forEach(run)
 }


### PR DESCRIPTION
I noticed that the computed module has been changed recently. [pull 1458](https://github.com/vuejs/vue-next/pull/1458).
But I tested and found that there was a problem with this change, but I am not sure whether my test is correct.
```js
const count = ref(0);
const plusOne = computed(() => {
  return count.value + 1;
});
effect(() => {
  console.log(plusOne.value + count.value);
});
function plus() {
  count.value++
}
plus();
// result
// 1
// 3
// 3
```

I changed the operation in the effect, the result was different.

```js
const count = ref(0);
const plusOne = computed(() => {
  return count.value + 1;
});
effect(() => {
  console.log(count.value + plusOne.value);
});
function plus() {
  count.value++
}
plus();
// result
// 1
// 2
// 3
```
I think the priority of computedRunners is higher than effects.