### PR TITLE
Fix Typescript 4.1 compile error

### DIFF
--- a/packages/reactivity/src/collectionHandlers.ts
+++ b/packages/reactivity/src/collectionHandlers.ts
@@ -21,7 +21,7 @@ const toReactive = <T extends unknown>(value: T): T =>
   isObject(value) ? reactive(value) : value
 
 const toReadonly = <T extends unknown>(value: T): T =>
-  isObject(value) ? readonly(value) : value
+  isObject(value) ? readonly(value as Record<any, any>) : value
 
 const toShallow = <T extends unknown>(value: T): T => value
 


### PR DESCRIPTION
Typescript 4.1 will have [stricter rules for type predicates](https://github.com/microsoft/TypeScript/pull/39258) like

```ts
export const isObject = (val: unknown): val is Record<any, any> =>
  val !== null && typeof val === 'object'
```

As a result of these rules, an expression in collectionHandlers.ts in the reactivity package doesn't get narrowed to the type it did in TS 4.0 and below. Instead it gets an intersection type, which doesn't work with subsequent code.

I restored the old type using a cast, since that's essentially what the old version of Typescript was doing here.

Discovered in the Typescript user tests: https://github.com/microsoft/TypeScript/pull/40156/files#diff-3ff86ade791953efc13be67665963d94

Fixes #2218