### PR TITLE
fix(runtime-core): computed refs should not trigger watch if value has no change

### DIFF
--- a/packages/reactivity/__tests__/computed.spec.ts
+++ b/packages/reactivity/__tests__/computed.spec.ts
@@ -7,6 +7,7 @@ import {
   WritableComputedRef,
   isReadonly
 } from '../src'
+import { isComputed } from '../src/computed'
 
 describe('reactivity/computed', () => {
   it('should return updated value', () => {
@@ -192,5 +193,28 @@ describe('reactivity/computed', () => {
     })
     expect(isReadonly(z)).toBe(false)
     expect(isReadonly(z.value.a)).toBe(false)
+  })
+
+  it('isComputed', () => {
+    expect(isComputed(computed(() => 1))).toBe(true)
+    expect(
+      isComputed(
+        computed({
+          get: () => 1,
+          set: () => undefined
+        })
+      )
+    ).toBe(true)
+
+    expect(isComputed(ref(1))).toBe(false)
+    expect(isComputed(0)).toBe(false)
+    expect(isComputed(1)).toBe(false)
+    // an object that looks like a computed ref isn't necessarily a computed ref
+    expect(
+      isComputed({
+        value: 0,
+        effect: () => undefined
+      })
+    ).toBe(false)
   })
 })

--- a/packages/reactivity/src/computed.ts
+++ b/packages/reactivity/src/computed.ts
@@ -89,3 +89,8 @@ export function computed<T>(
     isFunction(getterOrOptions) || !getterOrOptions.set
   ) as any
 }
+
+export function isComputed<T>(r: ComputedRef<T> | unknown): r is ComputedRef<T>
+export function isComputed(r: any): r is ComputedRef {
+  return Boolean(r && r instanceof ComputedRefImpl)
+}

--- a/packages/runtime-core/__tests__/apiWatch.spec.ts
+++ b/packages/runtime-core/__tests__/apiWatch.spec.ts
@@ -785,4 +785,17 @@ describe('api: watch', () => {
     await nextTick()
     expect(spy).toHaveBeenCalledTimes(1)
   })
+
+  // #2231
+  test('computed refs should not trigger watch if value has no change', async () => {
+    const spy = jest.fn()
+    const source = ref(0)
+    const price = computed(() => source.value === 0)
+    watch(price, spy)
+    source.value++
+    await nextTick()
+    source.value++
+    await nextTick()
+    expect(spy).toHaveBeenCalledTimes(1)
+  })
 })


### PR DESCRIPTION
close #2231 