### PR TITLE
fix(compiler-sfc): should keep template nodes with no content (close #2463)

### DIFF
--- a/packages/compiler-sfc/__tests__/parse.spec.ts
+++ b/packages/compiler-sfc/__tests__/parse.spec.ts
@@ -111,8 +111,13 @@ h1 { color: red }
     )
   })
 
-  test('should ignore nodes with no content', () => {
-    expect(parse(`<template/>`).descriptor.template).toBe(null)
+  test('should keep template nodes with no content', () => {
+    const { descriptor } = parse(`<template/>`)
+    expect(descriptor.template).toBeTruthy()
+    expect(descriptor.template!.content).toBeFalsy()
+  })
+
+  test('should ignore other nodes with no content', () => {
     expect(parse(`<script/>`).descriptor.script).toBe(null)
     expect(parse(`<style/>`).descriptor.styles.length).toBe(0)
     expect(parse(`<custom/>`).descriptor.customBlocks.length).toBe(0)

--- a/packages/compiler-sfc/src/parse.ts
+++ b/packages/compiler-sfc/src/parse.ts
@@ -134,7 +134,7 @@ export function parse(
     if (node.type !== NodeTypes.ELEMENT) {
       return
     }
-    if (!node.children.length && !hasSrc(node)) {
+    if (!node.children.length && !hasSrc(node) && node.tag !== 'template') {
       return
     }
     switch (node.tag) {


### PR DESCRIPTION
See #2463

This tweak is based on the following consideration:

> An empty `<template>` block means it should render empty string, which is different from no `<template>` block.