### PR TITLE
fix(reactivity): type of toRaw's parameter

### DIFF
--- a/packages/reactivity/src/reactive.ts
+++ b/packages/reactivity/src/reactive.ts
@@ -187,7 +187,7 @@ export function isProxy(value: unknown): boolean {
   return isReactive(value) || isReadonly(value)
 }
 
-export function toRaw<T>(observed: T): T {
+export function toRaw<T>(observed: UnwrapNestedRefs<T>): T {
   return (
     (observed && toRaw((observed as Target)[ReactiveFlags.RAW])) || observed
   )


### PR DESCRIPTION
From the return types of `reactive` and `readonly`, I think the type of `toRaw` should be as follows.
What do you think?

**reactive & readonly**
```
export declare function reactive<T extends object>(target: T): UnwrapNestedRefs<T>;
export declare function readonly<T extends object>(target: T): DeepReadonly<UnwrapNestedRefs<T>>;
```

**toRaw**
```
// currently
export declare function toRaw<T>(observed: T): T;

// expected
export declare function toRaw<T>(observed: UnwrapNestedRefs<T>): T;
```