### PR TITLE
types(runtime-core): svg xmlns attribute typing

### DIFF
--- a/packages/runtime-dom/types/jsx.d.ts
+++ b/packages/runtime-dom/types/jsx.d.ts
@@ -1004,6 +1004,7 @@ export interface SVGAttributes extends AriaAttributes, EventHandlers<Events> {
   xlinkShow?: string
   xlinkTitle?: string
   xlinkType?: string
+  xmlns?: string
   y1?: number | string
   y2?: number | string
   y?: number | string


### PR DESCRIPTION
Fix `Property 'xmlns' does not exist on type 'ElementAttrs<SVGAttributes>'.`

```tsx
const Svg = <svg xmlns="http://www.w3.org/2000/svg" />;
```
