### PR TITLE
fix(runtime-core): vnode.el is null in watcher after rerendering (fix #2170)

### DIFF
--- a/packages/runtime-core/src/renderer.ts
+++ b/packages/runtime-core/src/renderer.ts
@@ -1425,11 +1425,11 @@ function baseCreateRenderer(
         }
 
         if (next) {
+          next.el = vnode.el
           updateComponentPreRender(instance, next, optimized)
         } else {
           next = vnode
         }
-        next.el = vnode.el
 
         // beforeUpdate hook
         if (bu) {


### PR DESCRIPTION
An instance’s `el` property can be `null` inside a watcher after a component was rerendered (e.g. as a result of a changed prop). In an instance’s `update` method, the branch for handling mounted instances doesn’t set the `el` property of what will become the instance’s `vnode` property early enough. Upon execution of the `updateComponentPreRender` function, the `el` property is then `null` which causes issues in watcher routines that rely on an instance’s `$el` property.

Fixes #2170.

_(I have no knowledge of Vue’s internals besides what I gathered from trying to fix this bug, so the description here and the proposed change might not be adequate.)_