### PR TITLE
ci: add size check on push

### DIFF
--- a/.github/workflows/size-check.yml
+++ b/.github/workflows/size-check.yml
@@ -1,5 +1,8 @@
 name: 'size'
 on:
+  push:
+    branches:
+      - master
   pull_request:
     branches:
       - master
@@ -12,7 +15,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: bahmutov/npm-install@v1
 
-      - uses: posva/size-check-action@v1.0.2
+      - uses: posva/size-check-action@v1.1.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           build_script: size


### PR DESCRIPTION
Added the size check as a log for on push
![Screen Shot 2020-10-16 at 12 15 12](https://user-images.githubusercontent.com/664177/96246655-3f404b80-0fa9-11eb-9bef-a76c98ac577b.png)

Result: https://github.com/vuejs/vue-next/pull/2392/checks?check_run_id=1263863311

![Screen Shot 2020-10-16 at 12 18 38](https://user-images.githubusercontent.com/664177/96246973-ba096680-0fa9-11eb-8092-74000bc79202.png)
