### PR TITLE
fix(runtime-core): prevent self-injection (#2400)

### DIFF
--- a/packages/runtime-core/__tests__/apiInject.spec.ts
+++ b/packages/runtime-core/__tests__/apiInject.spec.ts
@@ -303,4 +303,19 @@ describe('api: provide/inject', () => {
     render(h(Provider), root)
     expect(`injection "foo" not found.`).not.toHaveBeenWarned()
   })
+
+  // #2400
+  it('should not self-inject', () => {
+    const Comp = {
+      setup() {
+        provide('foo', 'foo')
+        const injection = inject('foo', null)
+        return () => injection
+      }
+    }
+
+    const root = nodeOps.createElement('div')
+    render(h(Comp), root)
+    expect(serialize(root)).toBe(`<div><!----></div>`)
+  })
 })

--- a/packages/runtime-core/src/apiInject.ts
+++ b/packages/runtime-core/src/apiInject.ts
@@ -47,8 +47,15 @@ export function inject(
   // a functional component
   const instance = currentInstance || currentRenderingInstance
   if (instance) {
-    const provides = instance.provides
-    if ((key as string | symbol) in provides) {
+    // #2400
+    // to support `app.use` plugins,
+    // fallback to appContext's `provides` if the intance is at root
+    const provides =
+      instance.parent == null
+        ? instance.vnode.appContext && instance.vnode.appContext.provides
+        : instance.parent.provides
+
+    if (provides && (key as string | symbol) in provides) {
       // TS doesn't allow symbol as index type
       return provides[key as string]
     } else if (arguments.length > 1) {


### PR DESCRIPTION
fix #2400 

This fix makes sure the injection in the component comes from the parent.
For the root component, it is possible to inject properties provided through plugins.