### PR TITLE
types(runtime-core): Export RawProps in h.ts

### DIFF
--- a/packages/runtime-core/src/h.ts
+++ b/packages/runtime-core/src/h.ts
@@ -45,7 +45,7 @@ h(Component, {}, {}) // named slots
 h(Component, null, {})
 **/
 
-type RawProps = VNodeProps & {
+export type RawProps = VNodeProps & {
   // used to differ from a single VNode object as children
   __v_isVNode?: never
   // used to differ from Array children


### PR DESCRIPTION
Any reason to not export the RawProps type? Or am I using the wrong type for props (class, id etc.) on render()?

````
h(type: string, props?: RawProps | null, children?: RawChildren | RawSlots): VNode;
```