### PR TITLE
fix accessCache proto

### DIFF
--- a/packages/runtime-core/src/component.ts
+++ b/packages/runtime-core/src/component.ts
@@ -549,7 +549,7 @@ function setupStatefulComponent(
     }
   }
   // 0. create render proxy property access cache
-  instance.accessCache = {}
+  instance.accessCache = Object.create(null)
   // 1. create public instance / render proxy
   // also mark it raw so it's never observed
   instance.proxy = new Proxy(instance.ctx, PublicInstanceProxyHandlers)


### PR DESCRIPTION
### fix problems

```js
Vue.createApp({
  template: `<div>{{ hasOwnProperty }}</div>`,
  data () {
    return {
      hasOwnProperty: 3,
    };
  },
}).mount('body');
```

**production mode**: Can't find prop `hasOwnProperty` on `instance.ctx` while renderring, which should on `instance.data` in fact, but skipped by `switch(n)` check. See `PublicInstanceProxyHandlers.get`.

---

**development mode**: Seems right on UI, but in fact, it's readed from `instance.ctx` copy, not `instance.data`, so when the prop value is `Vue.ref(3)`, there will be `{ "_rawValue": 3, "_shallow": false, "__v_isRef": true, "_value": "old" }` but not `3` on the UI.

```js
Vue.createApp({
  template: `<div>{{ hasOwnProperty }}</div>`,
  data () {
    return {
      hasOwnProperty: Vue.ref(3),
    };
  },
}).mount('body');
```
