### PR TITLE
feat(effect): refactorings to improve performance, reduce memory usage

### DIFF
--- a/packages/reactivity/__tests__/effect.spec.ts
+++ b/packages/reactivity/__tests__/effect.spec.ts
@@ -578,7 +578,7 @@ describe('reactivity/effect', () => {
   it('lazy', () => {
     const obj = reactive({ foo: 1 })
     let dummy
-    const runner = effect(() => (dummy = obj.foo), {}, false, true)
+    const runner = effect(() => (dummy = obj.foo), undefined, false, true)
     expect(dummy).toBe(undefined)
 
     expect(runner.run()).toBe(1)
@@ -593,12 +593,9 @@ describe('reactivity/effect', () => {
       runner = _runner
     })
     const obj = reactive({ foo: 1 })
-    effect(
-      () => {
-        dummy = obj.foo
-      },
-      { scheduler }
-    )
+    effect(() => {
+      dummy = obj.foo
+    }, scheduler)
     expect(scheduler).not.toHaveBeenCalled()
     expect(dummy).toBe(1)
     // should be called on first trigger
@@ -625,6 +622,9 @@ describe('reactivity/effect', () => {
         dummy = 'bar' in obj
         dummy = Object.keys(obj)
       },
+      undefined,
+      false,
+      false,
       { onTrack }
     )
     expect(dummy).toEqual(['foo', 'bar'])
@@ -662,6 +662,9 @@ describe('reactivity/effect', () => {
       () => {
         dummy = obj.foo
       },
+      undefined,
+      false,
+      false,
       { onTrigger }
     )
 
@@ -715,9 +718,7 @@ describe('reactivity/effect', () => {
       () => {
         dummy = obj.prop
       },
-      {
-        scheduler: e => queue.push(e)
-      }
+      e => queue.push(e)
     )
     obj.prop = 2
     expect(dummy).toBe(1)
@@ -731,7 +732,7 @@ describe('reactivity/effect', () => {
 
   it('events: onStop', () => {
     const onStop = jest.fn()
-    const runner = effect(() => {}, {
+    const runner = effect(() => {}, undefined, false, false, {
       onStop
     })
 

--- a/packages/reactivity/__tests__/effect.spec.ts
+++ b/packages/reactivity/__tests__/effect.spec.ts
@@ -423,8 +423,8 @@ describe('reactivity/effect', () => {
     }
     const effect1 = effect(greet)
     const effect2 = effect(greet)
-    expect(typeof effect1).toBe('function')
-    expect(typeof effect2).toBe('function')
+    expect(typeof effect1).toBe('object')
+    expect(typeof effect2).toBe('object')
     expect(effect1).not.toBe(greet)
     expect(effect1).not.toBe(effect2)
   })
@@ -460,10 +460,10 @@ describe('reactivity/effect', () => {
     })
 
     expect(dummy).toBe('other')
-    runner()
+    runner.run()
     expect(dummy).toBe('other')
     run = true
-    runner()
+    runner.run()
     expect(dummy).toBe('value')
     obj.prop = 'World'
     expect(dummy).toBe('World')
@@ -490,7 +490,7 @@ describe('reactivity/effect', () => {
 
   it('should not double wrap if the passed function is a effect', () => {
     const runner = effect(() => {})
-    const otherRunner = effect(runner)
+    const otherRunner = effect(runner.executor)
     expect(runner).not.toBe(otherRunner)
     expect(runner.raw).toBe(otherRunner.raw)
   })
@@ -520,7 +520,7 @@ describe('reactivity/effect', () => {
     const childeffect = effect(childSpy)
     const parentSpy = jest.fn(() => {
       dummy.num2 = nums.num2
-      childeffect()
+      childeffect.run()
       dummy.num3 = nums.num3
     })
     effect(parentSpy)
@@ -581,7 +581,7 @@ describe('reactivity/effect', () => {
     const runner = effect(() => (dummy = obj.foo), { lazy: true })
     expect(dummy).toBe(undefined)
 
-    expect(runner()).toBe(1)
+    expect(runner.run()).toBe(1)
     expect(dummy).toBe(1)
     obj.foo = 2
     expect(dummy).toBe(2)
@@ -703,7 +703,7 @@ describe('reactivity/effect', () => {
     expect(dummy).toBe(2)
 
     // stopped effect should still be manually callable
-    runner()
+    runner.run()
     expect(dummy).toBe(3)
   })
 
@@ -752,7 +752,7 @@ describe('reactivity/effect', () => {
     // observed value in inner stopped effect
     // will track outer effect as an dependency
     effect(() => {
-      runner()
+      runner.run()
     })
     expect(dummy).toBe(2)
 

--- a/packages/reactivity/__tests__/effect.spec.ts
+++ b/packages/reactivity/__tests__/effect.spec.ts
@@ -578,7 +578,7 @@ describe('reactivity/effect', () => {
   it('lazy', () => {
     const obj = reactive({ foo: 1 })
     let dummy
-    const runner = effect(() => (dummy = obj.foo), {}, true)
+    const runner = effect(() => (dummy = obj.foo), {}, false, true)
     expect(dummy).toBe(undefined)
 
     expect(runner.run()).toBe(1)

--- a/packages/reactivity/__tests__/effect.spec.ts
+++ b/packages/reactivity/__tests__/effect.spec.ts
@@ -490,7 +490,7 @@ describe('reactivity/effect', () => {
 
   it('should not double wrap if the passed function is a effect', () => {
     const runner = effect(() => {})
-    const otherRunner = effect(runner.executor)
+    const otherRunner = effect(runner.func)
     expect(runner).not.toBe(otherRunner)
     expect(runner.raw).toBe(otherRunner.raw)
   })
@@ -578,7 +578,7 @@ describe('reactivity/effect', () => {
   it('lazy', () => {
     const obj = reactive({ foo: 1 })
     let dummy
-    const runner = effect(() => (dummy = obj.foo), { lazy: true })
+    const runner = effect(() => (dummy = obj.foo), {}, true)
     expect(dummy).toBe(undefined)
 
     expect(runner.run()).toBe(1)

--- a/packages/reactivity/__tests__/shallowReactive.spec.ts
+++ b/packages/reactivity/__tests__/shallowReactive.spec.ts
@@ -68,6 +68,9 @@ describe('shallowReactive', () => {
         () => {
           a = Array.from(shallowSet)
         },
+        undefined,
+        false,
+        false,
         {
           onTrack: onTrackFn
         }
@@ -113,6 +116,9 @@ describe('shallowReactive', () => {
         () => {
           a = Array.from(shallowArray)
         },
+        undefined,
+        false,
+        false,
         {
           onTrack: onTrackFn
         }

--- a/packages/reactivity/src/computed.ts
+++ b/packages/reactivity/src/computed.ts
@@ -1,8 +1,12 @@
-import { effect, ReactiveEffect, trigger, track } from './effect'
-import { TriggerOpTypes, TrackOpTypes } from './operations'
+import {
+  effect,
+  ReactiveEffect,
+  trackRefTarget,
+  triggerRefTarget
+} from './effect'
 import { Ref } from './ref'
 import { isFunction, NOOP } from '@vue/shared'
-import { ReactiveFlags, toRaw } from './reactive'
+import { ReactiveFlags } from './reactive'
 
 export interface ComputedRef<T = any> extends WritableComputedRef<T> {
   readonly value: T
@@ -39,7 +43,7 @@ class ComputedRefImpl<T> {
       () => {
         if (!this._dirty) {
           this._dirty = true
-          trigger(toRaw(this), TriggerOpTypes.SET, 'value')
+          triggerRefTarget(this)
         }
       },
       false,
@@ -54,7 +58,7 @@ class ComputedRefImpl<T> {
       this._value = this.effect.run() as T
       this._dirty = false
     }
-    track(toRaw(this), TrackOpTypes.GET, 'value')
+    trackRefTarget(this)
     return this._value
   }
 

--- a/packages/reactivity/src/computed.ts
+++ b/packages/reactivity/src/computed.ts
@@ -1,10 +1,5 @@
-import {
-  effect,
-  ReactiveEffect,
-  trackRefTarget,
-  triggerRefTarget
-} from './effect'
-import { Ref } from './ref'
+import { effect, ReactiveEffect } from './effect'
+import { Ref, trackRefValue, triggerRefValue } from './ref'
 import { isFunction, NOOP } from '@vue/shared'
 import { ReactiveFlags } from './reactive'
 
@@ -28,9 +23,8 @@ class ComputedRefImpl<T> {
   private _value!: T
   private _dirty = true
 
-  public readonly effect: ReactiveEffect<T>
+  public readonly effect: ReactiveEffect<T>;
 
-  public readonly __v_isRef = true;
   public readonly [ReactiveFlags.IS_READONLY]: boolean
 
   constructor(
@@ -43,7 +37,7 @@ class ComputedRefImpl<T> {
       () => {
         if (!this._dirty) {
           this._dirty = true
-          triggerRefTarget(this)
+          triggerRefValue(this)
         }
       },
       false,
@@ -58,7 +52,7 @@ class ComputedRefImpl<T> {
       this._value = this.effect.run() as T
       this._dirty = false
     }
-    trackRefTarget(this)
+    trackRefValue(this)
     return this._value
   }
 
@@ -66,6 +60,9 @@ class ComputedRefImpl<T> {
     this._setter(newValue)
   }
 }
+
+ComputedRefImpl.prototype.__v_isRef = true
+interface ComputedRefImpl<T> extends Ref<T> {}
 
 export function computed<T>(getter: ComputedGetter<T>): ComputedRef<T>
 export function computed<T>(

--- a/packages/reactivity/src/computed.ts
+++ b/packages/reactivity/src/computed.ts
@@ -34,15 +34,18 @@ class ComputedRefImpl<T> {
     private readonly _setter: ComputedSetter<T>,
     isReadonly: boolean
   ) {
-    this.effect = effect(getter, {
-      lazy: true,
-      scheduler: () => {
-        if (!this._dirty) {
-          this._dirty = true
-          trigger(toRaw(this), TriggerOpTypes.SET, 'value')
+    this.effect = effect(
+      getter,
+      {
+        scheduler: () => {
+          if (!this._dirty) {
+            this._dirty = true
+            trigger(toRaw(this), TriggerOpTypes.SET, 'value')
+          }
         }
-      }
-    })
+      },
+      true
+    )
 
     this[ReactiveFlags.IS_READONLY] = isReadonly
   }

--- a/packages/reactivity/src/computed.ts
+++ b/packages/reactivity/src/computed.ts
@@ -49,7 +49,7 @@ class ComputedRefImpl<T> {
 
   get value() {
     if (this._dirty) {
-      this._value = this.effect()
+      this._value = this.effect.run() as T
       this._dirty = false
     }
     track(toRaw(this), TrackOpTypes.GET, 'value')

--- a/packages/reactivity/src/computed.ts
+++ b/packages/reactivity/src/computed.ts
@@ -36,12 +36,10 @@ class ComputedRefImpl<T> {
   ) {
     this.effect = effect(
       getter,
-      {
-        scheduler: () => {
-          if (!this._dirty) {
-            this._dirty = true
-            trigger(toRaw(this), TriggerOpTypes.SET, 'value')
-          }
+      () => {
+        if (!this._dirty) {
+          this._dirty = true
+          trigger(toRaw(this), TriggerOpTypes.SET, 'value')
         }
       },
       false,

--- a/packages/reactivity/src/computed.ts
+++ b/packages/reactivity/src/computed.ts
@@ -44,6 +44,7 @@ class ComputedRefImpl<T> {
           }
         }
       },
+      false,
       true
     )
 

--- a/packages/reactivity/src/effect.ts
+++ b/packages/reactivity/src/effect.ts
@@ -61,7 +61,7 @@ export class ReactiveEffect<T = any> {
       const runner = () => {
         return this.run()
       }
-      runner._effect = this
+      runner.effect = this
       runner.allowRecurse = this.allowRecurse
       this.runner = runner
     }
@@ -82,7 +82,7 @@ ReactiveEffect.prototype.options = EMPTY_OBJ
 
 export interface ReactiveEffectFunction<T = any> {
   (): T | undefined
-  _effect: ReactiveEffect<T>
+  effect: ReactiveEffect<T>
   allowRecurse: boolean
 }
 
@@ -121,7 +121,7 @@ export const ITERATE_KEY = Symbol(__DEV__ ? 'iterate' : '')
 export const MAP_KEY_ITERATE_KEY = Symbol(__DEV__ ? 'Map key iterate' : '')
 
 export function isEffect(fn: any): fn is ReactiveEffectFunction {
-  return fn && !!fn._effect
+  return fn && !!fn.effect
 }
 
 export function effect<T = any>(
@@ -132,7 +132,7 @@ export function effect<T = any>(
   options: ReactiveEffectOptions | undefined = undefined
 ): ReactiveEffect<T> {
   if (isEffect(fn)) {
-    fn = fn._effect.raw
+    fn = fn.effect.raw
   }
   const effect = createReactiveEffect(fn, allowRecurse, scheduler, options)
 

--- a/packages/reactivity/src/effect.ts
+++ b/packages/reactivity/src/effect.ts
@@ -6,6 +6,9 @@ import { toRaw } from './reactive'
 // Conceptually, it's easier to think of a dependency as a Dep class
 // which maintains a Set of subscribers, but we simply store them as
 // raw Sets to reduce memory overhead.
+//
+// Notice that refs store their deps in a local property for
+// performance reasons.
 type Dep = Set<ReactiveEffect>
 type KeyToDepMap = Map<any, Dep>
 const targetMap = new WeakMap<any, KeyToDepMap>()

--- a/packages/reactivity/src/effect.ts
+++ b/packages/reactivity/src/effect.ts
@@ -12,7 +12,7 @@ type Dep = Set<ReactiveEffect>
 type KeyToDepMap = Map<any, Dep>
 const targetMap = new WeakMap<any, KeyToDepMap>()
 
-type EffectScheduler = (job: () => void) => void
+export type EffectScheduler = (job: () => void) => void
 
 export class ReactiveEffect<T = any> {
   public id = uid++

--- a/packages/reactivity/src/effect.ts
+++ b/packages/reactivity/src/effect.ts
@@ -37,7 +37,7 @@ export class ReactiveEffect<T = any> {
     }
   }
 
-  public get executor(): ReactiveEffectFunction<T> {
+  public get func(): ReactiveEffectFunction<T> {
     if (!this.runner) {
       const runner = () => {
         return this.run()
@@ -64,7 +64,6 @@ function createReactiveEffect<T = any>(
 }
 
 export interface ReactiveEffectOptions {
-  lazy?: boolean
   scheduler?: (job: () => void) => void
   onTrack?: (event: DebuggerEvent) => void
   onTrigger?: (event: DebuggerEvent) => void
@@ -97,14 +96,15 @@ export function isEffect(fn: any): fn is ReactiveEffectFunction {
 
 export function effect<T = any>(
   fn: () => T,
-  options: ReactiveEffectOptions = EMPTY_OBJ
+  options: ReactiveEffectOptions = EMPTY_OBJ,
+  lazy: boolean = false
 ): ReactiveEffect<T> {
   if (isEffect(fn)) {
     fn = fn._effect.raw
   }
   const effect = createReactiveEffect(fn, options)
 
-  if (!options.lazy) {
+  if (!lazy) {
     effect.run()
   }
   return effect
@@ -259,7 +259,7 @@ export function trigger(
       })
     }
     if (effect.options.scheduler) {
-      effect.options.scheduler(effect.executor)
+      effect.options.scheduler(effect.func)
     } else {
       effect.run()
     }

--- a/packages/reactivity/src/effect.ts
+++ b/packages/reactivity/src/effect.ts
@@ -52,7 +52,8 @@ export class ReactiveEffect<T = any> {
       } finally {
         effectStack.pop()
         resetTracking()
-        activeEffect = effectStack[effectStack.length - 1]
+        const n = effectStack.length
+        activeEffect = n ? effectStack[n - 1] : undefined
       }
     }
   }

--- a/packages/reactivity/src/index.ts
+++ b/packages/reactivity/src/index.ts
@@ -46,6 +46,7 @@ export {
   ITERATE_KEY,
   ReactiveEffect,
   ReactiveEffectOptions,
+  EffectScheduler,
   DebuggerEvent
 } from './effect'
 export { TrackOpTypes, TriggerOpTypes } from './operations'

--- a/packages/reactivity/src/reactive.ts
+++ b/packages/reactivity/src/reactive.ts
@@ -218,9 +218,8 @@ export function isProxy(value: unknown): boolean {
 }
 
 export function toRaw<T>(observed: T): T {
-  return (
-    (observed && toRaw((observed as Target)[ReactiveFlags.RAW])) || observed
-  )
+  const raw = observed && (observed as Target)[ReactiveFlags.RAW]
+  return raw ? toRaw(raw) : observed
 }
 
 export function markRaw<T extends object>(value: T): T {

--- a/packages/reactivity/src/ref.ts
+++ b/packages/reactivity/src/ref.ts
@@ -1,5 +1,4 @@
-import { track, trigger } from './effect'
-import { TrackOpTypes, TriggerOpTypes } from './operations'
+import { trackRefTarget, triggerRefTarget } from './effect'
 import { isArray, isObject, hasChanged } from '@vue/shared'
 import { reactive, isProxy, toRaw, isReactive } from './reactive'
 import { CollectionTypes } from './collectionHandlers'
@@ -57,7 +56,7 @@ class RefImpl<T> {
   }
 
   get value() {
-    track(toRaw(this), TrackOpTypes.GET, 'value')
+    trackRefTarget(this)
     return this._value
   }
 
@@ -65,7 +64,7 @@ class RefImpl<T> {
     if (hasChanged(toRaw(newVal), this._rawValue)) {
       this._rawValue = newVal
       this._value = this._shallow ? newVal : convert(newVal)
-      trigger(toRaw(this), TriggerOpTypes.SET, 'value', newVal)
+      triggerRefTarget(this, newVal)
     }
   }
 }
@@ -78,7 +77,7 @@ function createRef(rawValue: unknown, shallow = false) {
 }
 
 export function triggerRef(ref: Ref) {
-  trigger(toRaw(ref), TriggerOpTypes.SET, 'value', __DEV__ ? ref.value : void 0)
+  triggerRefTarget(ref, __DEV__ ? ref.value : void 0)
 }
 
 export function unref<T>(ref: T): T extends Ref<infer V> ? V : T {
@@ -122,8 +121,8 @@ class CustomRefImpl<T> {
 
   constructor(factory: CustomRefFactory<T>) {
     const { get, set } = factory(
-      () => track(this, TrackOpTypes.GET, 'value'),
-      () => trigger(this, TriggerOpTypes.SET, 'value')
+      () => trackRefTarget(this),
+      () => triggerRefTarget(this)
     )
     this._get = get
     this._set = set

--- a/packages/runtime-core/src/apiWatch.ts
+++ b/packages/runtime-core/src/apiWatch.ts
@@ -5,7 +5,8 @@ import {
   Ref,
   ComputedRef,
   ReactiveEffectOptions,
-  isReactive
+  isReactive,
+  EffectScheduler
 } from '@vue/reactivity'
 import { SchedulerJob, queuePreFlushCb } from './scheduler'
 import {
@@ -252,7 +253,7 @@ function doWatch(
   // it is allowed to self-trigger (#1727)
   job.allowRecurse = !!cb
 
-  let scheduler: ReactiveEffectOptions['scheduler']
+  let scheduler: EffectScheduler
   if (flush === 'sync') {
     scheduler = job
   } else if (flush === 'post') {

--- a/packages/runtime-core/src/apiWatch.ts
+++ b/packages/runtime-core/src/apiWatch.ts
@@ -236,7 +236,7 @@ function doWatch(
     }
     if (cb) {
       // watch(source, cb)
-      const newValue = runner()
+      const newValue = runner.run()
       if (deep || forceTrigger || hasChanged(newValue, oldValue)) {
         // cleanup before running cb again
         if (cleanup) {
@@ -252,7 +252,7 @@ function doWatch(
       }
     } else {
       // watchEffect
-      runner()
+      runner.run()
     }
   }
 
@@ -292,12 +292,12 @@ function doWatch(
     if (immediate) {
       job()
     } else {
-      oldValue = runner()
+      oldValue = runner.run()
     }
   } else if (flush === 'post') {
-    queuePostRenderEffect(runner, instance && instance.suspense)
+    queuePostRenderEffect(runner.executor, instance && instance.suspense)
   } else {
-    runner()
+    runner.run()
   }
 
   return () => {

--- a/packages/runtime-core/src/apiWatch.ts
+++ b/packages/runtime-core/src/apiWatch.ts
@@ -209,9 +209,10 @@ function doWatch(
 
   let cleanup: () => void
   const onInvalidate: InvalidateCbRegistrator = (fn: () => void) => {
-    cleanup = runner.options.onStop = () => {
+    cleanup = () => {
       callWithErrorHandling(fn, instance, ErrorCodes.WATCH_CLEANUP)
     }
+    runner.setOnStop(cleanup)
   }
 
   // in SSR there is no need to setup an actual effect, and it should be noop
@@ -278,16 +279,11 @@ function doWatch(
     }
   }
 
-  const runner = effect(
-    getter,
-    {
-      onTrack,
-      onTrigger,
-      scheduler
-    },
-    false,
-    true
-  )
+  let options: ReactiveEffectOptions | undefined = undefined
+  if (onTrack || onTrigger) {
+    options = { onTrack, onTrigger }
+  }
+  const runner = effect(getter, scheduler, false, true, options)
 
   recordInstanceBoundEffect(runner)
 

--- a/packages/runtime-core/src/apiWatch.ts
+++ b/packages/runtime-core/src/apiWatch.ts
@@ -285,6 +285,7 @@ function doWatch(
       onTrigger,
       scheduler
     },
+    false,
     true
   )
 

--- a/packages/runtime-core/src/apiWatch.ts
+++ b/packages/runtime-core/src/apiWatch.ts
@@ -145,15 +145,6 @@ function doWatch(
     }
   }
 
-  const warnInvalidSource = (s: unknown) => {
-    warn(
-      `Invalid watch source: `,
-      s,
-      `A watch source can only be a getter/effect function, a ref, ` +
-        `a reactive object, or an array of these types.`
-    )
-  }
-
   let getter: () => any
   let forceTrigger = false
   if (isRef(source)) {
@@ -306,6 +297,15 @@ function doWatch(
       remove(instance.effects!, runner)
     }
   }
+}
+
+function warnInvalidSource(s: unknown) {
+  warn(
+    `Invalid watch source: `,
+    s,
+    `A watch source can only be a getter/effect function, a ref, ` +
+      `a reactive object, or an array of these types.`
+  )
 }
 
 // this.$watch

--- a/packages/runtime-core/src/apiWatch.ts
+++ b/packages/runtime-core/src/apiWatch.ts
@@ -278,12 +278,15 @@ function doWatch(
     }
   }
 
-  const runner = effect(getter, {
-    lazy: true,
-    onTrack,
-    onTrigger,
-    scheduler
-  })
+  const runner = effect(
+    getter,
+    {
+      onTrack,
+      onTrigger,
+      scheduler
+    },
+    true
+  )
 
   recordInstanceBoundEffect(runner)
 
@@ -295,7 +298,7 @@ function doWatch(
       oldValue = runner.run()
     }
   } else if (flush === 'post') {
-    queuePostRenderEffect(runner.executor, instance && instance.suspense)
+    queuePostRenderEffect(runner.func, instance && instance.suspense)
   } else {
     runner.run()
   }

--- a/packages/runtime-core/src/componentPublicInstance.ts
+++ b/packages/runtime-core/src/componentPublicInstance.ts
@@ -212,7 +212,7 @@ const publicPropertiesMap: PublicPropertiesMap = extend(Object.create(null), {
   $root: i => i.root && i.root.proxy,
   $emit: i => i.emit,
   $options: i => (__FEATURE_OPTIONS_API__ ? resolveMergedOptions(i) : i.type),
-  $forceUpdate: i => () => queueJob(i.update),
+  $forceUpdate: i => () => queueJob(i.update.executor),
   $nextTick: i => nextTick.bind(i.proxy!),
   $watch: i => (__FEATURE_OPTIONS_API__ ? instanceWatch.bind(i) : NOOP)
 } as PublicPropertiesMap)

--- a/packages/runtime-core/src/componentPublicInstance.ts
+++ b/packages/runtime-core/src/componentPublicInstance.ts
@@ -212,7 +212,7 @@ const publicPropertiesMap: PublicPropertiesMap = extend(Object.create(null), {
   $root: i => i.root && i.root.proxy,
   $emit: i => i.emit,
   $options: i => (__FEATURE_OPTIONS_API__ ? resolveMergedOptions(i) : i.type),
-  $forceUpdate: i => () => queueJob(i.update.executor),
+  $forceUpdate: i => () => queueJob(i.update.func),
   $nextTick: i => nextTick.bind(i.proxy!),
   $watch: i => (__FEATURE_OPTIONS_API__ ? instanceWatch.bind(i) : NOOP)
 } as PublicPropertiesMap)

--- a/packages/runtime-core/src/components/BaseTransition.ts
+++ b/packages/runtime-core/src/components/BaseTransition.ts
@@ -220,7 +220,7 @@ const BaseTransitionImpl = {
           // return placeholder node and queue update when leave finishes
           leavingHooks.afterLeave = () => {
             state.isLeaving = false
-            instance.update()
+            instance.update.run()
           }
           return emptyPlaceholder(child)
         } else if (mode === 'in-out') {

--- a/packages/runtime-core/src/hmr.ts
+++ b/packages/runtime-core/src/hmr.ts
@@ -125,7 +125,7 @@ function reload(id: string, newComp: ComponentOptions | ClassComponent) {
       // 4. Force the parent instance to re-render. This will cause all updated
       // components to be unmounted and re-mounted. Queue the update so that we
       // don't end up forcing the same parent to re-render multiple times.
-      queueJob(instance.parent.update.executor)
+      queueJob(instance.parent.update.func)
     } else if (instance.appContext.reload) {
       // root instance mounted via createApp() has a reload method
       instance.appContext.reload()

--- a/packages/runtime-core/src/hmr.ts
+++ b/packages/runtime-core/src/hmr.ts
@@ -90,7 +90,7 @@ function rerender(id: string, newRender?: Function) {
     instance.renderCache = []
     // this flag forces child components with slot content to update
     isHmrUpdating = true
-    instance.update()
+    instance.update.run()
     isHmrUpdating = false
   })
 }
@@ -125,7 +125,7 @@ function reload(id: string, newComp: ComponentOptions | ClassComponent) {
       // 4. Force the parent instance to re-render. This will cause all updated
       // components to be unmounted and re-mounted. Queue the update so that we
       // don't end up forcing the same parent to re-render multiple times.
-      queueJob(instance.parent.update)
+      queueJob(instance.parent.update.executor)
     } else if (instance.appContext.reload) {
       // root instance mounted via createApp() has a reload method
       instance.appContext.reload()

--- a/packages/runtime-core/src/renderer.ts
+++ b/packages/runtime-core/src/renderer.ts
@@ -1324,7 +1324,7 @@ function baseCreateRenderer(
         instance.next = n2
         // in case the child component is also queued, remove it to avoid
         // double updating the same child component in the same flush.
-        invalidateJob(instance.update.executor)
+        invalidateJob(instance.update.func)
         // instance.update is the reactive effect runner.
         instance.update.run()
       }
@@ -1521,10 +1521,7 @@ function baseCreateRenderer(
 
     // props update may have triggered pre-flush watchers.
     // flush them before the render update.
-    flushPreFlushCbs(
-      undefined,
-      instance.update ? instance.update.executor : null
-    )
+    flushPreFlushCbs(undefined, instance.update ? instance.update.func : null)
   }
 
   const patchChildren: PatchChildrenFn = (

--- a/packages/runtime-core/src/renderer.ts
+++ b/packages/runtime-core/src/renderer.ts
@@ -266,9 +266,7 @@ export const enum MoveType {
 }
 
 const prodEffectOptions = {
-  scheduler: queueJob,
-  // #1801, #2043 component render effects should allow recursive updates
-  allowRecurse: true
+  scheduler: queueJob
 }
 
 function createDevEffectOptions(
@@ -276,7 +274,6 @@ function createDevEffectOptions(
 ): ReactiveEffectOptions {
   return {
     scheduler: queueJob,
-    allowRecurse: true,
     onTrack: instance.rtc ? e => invokeArrayFns(instance.rtc!, e) : void 0,
     onTrigger: instance.rtg ? e => invokeArrayFns(instance.rtg!, e) : void 0
   }
@@ -1346,53 +1343,132 @@ function baseCreateRenderer(
     optimized
   ) => {
     // create reactive effect for rendering
-    instance.update = effect(function componentEffect() {
-      if (!instance.isMounted) {
-        let vnodeHook: VNodeHook | null | undefined
-        const { el, props } = initialVNode
-        const { bm, m, parent } = instance
+    instance.update = effect(
+      function componentEffect() {
+        if (!instance.isMounted) {
+          let vnodeHook: VNodeHook | null | undefined
+          const { el, props } = initialVNode
+          const { bm, m, parent } = instance
 
-        // beforeMount hook
-        if (bm) {
-          invokeArrayFns(bm)
-        }
-        // onVnodeBeforeMount
-        if ((vnodeHook = props && props.onVnodeBeforeMount)) {
-          invokeVNodeHook(vnodeHook, parent, initialVNode)
-        }
-
-        // render
-        if (__DEV__) {
-          startMeasure(instance, `render`)
-        }
-        const subTree = (instance.subTree = renderComponentRoot(instance))
-        if (__DEV__) {
-          endMeasure(instance, `render`)
-        }
-
-        if (el && hydrateNode) {
-          if (__DEV__) {
-            startMeasure(instance, `hydrate`)
+          // beforeMount hook
+          if (bm) {
+            invokeArrayFns(bm)
           }
-          // vnode has adopted host node - perform hydration instead of mount.
-          hydrateNode(
-            initialVNode.el as Node,
-            subTree,
-            instance,
-            parentSuspense
-          )
-          if (__DEV__) {
-            endMeasure(instance, `hydrate`)
+          // onVnodeBeforeMount
+          if ((vnodeHook = props && props.onVnodeBeforeMount)) {
+            invokeVNodeHook(vnodeHook, parent, initialVNode)
           }
+
+          // render
+          if (__DEV__) {
+            startMeasure(instance, `render`)
+          }
+          const subTree = (instance.subTree = renderComponentRoot(instance))
+          if (__DEV__) {
+            endMeasure(instance, `render`)
+          }
+
+          if (el && hydrateNode) {
+            if (__DEV__) {
+              startMeasure(instance, `hydrate`)
+            }
+            // vnode has adopted host node - perform hydration instead of mount.
+            hydrateNode(
+              initialVNode.el as Node,
+              subTree,
+              instance,
+              parentSuspense
+            )
+            if (__DEV__) {
+              endMeasure(instance, `hydrate`)
+            }
+          } else {
+            if (__DEV__) {
+              startMeasure(instance, `patch`)
+            }
+            patch(
+              null,
+              subTree,
+              container,
+              anchor,
+              instance,
+              parentSuspense,
+              isSVG
+            )
+            if (__DEV__) {
+              endMeasure(instance, `patch`)
+            }
+            initialVNode.el = subTree.el
+          }
+          // mounted hook
+          if (m) {
+            queuePostRenderEffect(m, parentSuspense)
+          }
+          // onVnodeMounted
+          if ((vnodeHook = props && props.onVnodeMounted)) {
+            queuePostRenderEffect(() => {
+              invokeVNodeHook(vnodeHook!, parent, initialVNode)
+            }, parentSuspense)
+          }
+          // activated hook for keep-alive roots.
+          // #1742 activated hook must be accessed after first render
+          // since the hook may be injected by a child keep-alive
+          const { a } = instance
+          if (
+            a &&
+            initialVNode.shapeFlag & ShapeFlags.COMPONENT_SHOULD_KEEP_ALIVE
+          ) {
+            queuePostRenderEffect(a, parentSuspense)
+          }
+          instance.isMounted = true
         } else {
+          // updateComponent
+          // This is triggered by mutation of component's own state (next: null)
+          // OR parent calling processComponent (next: VNode)
+          let { next, bu, u, parent, vnode } = instance
+          let originNext = next
+          let vnodeHook: VNodeHook | null | undefined
+          if (__DEV__) {
+            pushWarningContext(next || instance.vnode)
+          }
+
+          if (next) {
+            next.el = vnode.el
+            updateComponentPreRender(instance, next, optimized)
+          } else {
+            next = vnode
+          }
+
+          // beforeUpdate hook
+          if (bu) {
+            invokeArrayFns(bu)
+          }
+          // onVnodeBeforeUpdate
+          if ((vnodeHook = next.props && next.props.onVnodeBeforeUpdate)) {
+            invokeVNodeHook(vnodeHook, parent, next, vnode)
+          }
+
+          // render
+          if (__DEV__) {
+            startMeasure(instance, `render`)
+          }
+          const nextTree = renderComponentRoot(instance)
+          if (__DEV__) {
+            endMeasure(instance, `render`)
+          }
+          const prevTree = instance.subTree
+          instance.subTree = nextTree
+
           if (__DEV__) {
             startMeasure(instance, `patch`)
           }
           patch(
-            null,
-            subTree,
-            container,
-            anchor,
+            prevTree,
+            nextTree,
+            // parent may have changed if it's in a teleport
+            hostParentNode(prevTree.el!)!,
+            // anchor may have changed if it's in a fragment
+            getNextHostNode(prevTree),
             instance,
             parentSuspense,
             isSVG
@@ -1400,111 +1476,36 @@ function baseCreateRenderer(
           if (__DEV__) {
             endMeasure(instance, `patch`)
           }
-          initialVNode.el = subTree.el
-        }
-        // mounted hook
-        if (m) {
-          queuePostRenderEffect(m, parentSuspense)
-        }
-        // onVnodeMounted
-        if ((vnodeHook = props && props.onVnodeMounted)) {
-          queuePostRenderEffect(() => {
-            invokeVNodeHook(vnodeHook!, parent, initialVNode)
-          }, parentSuspense)
-        }
-        // activated hook for keep-alive roots.
-        // #1742 activated hook must be accessed after first render
-        // since the hook may be injected by a child keep-alive
-        const { a } = instance
-        if (
-          a &&
-          initialVNode.shapeFlag & ShapeFlags.COMPONENT_SHOULD_KEEP_ALIVE
-        ) {
-          queuePostRenderEffect(a, parentSuspense)
-        }
-        instance.isMounted = true
-      } else {
-        // updateComponent
-        // This is triggered by mutation of component's own state (next: null)
-        // OR parent calling processComponent (next: VNode)
-        let { next, bu, u, parent, vnode } = instance
-        let originNext = next
-        let vnodeHook: VNodeHook | null | undefined
-        if (__DEV__) {
-          pushWarningContext(next || instance.vnode)
-        }
+          next.el = nextTree.el
+          if (originNext === null) {
+            // self-triggered update. In case of HOC, update parent component
+            // vnode el. HOC is indicated by parent instance's subTree pointing
+            // to child component's vnode
+            updateHOCHostEl(instance, nextTree.el)
+          }
+          // updated hook
+          if (u) {
+            queuePostRenderEffect(u, parentSuspense)
+          }
+          // onVnodeUpdated
+          if ((vnodeHook = next.props && next.props.onVnodeUpdated)) {
+            queuePostRenderEffect(() => {
+              invokeVNodeHook(vnodeHook!, parent, next!, vnode)
+            }, parentSuspense)
+          }
 
-        if (next) {
-          next.el = vnode.el
-          updateComponentPreRender(instance, next, optimized)
-        } else {
-          next = vnode
-        }
+          if (__DEV__ || __FEATURE_PROD_DEVTOOLS__) {
+            devtoolsComponentUpdated(instance)
+          }
 
-        // beforeUpdate hook
-        if (bu) {
-          invokeArrayFns(bu)
+          if (__DEV__) {
+            popWarningContext()
+          }
         }
-        // onVnodeBeforeUpdate
-        if ((vnodeHook = next.props && next.props.onVnodeBeforeUpdate)) {
-          invokeVNodeHook(vnodeHook, parent, next, vnode)
-        }
-
-        // render
-        if (__DEV__) {
-          startMeasure(instance, `render`)
-        }
-        const nextTree = renderComponentRoot(instance)
-        if (__DEV__) {
-          endMeasure(instance, `render`)
-        }
-        const prevTree = instance.subTree
-        instance.subTree = nextTree
-
-        if (__DEV__) {
-          startMeasure(instance, `patch`)
-        }
-        patch(
-          prevTree,
-          nextTree,
-          // parent may have changed if it's in a teleport
-          hostParentNode(prevTree.el!)!,
-          // anchor may have changed if it's in a fragment
-          getNextHostNode(prevTree),
-          instance,
-          parentSuspense,
-          isSVG
-        )
-        if (__DEV__) {
-          endMeasure(instance, `patch`)
-        }
-        next.el = nextTree.el
-        if (originNext === null) {
-          // self-triggered update. In case of HOC, update parent component
-          // vnode el. HOC is indicated by parent instance's subTree pointing
-          // to child component's vnode
-          updateHOCHostEl(instance, nextTree.el)
-        }
-        // updated hook
-        if (u) {
-          queuePostRenderEffect(u, parentSuspense)
-        }
-        // onVnodeUpdated
-        if ((vnodeHook = next.props && next.props.onVnodeUpdated)) {
-          queuePostRenderEffect(() => {
-            invokeVNodeHook(vnodeHook!, parent, next!, vnode)
-          }, parentSuspense)
-        }
-
-        if (__DEV__ || __FEATURE_PROD_DEVTOOLS__) {
-          devtoolsComponentUpdated(instance)
-        }
-
-        if (__DEV__) {
-          popWarningContext()
-        }
-      }
-    }, __DEV__ ? createDevEffectOptions(instance) : prodEffectOptions)
+      },
+      __DEV__ ? createDevEffectOptions(instance) : prodEffectOptions,
+      true // #1801, #2043 component render effects should allow recursive updates
+    )
   }
 
   const updateComponentPreRender = (

--- a/packages/runtime-core/src/renderer.ts
+++ b/packages/runtime-core/src/renderer.ts
@@ -1324,9 +1324,9 @@ function baseCreateRenderer(
         instance.next = n2
         // in case the child component is also queued, remove it to avoid
         // double updating the same child component in the same flush.
-        invalidateJob(instance.update)
+        invalidateJob(instance.update.executor)
         // instance.update is the reactive effect runner.
-        instance.update()
+        instance.update.run()
       }
     } else {
       // no update needed. just copy over properties
@@ -1521,7 +1521,10 @@ function baseCreateRenderer(
 
     // props update may have triggered pre-flush watchers.
     // flush them before the render update.
-    flushPreFlushCbs(undefined, instance.update)
+    flushPreFlushCbs(
+      undefined,
+      instance.update ? instance.update.executor : null
+    )
   }
 
   const patchChildren: PatchChildrenFn = (

--- a/packages/runtime-core/src/renderer.ts
+++ b/packages/runtime-core/src/renderer.ts
@@ -265,15 +265,10 @@ export const enum MoveType {
   REORDER
 }
 
-const prodEffectOptions = {
-  scheduler: queueJob
-}
-
 function createDevEffectOptions(
   instance: ComponentInternalInstance
 ): ReactiveEffectOptions {
   return {
-    scheduler: queueJob,
     onTrack: instance.rtc ? e => invokeArrayFns(instance.rtc!, e) : void 0,
     onTrigger: instance.rtg ? e => invokeArrayFns(instance.rtg!, e) : void 0
   }
@@ -1503,8 +1498,10 @@ function baseCreateRenderer(
           }
         }
       },
-      __DEV__ ? createDevEffectOptions(instance) : prodEffectOptions,
-      true // #1801, #2043 component render effects should allow recursive updates
+      queueJob,
+      true, // #1801, #2043 component render effects should allow recursive updates
+      false,
+      __DEV__ ? createDevEffectOptions(instance) : undefined
     )
   }
 

--- a/packages/runtime-dom/__tests__/directives/vOn.spec.ts
+++ b/packages/runtime-dom/__tests__/directives/vOn.spec.ts
@@ -41,9 +41,9 @@ describe('runtime-dom: v-on directive', () => {
   })
 
   test('it should support key modifiers and system modifiers', () => {
-    const keyNames = ["ctrl","shift","meta","alt"]
+    const keyNames = ['ctrl', 'shift', 'meta', 'alt']
 
-    keyNames.forEach(keyName=>{
+    keyNames.forEach(keyName => {
       const el = document.createElement('div')
       const fn = jest.fn()
       // <div @keyup[keyName].esc="test"/>
@@ -52,28 +52,28 @@ describe('runtime-dom: v-on directive', () => {
         'arrow-left'
       ])
       patchEvent(el, 'onKeyup', null, nextValue, null)
-  
+
       triggerEvent(el, 'keyup', e => (e.key = 'a'))
       expect(fn).not.toBeCalled()
-  
+
       triggerEvent(el, 'keyup', e => {
         e[`${keyName}Key`] = false
         e.key = 'esc'
       })
       expect(fn).not.toBeCalled()
-  
+
       triggerEvent(el, 'keyup', e => {
         e[`${keyName}Key`] = true
         e.key = 'Escape'
       })
       expect(fn).toBeCalledTimes(1)
-  
+
       triggerEvent(el, 'keyup', e => {
         e[`${keyName}Key`] = true
         e.key = 'ArrowLeft'
       })
       expect(fn).toBeCalledTimes(2)
-    });
+    })
   })
 
   test('it should support "exact" modifier', () => {

--- a/packages/shared/__tests__/looseEqual.spec.ts
+++ b/packages/shared/__tests__/looseEqual.spec.ts
@@ -54,27 +54,27 @@ describe('utils/looseEqual', () => {
     const date2 = new Date(2019, 1, 2, 3, 4, 5, 7)
     const file1 = new File([''], 'filename.txt', {
       type: 'text/plain',
-      lastModified: date1.getTime(),
+      lastModified: date1.getTime()
     })
     const file2 = new File([''], 'filename.txt', {
       type: 'text/plain',
-      lastModified: date1.getTime(),
+      lastModified: date1.getTime()
     })
     const file3 = new File([''], 'filename.txt', {
       type: 'text/plain',
-      lastModified: date2.getTime(),
+      lastModified: date2.getTime()
     })
     const file4 = new File([''], 'filename.csv', {
       type: 'text/csv',
-      lastModified: date1.getTime(),
+      lastModified: date1.getTime()
     })
     const file5 = new File(['abcdef'], 'filename.txt', {
       type: 'text/plain',
-      lastModified: date1.getTime(),
+      lastModified: date1.getTime()
     })
     const file6 = new File(['12345'], 'filename.txt', {
       type: 'text/plain',
-      lastModified: date1.getTime(),
+      lastModified: date1.getTime()
     })
 
     // Identical file object references
@@ -163,7 +163,7 @@ describe('utils/looseEqual', () => {
     const date1 = new Date(2019, 1, 2, 3, 4, 5, 6)
     const file1 = new File([''], 'filename.txt', {
       type: 'text/plain',
-      lastModified: date1.getTime(),
+      lastModified: date1.getTime()
     })
 
     expect(looseEqual(123, '123')).toBe(true)


### PR DESCRIPTION
This PR is a refactoring of the *reactivity* module.

1. Make use of object **prototypes** for effects to reduce memory usage
2. Ref-specific high-performance implementation for *track* and *trigger*
3. Miscellaneous memory- and performance-related tweaks

# Results
* Big runtime performance improvement for ref, computed, watch and watchEffect (30%-80% depending on the amount of dependencies)
* Memory usage decreased by about 30% when creating ref, computed, watch and watchEffect
* Creation time performance improvement, most notably for watchers and watchEffects

## Performance
You can compare my benchmarks on your own machine:
[This PR](https://basvanmeurs.github.io/vue-next-benchmarks/?v=%20)
[3.0.0](https://basvanmeurs.github.io/vue-next-benchmarks/?v=3.0.0)

Or view my own results:
![performance-comparison](https://user-images.githubusercontent.com/120531/95851882-2dfe0180-0d53-11eb-8138-ebaef858b103.png)

## Memory
In terms of memory I only did a pretty rudimentary test:
```javascript
                const arr = [];
		for (let i = 0; i < 1e5; i++) {
			const v = ref(100);
			const c = computed(() => v.value * 2);
			const w = watch(c, (v) => {
			});
			const we = watchEffect(() => {
				const v = c.value;
			});
			arr.push(v);
			arr.push(c);
			arr.push(w);
			arr.push(we);
		}
```
![memory-comparison](https://user-images.githubusercontent.com/120531/95856042-b384b000-0d59-11eb-90f7-d121dbe3a7a6.png)

I managed to save some memory by using more properties on the prototypes, and moved some parameters from the option object because those ReactiveEffectOptions objects have a memory overhead as well. Left is the PR in its current state, right is 3.0.0. A reduction of about 30%. I think we're approaching the limit of what we can do.
