### PR TITLE
fix(runtime-dom): add missing dependency @vue/reactivity

### DIFF
--- a/packages/runtime-dom/package.json
+++ b/packages/runtime-dom/package.json
@@ -36,6 +36,7 @@
   "homepage": "https://github.com/vuejs/vue-next/tree/master/packages/runtime-dom#readme",
   "dependencies": {
     "@vue/shared": "3.0.2",
+    "@vue/reactivity": "3.0.2",
     "@vue/runtime-core": "3.0.2",
     "csstype": "^2.6.8"
   }


### PR DESCRIPTION
**What's the problem this PR addresses?**

`@vue/runtime-dom` is importing `@vue/reactivity` without declaring it as a dependency at https://github.com/vuejs/vue-next/blob/ad199e1a252f80c85a8e40a4b4539ad27c39505c/packages/runtime-dom/src/components/TransitionGroup.ts#L23

**How did you fix it?**

Added `@vue/reactivity` as a dependency