### PR TITLE
types(runtime-core): add devtools to AppConfig

### DIFF
--- a/packages/runtime-core/src/apiCreateApp.ts
+++ b/packages/runtime-core/src/apiCreateApp.ts
@@ -49,8 +49,9 @@ export type OptionMergeFunction = (
 
 export interface AppConfig {
   // @private
-  readonly isNativeTag?: (tag: string) => boolean
-
+  readonly isNativeTag?: (tag: string) => boolean 
+  
+  devtools: boolean
   performance: boolean
   optionMergeStrategies: Record<string, OptionMergeFunction>
   globalProperties: Record<string, any>


### PR DESCRIPTION
`AppConfig` is missing `devtools`