### PR TITLE
feat(computed): add cleanup method

### DIFF
--- a/packages/reactivity/src/computed.ts
+++ b/packages/reactivity/src/computed.ts
@@ -64,6 +64,7 @@ class ComputedRefImpl<T> {
   cleanup() {
     cleanup(this.effect)
     this._dirty = true
+    this._value = undefined!
   }
 }
 

--- a/packages/reactivity/src/computed.ts
+++ b/packages/reactivity/src/computed.ts
@@ -1,4 +1,4 @@
-import { effect, ReactiveEffect, trigger, track } from './effect'
+import { effect, ReactiveEffect, trigger, track, cleanup } from './effect'
 import { TriggerOpTypes, TrackOpTypes } from './operations'
 import { Ref } from './ref'
 import { isFunction, NOOP } from '@vue/shared'
@@ -6,6 +6,7 @@ import { ReactiveFlags, toRaw } from './reactive'
 
 export interface ComputedRef<T = any> extends WritableComputedRef<T> {
   readonly value: T
+  cleanup(): void
 }
 
 export interface WritableComputedRef<T> extends Ref<T> {
@@ -58,6 +59,11 @@ class ComputedRefImpl<T> {
 
   set value(newValue: T) {
     this._setter(newValue)
+  }
+
+  cleanup() {
+    cleanup(this.effect)
+    this._dirty = true
   }
 }
 

--- a/packages/reactivity/src/effect.ts
+++ b/packages/reactivity/src/effect.ts
@@ -110,7 +110,7 @@ function createReactiveEffect<T = any>(
   return effect
 }
 
-function cleanup(effect: ReactiveEffect) {
+export function cleanup(effect: ReactiveEffect) {
   const { deps } = effect
   if (deps.length) {
     for (let i = 0; i < deps.length; i++) {


### PR DESCRIPTION
See https://github.com/vuejs/vue-next/issues/2261#issuecomment-705170322

The cleanup method will remove all dep references to and from dependency sets. This allows the computed to be GC collected (if no other references remain).

Another reason to call this cleanup is to reduce the number of dependencies. Triggering a ref may become slow when there are many stale computeds that depend on it - as they will all have to be triggered. When calling cleanup, you can reduce the amount of stale computeds.

Notice that the computed will remain *active* and fully functional after cleanup. By simply setting the dirty flag upon cleanup, when getting the computed value later, all dependencies will simply be recovered and the correct value will be returned!