### PR TITLE
types: mixin and extends typing on data and setup

### DIFF
--- a/packages/runtime-core/src/componentOptions.ts
+++ b/packages/runtime-core/src/componentOptions.ts
@@ -368,7 +368,7 @@ interface LegacyOptions<
       Props,
       {},
       {},
-      ComputedOptions,
+      {},
       MethodOptions,
       Mixin,
       Extends
@@ -377,7 +377,7 @@ interface LegacyOptions<
       Props,
       {},
       {},
-      ComputedOptions,
+      {},
       MethodOptions,
       Mixin,
       Extends

--- a/test-dts/defineComponent.test-d.tsx
+++ b/test-dts/defineComponent.test-d.tsx
@@ -444,6 +444,9 @@ describe('with mixins', () => {
         d: 4
       }
     },
+    setup(props) {
+      expectType<string>(props.aP1)
+    },
     computed: {
       dC1(): number {
         return this.d + this.a
@@ -461,6 +464,36 @@ describe('with mixins', () => {
         type: String,
         required: true
       }
+    },
+
+    data(vm) {
+      expectType<number>(vm.a)
+      expectType<number>(vm.b)
+      expectType<number>(vm.c)
+      expectType<number>(vm.d)
+
+      // should also expose declared props on `this`
+      expectType<number>(this.a)
+      expectType<string>(this.aP1)
+      expectType<boolean | undefined>(this.aP2)
+      expectType<number>(this.b)
+      expectType<any>(this.bP1)
+      expectType<number>(this.c)
+      expectType<number>(this.d)
+      expectType<number>(this.dC1)
+      expectType<string>(this.dC2)
+
+      return {}
+    },
+
+    setup(props) {
+      expectType<string>(props.z)
+      // props
+      expectType<string>(props.aP1)
+      expectType<boolean | undefined>(props.aP2)
+      expectType<any>(props.bP1)
+      expectType<any>(props.bP2)
+      expectType<string>(props.z)
     },
     render() {
       const props = this.$props

--- a/test-dts/defineComponent.test-d.tsx
+++ b/test-dts/defineComponent.test-d.tsx
@@ -440,6 +440,11 @@ describe('with mixins', () => {
   const MixinD = defineComponent({
     mixins: [MixinA],
     data() {
+      //@ts-expect-error computed are not available on data()
+      expectError<number>(this.dC1)
+      //@ts-expect-error computed are not available on data()
+      expectError<string>(this.dC2)
+
       return {
         d: 4
       }
@@ -480,8 +485,6 @@ describe('with mixins', () => {
       expectType<any>(this.bP1)
       expectType<number>(this.c)
       expectType<number>(this.d)
-      expectType<number>(this.dC1)
-      expectType<string>(this.dC2)
 
       return {}
     },


### PR DESCRIPTION
Fix #2350

Provide mixing info inside of `data()` and infer mixins props in `setup(props)`