### PR TITLE
fix(reactivity): ensure  readonly on plain arrays doesn't track array methods. (close: #2493)

### DIFF
--- a/packages/reactivity/__tests__/readonly.spec.ts
+++ b/packages/reactivity/__tests__/readonly.spec.ts
@@ -375,6 +375,16 @@ describe('reactivity/readonly', () => {
     expect(dummy).toBe(1)
   })
 
+  test('readonly array should not track', () => {
+    const arr = [1]
+    const roArr = readonly(arr)
+
+    const eff = effect(() => {
+      roArr.includes(2)
+    })
+    expect(eff.deps.length).toBe(0)
+  })
+
   test('readonly should track and trigger if wrapping reactive original (collection)', () => {
     const a = reactive(new Map())
     const b = readonly(a)

--- a/packages/reactivity/src/baseHandlers.ts
+++ b/packages/reactivity/src/baseHandlers.ts
@@ -83,7 +83,8 @@ function createGetter(isReadonly = false, shallow = false) {
     }
 
     const targetIsArray = isArray(target)
-    if (targetIsArray && hasOwn(arrayInstrumentations, key)) {
+
+    if (!isReadonly && targetIsArray && hasOwn(arrayInstrumentations, key)) {
       return Reflect.get(arrayInstrumentations, key, receiver)
     }
 


### PR DESCRIPTION
When using `readonly()` on a plain array, accessing the array in any way should not result in any tracking, no deps should be collected, as a plain array can't be tracked anyway.

However, for array methods like `includes`, we currently use `arrayImplementations` that *do* track wether or not the proxy is a reactive or readonly one.

Consequently, this doesn't result in tracking:

```js
readonly([1, 2])[0]
```

but this does:

```
readonly([1, 2]).includes(1)
```


close: #2493