### PR TITLE
feat(runtime-core): *.vue component type declaration

### DIFF
--- a/packages/global.d.ts
+++ b/packages/global.d.ts
@@ -22,3 +22,11 @@ declare namespace jest {
     toHaveBeenWarnedTimes(n: number): R
   }
 }
+
+// for vue components
+declare module '*.vue' {
+  import { defineComponent } from 'vue'
+
+  const component: ReturnType<typeof defineComponent>
+  export default component
+}


### PR DESCRIPTION
- Added `*.vue` component type declarations

It is useful to have this inside the actual vue package, so developers don't have to create a declaration file, if they want to use Typescript.