### PR TITLE
test(reactivity): add tests about ref input in toRefs

### DIFF
--- a/packages/reactivity/__tests__/ref.spec.ts
+++ b/packages/reactivity/__tests__/ref.spec.ts
@@ -283,6 +283,47 @@ describe('reactivity/ref', () => {
     expect(dummyY).toBe(5)
   })
 
+  test('toRefs on ref object', () => {
+    const a = ref({
+      x: 1,
+      y: 2
+    })
+
+    const { x, y } = toRefs(a.value)
+
+    expect(isRef(x)).toBe(true)
+    expect(isRef(y)).toBe(true)
+    expect(x.value).toBe(1)
+    expect(y.value).toBe(2)
+
+    // source -> proxy
+    a.value.x = 2
+    a.value.y = 3
+    expect(x.value).toBe(2)
+    expect(y.value).toBe(3)
+
+    // proxy -> source
+    x.value = 3
+    y.value = 4
+    expect(a.value.x).toBe(3)
+    expect(a.value.y).toBe(4)
+
+    // reactivity
+    let dummyX, dummyY
+    effect(() => {
+      dummyX = x.value
+      dummyY = y.value
+    })
+    expect(dummyX).toBe(x.value)
+    expect(dummyY).toBe(y.value)
+
+    // mutating source should trigger effect using the proxy refs
+    a.value.x = 4
+    a.value.y = 5
+    expect(dummyX).toBe(4)
+    expect(dummyY).toBe(5)
+  })
+
   test('toRefs should warn on plain object', () => {
     toRefs({})
     expect(`toRefs() expects a reactive object`).toHaveBeenWarned()
@@ -293,7 +334,7 @@ describe('reactivity/ref', () => {
     expect(`toRefs() expects a reactive object`).toHaveBeenWarned()
   })
 
-  test('toRefs reactive array', () => {
+  test('toRefs on reactive array', () => {
     const arr = reactive(['a', 'b', 'c'])
     const refs = toRefs(arr)
 
@@ -303,6 +344,19 @@ describe('reactivity/ref', () => {
     expect(arr[0]).toBe('1')
 
     arr[1] = '2'
+    expect(refs[1].value).toBe('2')
+  })
+
+  test('toRefs on ref array', () => {
+    const arr = ref(['a', 'b', 'c'])
+    const refs = toRefs(arr.value)
+
+    expect(Array.isArray(refs)).toBe(true)
+
+    refs[0].value = '1'
+    expect(arr.value[0]).toBe('1')
+
+    arr.value[1] = '2'
     expect(refs[1].value).toBe('2')
   })
 


### PR DESCRIPTION
Hi, 


This PR only add tests, for a working behaviour I didn't know. 

I explain why It's working, and think it's important to know.

For an application, I had ref with an object in it. (from api call, other hooks, etc. Doesn't matter).

My goal was to transform 
`const a = ref({ foo: 'xxx', bar: 'xxx' })` to `const b = { foo: ref('xxx'), bar: ref('xxx') }`

In the doc it's explained than you can use toRefs to do that the almost same thing, **but with reactive (and not ref)** : `toRefs({foo: 'xxx', bar: 'xxx'}) // {foo: ref('xxx'), bar: ref('xxx')}`

I made some weird tries to do that, before digging in the code, and seeing that the `toRef` function is just returning a new `ObjectRefImpl`, which is a simple proxy to any basic object:

```ts
class ObjectRefImpl<T extends object, K extends keyof T> {
  public readonly __v_isRef = true

  constructor(private readonly _object: T, private readonly _key: K) {}

  get value() {
    return this._object[this._key]
  }

  set value(newVal) {
    this._object[this._key] = newVal
  }
}
```

This tells us that we can totally use `toRef` and `toRef` functions with ref as input:


```js
const a = ref({ foo: 'xxx', bar: 'xxx' })

const b = toRefs(a.value)
```


This also tells us, that we can answer the many devs asking "how to destructure ref" by:

 ```js
const a = ref({ foo: 'xxx', bar: 'xxx' })

const { foo, bar } = toRefs(a.value)
```

I will make an other PR to the docs to explain that it's possible and add examples of that if you're ok with it.

Thanks as always for your amazing work.

Matt'