### PR TITLE
fix(compiler-ssr): fix SSR issue when dynamic and static class used

### DIFF
--- a/packages/compiler-ssr/__tests__/ssrElement.spec.ts
+++ b/packages/compiler-ssr/__tests__/ssrElement.spec.ts
@@ -112,6 +112,15 @@ describe('ssr: element', () => {
       `)
     })
 
+    test('v-bind:class + static class', () => {
+      expect(getCompiledString(`<div :class="bar" class="foo"></div>`))
+        .toMatchInlineSnapshot(`
+        "\`<div class=\\"\${
+            _ssrRenderClass([_ctx.bar, \\"foo\\"])
+          }\\"></div>\`"
+      `)
+    })
+
     test('v-bind:style', () => {
       expect(getCompiledString(`<div id="foo" :style="bar"></div>`))
         .toMatchInlineSnapshot(`

--- a/packages/compiler-ssr/src/transforms/ssrInjectCssVars.ts
+++ b/packages/compiler-ssr/src/transforms/ssrInjectCssVars.ts
@@ -15,8 +15,8 @@ export const ssrInjectCssVars: NodeTransform = (node, context) => {
     return
   }
 
-  // _cssVars is initailized once per render function
-  // the code is injected in ssrCodegenTrasnform when creating the
+  // _cssVars is initialized once per render function
+  // the code is injected in ssrCodegenTransform when creating the
   // ssr transform context
   if (node.type === NodeTypes.ROOT) {
     context.identifiers._cssVars = 1

--- a/packages/compiler-ssr/src/transforms/ssrTransformElement.ts
+++ b/packages/compiler-ssr/src/transforms/ssrTransformElement.ts
@@ -324,9 +324,10 @@ function removeStaticBinding(
   tag: TemplateLiteral['elements'],
   binding: string
 ) {
-  const i = tag.findIndex(
-    e => typeof e === 'string' && e.startsWith(` ${binding}=`)
-  )
+  const regExp = new RegExp(`^ ${binding}=".+"$`)
+
+  const i = tag.findIndex(e => typeof e === 'string' && regExp.test(e))
+
   if (i > -1) {
     tag.splice(i, 1)
   }

--- a/packages/server-renderer/__tests__/renderToString.spec.ts
+++ b/packages/server-renderer/__tests__/renderToString.spec.ts
@@ -142,6 +142,24 @@ describe('ssr: renderToString', () => {
       )
     })
 
+    test('template components with dynamic class attribute after static', async () => {
+      const app = createApp({
+        template: `<div><div class="child" :class="'dynamic'"></div></div>`
+      })
+      expect(await renderToString(app)).toBe(
+        `<div><div class="dynamic child"></div></div>`
+      )
+    })
+
+    test('template components with dynamic class attribute before static', async () => {
+      const app = createApp({
+        template: `<div><div :class="'dynamic'" class="child"></div></div>`
+      })
+      expect(await renderToString(app)).toBe(
+        `<div><div class="dynamic child"></div></div>`
+      )
+    })
+
     test('mixing optimized / vnode / template components', async () => {
       const OptimizedChild = {
         props: ['msg'],


### PR DESCRIPTION
Hi,

First PR on Vue3, and first time looking at the SSR process!
This one kept me busy few hours, to understand how all of that that runs (hurray for the debugger!).

As you can see [in the Template explorer](https://vue-next-template-explorer.netlify.app/#%7B%22src%22%3A%22%3Cdiv%3E%5Cn%20%20%3Cdiv%20%3Aclass%3D%5C%22dynamic%5C%22%20class%3D%5C%22child%5C%22%3E%3C%2Fdiv%3E%5Cn%20%20%3Cdiv%20class%3D%5C%22child%5C%22%20%3Aclass%3D%5C%22dynamic%5C%22%3E%3C%2Fdiv%3E%5Cn%3C%2Fdiv%3E%5Cn%5Cn%5Cn%22%2C%22ssr%22%3Atrue%2C%22options%22%3A%7B%22mode%22%3A%22module%22%2C%22prefixIdentifiers%22%3Afalse%2C%22optimizeImports%22%3Afalse%2C%22hoistStatic%22%3Afalse%2C%22cacheHandlers%22%3Afalse%2C%22scopeId%22%3Anull%2C%22ssrCssVars%22%3A%22%7B%20color%20%7D%22%2C%22bindingMetadata%22%3A%7B%22TestComponent%22%3A%22setup%22%2C%22foo%22%3A%22setup%22%2C%22bar%22%3A%22props%22%7D%7D%7D), there is an issue with the ssr compiler.

In the case of a dynamic class attribute first, we end up with:

```vue
// input
<div :class="'dynamic'" class="child"></div>

// render function
<div${
    _ssrRenderClass(['dynamic', "child"])
  }" class="child"></div>

// output
<divdynamic child" class="child"></div>
```

Instead of, if we invert the order:

```vue
// input
<div class="child" :class="'dynamic'"></div>

// render function
<div class="${
    _ssrRenderClass(['dynamic', "child"])
  }"></div>

// output
<div class="dynamic child"></div>
```

(Actually, it happens only if there is a parent, but I've omitted it in the example, for simplicity)


This comes from the `removeStaticBinding` function in [compiler-ssr/src/transforms/ssrTransformElement.ts](https://github.com/vuejs/vue-next/blob/2ae3b26679faf2d5393998ba806b99748679195a/packages/compiler-ssr/src/transforms/ssrTransformElement.ts#L323-L334) which is supposed to remove the static binding, but which in fact removes only the first one found.

This PR adds some tests to reproduce the bug and fixes the issue.

Thanks for your work!

Matt'