### PR TITLE
feat(runtime-core): improve render context warning

### DIFF
--- a/packages/runtime-core/src/componentPublicInstance.ts
+++ b/packages/runtime-core/src/componentPublicInstance.ts
@@ -339,7 +339,7 @@ export const PublicInstanceProxyHandlers: ProxyHandler<any> = {
           )} must be accessed via $data because it starts with a reserved ` +
             `character ("$" or "_") and is not proxied on the render context.`
         )
-      } else {
+      } else if (instance === currentRenderingInstance) {
         warn(
           `Property ${JSON.stringify(key)} was accessed during render ` +
             `but is not defined on instance.`


### PR DESCRIPTION
## Problem 

When we try to access a non-existing property on a component during rendering, we get this helpful warning:

> Property ${JSON.stringify(key)} was accessed during render but is not defined on instance.

However, the current implementation logs this warning as long as *some* component is currently rendering. In other words, the warning is not limited to the render cycle of the component instance that we tried to read the property from.

## Solution

I think this warning should only be printed out during the component's own render. 

### Use case: 

When reading a property from a child component instance obtained from a template ref, one might not know which kind of component the ref contains, so reading a prop in order to do a sort of duck typing is useful.

But with the current implementation, a warning would be logged to the console each time a child component is checked programmatically like this.