### PR TITLE
types(defineComponent): fix missing exported types

### DIFF
--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -174,8 +174,11 @@ export {
   ComponentOptionsWithArrayProps,
   ComponentCustomOptions,
   ComponentOptionsBase,
-  RenderFunction
+  RenderFunction,
+  MethodOptions,
+  ComputedOptions
 } from './componentOptions'
+export { EmitsOptions, ObjectEmitsOptions } from './componentEmits'
 export {
   ComponentPublicInstance,
   ComponentCustomProperties

--- a/test-dts/defineComponent.test-d.tsx
+++ b/test-dts/defineComponent.test-d.tsx
@@ -900,3 +900,10 @@ describe('async setup', () => {
   // setup context properties should be mutable
   vm.a = 2
 })
+
+// check if defineComponent can be exported
+export default defineComponent({
+  setup() {
+    return {}
+  }
+})

--- a/test-dts/defineComponent.test-d.tsx
+++ b/test-dts/defineComponent.test-d.tsx
@@ -10,7 +10,8 @@ import {
   expectType,
   ComponentPublicInstance,
   ComponentOptions,
-  SetupContext
+  SetupContext,
+  h
 } from './index'
 
 describe('with object props', () => {
@@ -902,8 +903,21 @@ describe('async setup', () => {
 })
 
 // check if defineComponent can be exported
-export default defineComponent({
-  setup() {
-    return {}
-  }
-})
+export default {
+  // function components
+  a: defineComponent(_ => h('div')),
+  // no props
+  b: defineComponent({
+    data() {
+      return {}
+    }
+  }),
+  c: defineComponent({
+    props: ['a']
+  }),
+  d: defineComponent({
+    props: {
+      a: Number
+    }
+  })
+}

--- a/test-dts/tsconfig.build.json
+++ b/test-dts/tsconfig.build.json
@@ -1,10 +1,18 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "noEmit": false,
     "paths": {
       "@vue/*": ["../packages/*/dist"],
       "vue": ["../packages/vue/dist"]
     }
   },
-  "exclude": ["../packages/*/__tests__", "../packages/*/src"]
+  "exclude": ["../packages/*/__tests__", "../packages/*/src"],
+  "include": [
+    "../packages/global.d.ts",
+    "../packages/*/dist",
+    "../packages/runtime-dom/types/jsx.d.ts",
+    "../packages/*/__tests__",
+    "../test-dts"
+  ]
 }


### PR DESCRIPTION
Fix error when libraries export `defineComponent` also added a verification on dts file.