### PR TITLE
feat(compiler-sfc): support transforming asset urls with full base url.

### DIFF
--- a/packages/compiler-sfc/__tests__/__snapshots__/templateTransformAssetUrl.spec.ts.snap
+++ b/packages/compiler-sfc/__tests__/__snapshots__/templateTransformAssetUrl.spec.ts.snap
@@ -1,5 +1,29 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`compiler sfc: transform asset url should allow for full base URLs, with paths 1`] = `
+"import { createVNode as _createVNode, openBlock as _openBlock, createBlock as _createBlock } from \\"vue\\"
+
+export function render(_ctx, _cache) {
+  return (_openBlock(), _createBlock(\\"img\\", { src: \\"http://localhost:3000/src/logo.png\\" }))
+}"
+`;
+
+exports[`compiler sfc: transform asset url should allow for full base URLs, without paths 1`] = `
+"import { createVNode as _createVNode, openBlock as _openBlock, createBlock as _createBlock } from \\"vue\\"
+
+export function render(_ctx, _cache) {
+  return (_openBlock(), _createBlock(\\"img\\", { src: \\"http://localhost:3000/logo.png\\" }))
+}"
+`;
+
+exports[`compiler sfc: transform asset url should allow for full base URLs, without port 1`] = `
+"import { createVNode as _createVNode, openBlock as _openBlock, createBlock as _createBlock } from \\"vue\\"
+
+export function render(_ctx, _cache) {
+  return (_openBlock(), _createBlock(\\"img\\", { src: \\"http://localhost/logo.png\\" }))
+}"
+`;
+
 exports[`compiler sfc: transform asset url support uri fragment 1`] = `
 "import { createVNode as _createVNode, openBlock as _openBlock, createBlock as _createBlock } from \\"vue\\"
 import _imports_0 from '@svg/file.svg'

--- a/packages/compiler-sfc/__tests__/templateTransformAssetUrl.spec.ts
+++ b/packages/compiler-sfc/__tests__/templateTransformAssetUrl.spec.ts
@@ -94,4 +94,28 @@ describe('compiler sfc: transform asset url', () => {
     // should not remove it
     expect(code).toMatch(`"xlink:href": "#myCircle"`)
   })
+
+  test('should allow for full base URLs, with paths', () => {
+    const { code } = compileWithAssetUrls(`<img src="./logo.png" />`, {
+      base: 'http://localhost:3000/src/'
+    })
+
+    expect(code).toMatchSnapshot()
+  })
+
+  test('should allow for full base URLs, without paths', () => {
+    const { code } = compileWithAssetUrls(`<img src="./logo.png" />`, {
+      base: 'http://localhost:3000'
+    })
+
+    expect(code).toMatchSnapshot()
+  })
+
+  test('should allow for full base URLs, without port', () => {
+    const { code } = compileWithAssetUrls(`<img src="./logo.png" />`, {
+      base: 'http://localhost'
+    })
+
+    expect(code).toMatchSnapshot()
+  })
 })

--- a/packages/compiler-sfc/src/templateTransformAssetUrl.ts
+++ b/packages/compiler-sfc/src/templateTransformAssetUrl.ts
@@ -120,12 +120,16 @@ export const transformAssetUrl: NodeTransform = (
           attr.value.content[0] !== '@' &&
           isRelativeUrl(attr.value.content)
         ) {
+          // Allow for full hostnames provided in options.base
+          const base = parseUrl(options.base)
+          const host = base.host ? base.protocol + '//' + base.host : ''
+          const basePath = base.path || options.base
+
           // when packaged in the browser, path will be using the posix-
           // only version provided by rollup-plugin-node-builtins.
-          attr.value.content = (path.posix || path).join(
-            options.base,
-            url.path + (url.hash || '')
-          )
+          attr.value.content =
+            host +
+            (path.posix || path).join(basePath, url.path + (url.hash || ''))
         }
         return
       }


### PR DESCRIPTION
This feature allows for full URLs (including protocol, host, and port) to be provided as `options.base` when transforming template asset urls. Previously, passing full URLs was unsupported, since `path.join()` does not work well with full URLs.

This is my first contribution to vue 3 and I'm not sure if the lack of support for this was intentional or not. I am looking forward to your feedback.