### PR TITLE
chore: typos in suspense events

### DIFF
--- a/packages/runtime-core/src/components/Suspense.ts
+++ b/packages/runtime-core/src/components/Suspense.ts
@@ -502,7 +502,7 @@ function createSuspenseBoundary(
         optimized
       } = suspense
 
-      // invoke @recede event
+      // invoke @fallback event
       const onFallback = vnode.props && vnode.props.onFallback
       if (isFunction(onFallback)) {
         onFallback()

--- a/test-dts/tsx.test-d.tsx
+++ b/test-dts/tsx.test-d.tsx
@@ -49,6 +49,8 @@ expectError(<KeepAlive include={123} />)
 // Suspense
 expectType<JSX.Element>(<Suspense />)
 expectType<JSX.Element>(<Suspense key="1" />)
-expectType<JSX.Element>(<Suspense onResolve={() => {}} onFallback={() => {}} />)
+expectType<JSX.Element>(
+  <Suspense onResolve={() => {}} onFallback={() => {}} onPending={() => {}} />
+)
 // @ts-expect-error
 expectError(<Suspense onResolve={123} />)


### PR DESCRIPTION
Removes the mention of the recede event that has been replaced.
Adds a typing test on the new pending event