### PR TITLE
feat(runtime-core): api to detach watchers and computed values from component lifecycle

### DIFF
--- a/packages/runtime-core/__tests__/apiComputed.spec.ts
+++ b/packages/runtime-core/__tests__/apiComputed.spec.ts
@@ -1,0 +1,61 @@
+import { ref } from '@vue/reactivity'
+import { h, nextTick, staticComputed } from '@vue/runtime-core'
+import { nodeOps, render } from '@vue/runtime-test'
+
+it('detach staticComputed from components and stop them manually', async () => {
+  const toggle = ref(true)
+
+  class Service {
+    counter = ref(0)
+    counterComputed = staticComputed(() => this.counter.value + 1)
+  }
+
+  let singleton: Service
+
+  function makeService() {
+    if (!singleton) {
+      singleton = new Service()
+    }
+    return singleton
+  }
+
+  const Child = {
+    setup() {
+      makeService()
+    },
+    render() {}
+  }
+
+  const App = {
+    setup() {
+      return () => {
+        return toggle.value ? h(Child) : null
+      }
+    }
+  }
+
+  render(h(App), nodeOps.createElement('div'))
+
+  expect(`must be stopped manually`).toHaveBeenWarned()
+
+  await nextTick()
+  expect(singleton!.counterComputed.value).toBe(1)
+
+  singleton!.counter.value++
+  await nextTick()
+  expect(singleton!.counterComputed.value).toBe(2)
+
+  toggle.value = false
+  await nextTick()
+  toggle.value = true
+  await nextTick()
+
+  singleton!.counter.value++
+  await nextTick()
+  expect(singleton!.counterComputed.value).toBe(3)
+
+  singleton!.counterComputed.stop()
+  singleton!.counter.value++
+  await nextTick()
+  expect(singleton!.counterComputed.value).toBe(3)
+})

--- a/packages/runtime-core/src/apiComputed.ts
+++ b/packages/runtime-core/src/apiComputed.ts
@@ -1,11 +1,13 @@
 import {
   computed as _computed,
+  ComputedGetter,
   ComputedRef,
+  stop,
   WritableComputedOptions,
-  WritableComputedRef,
-  ComputedGetter
+  WritableComputedRef
 } from '@vue/reactivity'
 import { recordInstanceBoundEffect } from './component'
+import { warn } from './warning'
 
 export function computed<T>(getter: ComputedGetter<T>): ComputedRef<T>
 export function computed<T>(
@@ -16,5 +18,36 @@ export function computed<T>(
 ) {
   const c = _computed(getterOrOptions as any)
   recordInstanceBoundEffect(c.effect)
+  return c
+}
+
+export interface StaticComputedRef<T> extends ComputedRef<T> {
+  stop: () => void
+}
+
+export interface StaticWritableComputedRef<T> extends WritableComputedRef<T> {
+  stop: () => void
+}
+
+export function staticComputed<T>(
+  getter: ComputedGetter<T>
+): StaticComputedRef<T>
+export function staticComputed<T>(
+  options: WritableComputedOptions<T>
+): StaticWritableComputedRef<T>
+export function staticComputed<T>(
+  getterOrOptions: ComputedGetter<T> | WritableComputedOptions<T>
+) {
+  if (__DEV__) {
+    warn(
+      'note that static life computed value must be stopped manually ' +
+        'to prevent memory leaks.'
+    )
+  }
+
+  const c = _computed(getterOrOptions as any) as any
+  c.stop = () => {
+    stop(c.effect)
+  }
   return c
 }

--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -24,7 +24,7 @@ export {
   markRaw,
   toRaw
 } from '@vue/reactivity'
-export { computed } from './apiComputed'
+export { computed, staticComputed } from './apiComputed'
 export { watch, watchEffect } from './apiWatch'
 export {
   onBeforeMount,


### PR DESCRIPTION
related: #1532 

### `watch` and `wathEffect`

option `lifecycle: 'static' | 'instance'`, default to `instance`

with the static lifecycle, effects created inside a `setup` will still live after the component instance unmounted.

```js
const stop = watchEffect(()=>{
        // ...
      }, { lifecycle: 'static' })

// in dev mode, a warn will be output to remind users to stop effects manually
```

### `staticComputed`

in order to not break current behavior, provide a new api `staticComputed` which can create computed values of static lifecycle.

users can stop effects manually by call `stop` method on computed value

```js
const someValue = ref(0)
const val = staticComputed(() => someValue.value + 1)
val.value // 1
val.stop() // stop the effect inside computed value
```


close #1532 