### PR TITLE
feat(compiler-core): remove-metadata-bindings-never-used

### DIFF
--- a/packages/compiler-core/__tests__/__snapshots__/codegen.spec.ts.snap
+++ b/packages/compiler-core/__tests__/__snapshots__/codegen.spec.ts.snap
@@ -202,6 +202,14 @@ return function render(_ctx, _cache) {
 }"
 `;
 
+exports[`compiler: codegen with bindingMetadata data 1`] = `
+"import { createVNode as _createVNode, resolveDirective as _resolveDirective } from \\"vue\\"
+
+export function render(_ctx, _cache, $props, $setup, $data) {
+  return null
+}"
+`;
+
 exports[`compiler: codegen with bindingMetadata includes props,setup,data,options 1`] = `
 "import { createVNode as _createVNode, resolveDirective as _resolveDirective } from \\"vue\\"
 
@@ -210,10 +218,34 @@ export function render(_ctx, _cache, $props, $setup, $data, $options) {
 }"
 `;
 
-exports[`compiler: codegen with some of the bindingMetadata 1`] = `
+exports[`compiler: codegen with bindingMetadata options 1`] = `
 "import { createVNode as _createVNode, resolveDirective as _resolveDirective } from \\"vue\\"
 
-export function render(_ctx, _cache, $props, $setup, $data) {
+export function render(_ctx, _cache, $props, $setup, $data, $options) {
+  return null
+}"
+`;
+
+exports[`compiler: codegen with bindingMetadata props 1`] = `
+"import { createVNode as _createVNode, resolveDirective as _resolveDirective } from \\"vue\\"
+
+export function render(_ctx, _cache, $props) {
+  return null
+}"
+`;
+
+exports[`compiler: codegen with bindingMetadata setup 1`] = `
+"import { createVNode as _createVNode, resolveDirective as _resolveDirective } from \\"vue\\"
+
+export function render(_ctx, _cache, $props, $setup) {
+  return null
+}"
+`;
+
+exports[`compiler: codegen with no bindingMetadata 1`] = `
+"import { createVNode as _createVNode, resolveDirective as _resolveDirective } from \\"vue\\"
+
+export function render(_ctx, _cache) {
   return null
 }"
 `;

--- a/packages/compiler-core/__tests__/__snapshots__/codegen.spec.ts.snap
+++ b/packages/compiler-core/__tests__/__snapshots__/codegen.spec.ts.snap
@@ -201,3 +201,19 @@ return function render(_ctx, _cache) {
   }
 }"
 `;
+
+exports[`compiler: codegen with bindingMetadata includes props,setup,data,options 1`] = `
+"import { createVNode as _createVNode, resolveDirective as _resolveDirective } from \\"vue\\"
+
+export function render(_ctx, _cache, $props, $setup, $data, $options) {
+  return null
+}"
+`;
+
+exports[`compiler: codegen with some of the bindingMetadata 1`] = `
+"import { createVNode as _createVNode, resolveDirective as _resolveDirective } from \\"vue\\"
+
+export function render(_ctx, _cache, $props, $setup, $data) {
+  return null
+}"
+`;

--- a/packages/compiler-core/__tests__/codegen.spec.ts
+++ b/packages/compiler-core/__tests__/codegen.spec.ts
@@ -142,20 +142,74 @@ describe('compiler: codegen', () => {
     expect(code).toMatchSnapshot()
   })
 
-  test('with some of the bindingMetadata', () => {
+  test('with bindingMetadata options', () => {
     const root = createRoot({
       helpers: [CREATE_VNODE, RESOLVE_DIRECTIVE]
     })
     const { code } = generate(root, {
       mode: 'module',
       bindingMetadata: {
-        props: 'props',
+        options: 'options'
+      }
+    })
+    expect(code).toMatch(
+      `export function render(_ctx, _cache, $props, $setup, $data, $options)`
+    )
+    expect(code).toMatchSnapshot()
+  })
+
+  test('with bindingMetadata data', () => {
+    const root = createRoot({
+      helpers: [CREATE_VNODE, RESOLVE_DIRECTIVE]
+    })
+    const { code } = generate(root, {
+      mode: 'module',
+      bindingMetadata: {
         data: 'data'
       }
     })
     expect(code).toMatch(
       `export function render(_ctx, _cache, $props, $setup, $data)`
     )
+    expect(code).toMatchSnapshot()
+  })
+
+  test('with bindingMetadata setup', () => {
+    const root = createRoot({
+      helpers: [CREATE_VNODE, RESOLVE_DIRECTIVE]
+    })
+    const { code } = generate(root, {
+      mode: 'module',
+      bindingMetadata: {
+        setup: 'setup'
+      }
+    })
+    expect(code).toMatch(`export function render(_ctx, _cache, $props, $setup)`)
+    expect(code).toMatchSnapshot()
+  })
+
+  test('with bindingMetadata props', () => {
+    const root = createRoot({
+      helpers: [CREATE_VNODE, RESOLVE_DIRECTIVE]
+    })
+    const { code } = generate(root, {
+      mode: 'module',
+      bindingMetadata: {
+        props: 'props'
+      }
+    })
+    expect(code).toMatch(`export function render(_ctx, _cache, $props)`)
+    expect(code).toMatchSnapshot()
+  })
+
+  test('with no bindingMetadata', () => {
+    const root = createRoot({
+      helpers: [CREATE_VNODE, RESOLVE_DIRECTIVE]
+    })
+    const { code } = generate(root, {
+      mode: 'module'
+    })
+    expect(code).toMatch(`export function render(_ctx, _cache)`)
     expect(code).toMatchSnapshot()
   })
 

--- a/packages/compiler-core/__tests__/codegen.spec.ts
+++ b/packages/compiler-core/__tests__/codegen.spec.ts
@@ -123,6 +123,42 @@ describe('compiler: codegen', () => {
     expect(code).toMatchSnapshot()
   })
 
+  test('with bindingMetadata includes props,setup,data,options', () => {
+    const root = createRoot({
+      helpers: [CREATE_VNODE, RESOLVE_DIRECTIVE]
+    })
+    const { code } = generate(root, {
+      mode: 'module',
+      bindingMetadata: {
+        props: 'props',
+        setup: 'setup',
+        data: 'data',
+        options: 'options'
+      }
+    })
+    expect(code).toMatch(
+      `export function render(_ctx, _cache, $props, $setup, $data, $options)`
+    )
+    expect(code).toMatchSnapshot()
+  })
+
+  test('with some of the bindingMetadata', () => {
+    const root = createRoot({
+      helpers: [CREATE_VNODE, RESOLVE_DIRECTIVE]
+    })
+    const { code } = generate(root, {
+      mode: 'module',
+      bindingMetadata: {
+        props: 'props',
+        data: 'data'
+      }
+    })
+    expect(code).toMatch(
+      `export function render(_ctx, _cache, $props, $setup, $data)`
+    )
+    expect(code).toMatchSnapshot()
+  })
+
   test('assets + temps', () => {
     const root = createRoot({
       components: [`Foo`, `bar-baz`, `barbaz`],

--- a/packages/compiler-core/src/codegen.ts
+++ b/packages/compiler-core/src/codegen.ts
@@ -218,16 +218,15 @@ export function generate(
       'options'
     ]
     const bindingMetadataValues = [...new Set(Object.values(bindingMetadata))]
-    let metadataArgs: MetadataType[] = []
     for (let i = bindingMetadataRank.length - 1; i >= 0; i--) {
       if (bindingMetadataValues.includes(bindingMetadataRank[i])) {
-        metadataArgs = bindingMetadataRank.slice(0, i + 1)
+        optimizeSources = `, ${bindingMetadataRank
+          .slice(0, i + 1)
+          .map(metadataName => `$${metadataName}`)
+          .join(', ')}`
         break
       }
     }
-    optimizeSources = `, ${metadataArgs
-      .map(metadataName => `$${metadataName}`)
-      .join(', ')}`
   }
   // enter render function
   if (!ssr) {

--- a/packages/compiler-core/src/codegen.ts
+++ b/packages/compiler-core/src/codegen.ts
@@ -219,7 +219,7 @@ export function generate(
     ]
     const bindingMetadataValues = [...new Set(Object.values(bindingMetadata))]
     let metadataArgs: MetadataType[] = []
-    for (let i = bindingMetadataRank.length - 1; i > 0; i--) {
+    for (let i = bindingMetadataRank.length - 1; i >= 0; i--) {
       if (bindingMetadataValues.includes(bindingMetadataRank[i])) {
         metadataArgs = bindingMetadataRank.slice(0, i + 1)
         break

--- a/packages/compiler-core/src/codegen.ts
+++ b/packages/compiler-core/src/codegen.ts
@@ -1,4 +1,4 @@
-import { CodegenOptions } from './options'
+import { CodegenOptions, MetadataType } from './options'
 import {
   RootNode,
   TemplateChildNode,
@@ -208,9 +208,27 @@ export function generate(
   }
 
   // binding optimizations
-  const optimizeSources = options.bindingMetadata
-    ? `, $props, $setup, $data, $options`
-    : ``
+  let optimizeSources = ''
+  const bindingMetadata = options.bindingMetadata
+  if (bindingMetadata) {
+    const bindingMetadataRank: MetadataType[] = [
+      'props',
+      'setup',
+      'data',
+      'options'
+    ]
+    const bindingMetadataValues = [...new Set(Object.values(bindingMetadata))]
+    let metadataArgs: MetadataType[] = []
+    for (let i = bindingMetadataRank.length - 1; i > 0; i--) {
+      if (bindingMetadataValues.includes(bindingMetadataRank[i])) {
+        metadataArgs = bindingMetadataRank.slice(0, i + 1)
+        break
+      }
+    }
+    optimizeSources = `, ${metadataArgs
+      .map(metadataName => `$${metadataName}`)
+      .join(', ')}`
+  }
   // enter render function
   if (!ssr) {
     if (genScopeId) {

--- a/packages/compiler-core/src/options.ts
+++ b/packages/compiler-core/src/options.ts
@@ -61,8 +61,10 @@ export type HoistTransform = (
   parent: ParentNode
 ) => void
 
+export type MetadataType = 'data' | 'props' | 'setup' | 'options'
+
 export interface BindingMetadata {
-  [key: string]: 'data' | 'props' | 'setup' | 'options'
+  [key: string]: MetadataType
 }
 
 export interface TransformOptions {


### PR DESCRIPTION
Remove metadata bindings never used in render function:
Template:
```html
<div @click="a">{{bar}}</div>
<div @click="a">{{foo}}</div>
```
`bar` and `foo` are set as metadata:
```js
bindingMetadata: {
  TestComponent: 'setup',
  foo: 'setup',
  bar: 'props'
}
```
Compiler result before:
```js
import { toDisplayString as _toDisplayString, createVNode as _createVNode, Fragment as _Fragment, openBlock as _openBlock, createBlock as _createBlock } from "vue"

export function render(_ctx, _cache, $props, $setup, $data, $options) {
  return (_openBlock(), _createBlock(_Fragment, null, [
    _createVNode("div", { onClick: _ctx.a }, _toDisplayString($props.bar), 9 /* TEXT, PROPS */, ["onClick"]),
    _createVNode("div", { onClick: _ctx.a }, _toDisplayString($setup.foo), 9 /* TEXT, PROPS */, ["onClick"])
  ], 64 /* STABLE_FRAGMENT */))
}

```
Compiler result after
```js
import { toDisplayString as _toDisplayString, createVNode as _createVNode, Fragment as _Fragment, openBlock as _openBlock, createBlock as _createBlock } from "vue"

export function render(_ctx, _cache, $props, $setup) {  // remove $data and $options here
  return (_openBlock(), _createBlock(_Fragment, null, [
    _createVNode("div", { onClick: _ctx.a }, _toDisplayString($props.bar), 9 /* TEXT, PROPS */, ["onClick"]),
    _createVNode("div", { onClick: _ctx.a }, _toDisplayString($setup.foo), 9 /* TEXT, PROPS */, ["onClick"])
  ], 64 /* STABLE_FRAGMENT */))
}

```