### PR TITLE
feat(reactivity): unlink triggered effects to dereference effects when possible

### DIFF
--- a/packages/reactivity/src/effect.ts
+++ b/packages/reactivity/src/effect.ts
@@ -183,7 +183,7 @@ export function trigger(
         if (effect !== activeEffect || effect.options.allowRecurse) {
           effects.add(effect)
 
-          // unlink effect to dereference stale computeds
+          // unlink effect to dereference stale computeds #2261
           effectsToAdd.delete(effect)
         }
       })

--- a/packages/reactivity/src/effect.ts
+++ b/packages/reactivity/src/effect.ts
@@ -182,6 +182,9 @@ export function trigger(
       effectsToAdd.forEach(effect => {
         if (effect !== activeEffect || effect.options.allowRecurse) {
           effects.add(effect)
+
+          // unlink effect to dereference stale computeds
+          effectsToAdd.delete(effect)
         }
       })
     }


### PR DESCRIPTION
This mitigates the memory leak problem with computeds, as well as improving performance in a one-to-many computeds scenario.

Closes https://github.com/vuejs/vue-next/issues/2261