### PR TITLE
test: remove unused ParserOptions, destroyed to unmounted

### DIFF
--- a/packages/compiler-sfc/src/compileScript.ts
+++ b/packages/compiler-sfc/src/compileScript.ts
@@ -1,7 +1,7 @@
 import MagicString from 'magic-string'
 import { BindingMetadata } from '@vue/compiler-core'
 import { SFCDescriptor, SFCScriptBlock } from './parse'
-import { parse, ParserPlugin, ParserOptions } from '@babel/parser'
+import { parse, ParserPlugin } from '@babel/parser'
 import { babelParserDefaultPlugins, generateCodeFrame } from '@vue/shared'
 import {
   Node,

--- a/packages/vue/__tests__/index.spec.ts
+++ b/packages/vue/__tests__/index.spec.ts
@@ -24,7 +24,7 @@ describe('compiler + runtime integration', () => {
       mounted: jest.fn(),
       activated: jest.fn(),
       deactivated: jest.fn(),
-      destroyed: jest.fn()
+      unmounted: jest.fn()
     }
 
     const toggle = ref(true)
@@ -50,7 +50,7 @@ describe('compiler + runtime integration', () => {
     expect(one.mounted).toHaveBeenCalledTimes(1)
     expect(one.activated).toHaveBeenCalledTimes(1)
     expect(one.deactivated).toHaveBeenCalledTimes(0)
-    expect(one.destroyed).toHaveBeenCalledTimes(0)
+    expect(one.unmounted).toHaveBeenCalledTimes(0)
 
     toggle.value = false
     await nextTick()
@@ -59,7 +59,7 @@ describe('compiler + runtime integration', () => {
     expect(one.mounted).toHaveBeenCalledTimes(1)
     expect(one.activated).toHaveBeenCalledTimes(1)
     expect(one.deactivated).toHaveBeenCalledTimes(1)
-    expect(one.destroyed).toHaveBeenCalledTimes(0)
+    expect(one.unmounted).toHaveBeenCalledTimes(0)
 
     toggle.value = true
     await nextTick()
@@ -68,7 +68,7 @@ describe('compiler + runtime integration', () => {
     expect(one.mounted).toHaveBeenCalledTimes(1)
     expect(one.activated).toHaveBeenCalledTimes(2)
     expect(one.deactivated).toHaveBeenCalledTimes(1)
-    expect(one.destroyed).toHaveBeenCalledTimes(0)
+    expect(one.unmounted).toHaveBeenCalledTimes(0)
   })
 
   it('should support runtime template via CSS ID selector', () => {


### PR DESCRIPTION
This PR seeks to fix two broken tests by removing an unused `ParserOptions` import and renaming `destroyed` to `unmounted`

I only noticed one was broken at first - sorry about the vagueness of the PR title 😅 

1. `ParserOptions` is imported in `packages/compiler-sfc/src/compileScript.ts` but is unused and therefore breaks tests/build etc.
https://app.circleci.com/pipelines/github/vuejs/vue-next/4190/workflows/306e4d28-c993-4662-9565-93f68ff76137/jobs/9323


2. `destroyed` is used instead of `unmounted` in `packages/vue/__tests__/index.spec.ts`
https://app.circleci.com/pipelines/github/vuejs/vue-next/4191/workflows/6b37db70-b8ef-4e10-ab16-e92b49d6b45e/jobs/9326

![image](https://user-images.githubusercontent.com/20028526/93194218-c185e780-f73f-11ea-91f7-bc7b5696123c.png)



