### PR TITLE
fix(compiler-core): make v-once work with v-if/else-if/else

### DIFF
--- a/packages/compiler-core/__tests__/transforms/vOnce.spec.ts
+++ b/packages/compiler-core/__tests__/transforms/vOnce.spec.ts
@@ -99,15 +99,26 @@ describe('compiler: v-once transform', () => {
     expect(generate(root).code).toMatchSnapshot()
   })
 
-  test('with v-if', () => {
-    const root = transformWithOnce(`<div v-if="true" v-once />`)
+  test('with v-if/else', () => {
+    const root = transformWithOnce(`<div v-if="BOOLEAN" v-once /><p v-else/>`)
     expect(root.cached).toBe(1)
     expect(root.helpers).toContain(SET_BLOCK_TRACKING)
     expect(root.children[0]).toMatchObject({
       type: NodeTypes.IF,
-      // should cache the entire v-if expression, not just a single branch
+      // should cache the entire v-if/else-if/else expression, not just a single branch
       codegenNode: {
-        type: NodeTypes.JS_CACHE_EXPRESSION
+        type: NodeTypes.JS_CACHE_EXPRESSION,
+        value: {
+          type: NodeTypes.JS_CONDITIONAL_EXPRESSION,
+          consequent: {
+            type: NodeTypes.VNODE_CALL,
+            tag: `"div"`
+          },
+          alternate: {
+            type: NodeTypes.VNODE_CALL,
+            tag: `"p"`
+          }
+        }
       }
     })
   })

--- a/packages/compiler-core/src/ast.ts
+++ b/packages/compiler-core/src/ast.ts
@@ -236,7 +236,7 @@ export interface CompoundExpressionNode extends Node {
 export interface IfNode extends Node {
   type: NodeTypes.IF
   branches: IfBranchNode[]
-  codegenNode?: IfConditionalExpression
+  codegenNode?: IfConditionalExpression | CacheExpression // <div v-if v-once>
 }
 
 export interface IfBranchNode extends Node {


### PR DESCRIPTION
Fix: #2035.
This PR only fix the issue of using `v-once` with `v-if/else-if/else`, but not for using the `v-once` inside `v-for`.