### PR TITLE
fix(runtime-core): fix inconsistent event casing for render functions, see issue#2249

### DIFF
--- a/packages/compiler-core/src/transforms/vOn.ts
+++ b/packages/compiler-core/src/transforms/vOn.ts
@@ -42,10 +42,8 @@ export const transformOn: DirectiveTransform = (
   if (arg.type === NodeTypes.SIMPLE_EXPRESSION) {
     if (arg.isStatic) {
       const rawName = arg.content
-      // for @vnode-xxx event listeners, auto convert it to camelCase
-      const normalizedName = rawName.startsWith(`vnode`)
-        ? capitalize(camelize(rawName))
-        : capitalize(rawName)
+      // for all event listeners, auto convert it to camelCase. See issue #2249
+      const normalizedName = capitalize(camelize(rawName))
       eventName = createSimpleExpression(`on${normalizedName}`, true, arg.loc)
     } else {
       eventName = createCompoundExpression([

--- a/packages/runtime-core/__tests__/componentEmits.spec.ts
+++ b/packages/runtime-core/__tests__/componentEmits.spec.ts
@@ -28,6 +28,24 @@ describe('component: emit', () => {
     expect(onBaz).toHaveBeenCalled()
   })
 
+  test('trigger camelize event', () => {
+    const Foo = defineComponent({
+      render() {},
+      created() {
+        this.$emit('test-event')
+      }
+    })
+
+    const fooSpy = jest.fn()
+    const Comp = () =>
+      h(Foo, {
+        onTestEvent: fooSpy
+      })
+    render(h(Comp), nodeOps.createElement('div'))
+
+    expect(fooSpy).toHaveBeenCalled()
+  })
+
   // for v-model:foo-bar usage in DOM templates
   test('trigger hyphenated events for update:xxx events', () => {
     const Foo = defineComponent({


### PR DESCRIPTION
In issue #2249 , we found inconsistent event casing for render functions.

The reproduction link in issue#2249 is here:
https://codesandbox.io/s/nervous-surf-f5lbs

In that case, when we emit `test-event`, only `onTest-Event` worked. But the one expected to work on the render function should be `onTestedEvent`.

So I fix it in this PR, and add test case for it.

All test cases were passed.

Close #2249 