### PR TITLE
types(h): support for resolveComponent

### DIFF
--- a/packages/runtime-core/src/h.ts
+++ b/packages/runtime-core/src/h.ts
@@ -10,7 +10,12 @@ import { Teleport, TeleportProps } from './components/Teleport'
 import { Suspense, SuspenseProps } from './components/Suspense'
 import { isObject, isArray } from '@vue/shared'
 import { RawSlots } from './componentSlots'
-import { FunctionalComponent, Component, ComponentOptions } from './component'
+import {
+  FunctionalComponent,
+  Component,
+  ComponentOptions,
+  ConcreteComponent
+} from './component'
 import { EmitsOptions } from './componentEmits'
 import { DefineComponent } from './apiDefineComponent'
 
@@ -111,6 +116,17 @@ export function h<P, E extends EmitsOptions = {}>(
 
 // catch-all for generic component types
 export function h(type: Component, children?: RawChildren): VNode
+
+// concrete component
+export function h<P>(
+  type: ConcreteComponent | string,
+  children?: RawChildren
+): VNode
+export function h<P>(
+  type: ConcreteComponent<P> | string,
+  props?: (RawProps & P) | ({} extends P ? null : never),
+  children?: RawChildren
+): VNode
 
 // component without props
 export function h(

--- a/packages/runtime-core/src/helpers/resolveAssets.ts
+++ b/packages/runtime-core/src/helpers/resolveAssets.ts
@@ -16,9 +16,7 @@ const DIRECTIVES = 'directives'
 /**
  * @private
  */
-export function resolveComponent(
-  name: string
-): ConcreteComponent | string | undefined {
+export function resolveComponent(name: string): ConcreteComponent | string {
   return resolveAsset(COMPONENTS, name) || name
 }
 

--- a/test-dts/h.test-d.ts
+++ b/test-dts/h.test-d.ts
@@ -8,7 +8,8 @@ import {
   Suspense,
   Component,
   expectError,
-  expectAssignable
+  expectAssignable,
+  resolveComponent
 } from './index'
 
 describe('h inference w/ element', () => {
@@ -197,4 +198,12 @@ describe('component w/ props w/ default value', () => {
   })
 
   h(MyComponent, {})
+})
+
+// #2357
+describe('resolveComponent should work', () => {
+  h(resolveComponent('test'))
+  h(resolveComponent('test'), {
+    message: '1'
+  })
 })


### PR DESCRIPTION
Fix #2357 

> Note: resolveComponent cannot return `undefined`, so I removed it