### PR TITLE
fix(runtime-core): fix the warning "Extraneous non-emits event listeners" shows up even when emits is set

### DIFF
--- a/packages/runtime-core/__tests__/componentEmits.spec.ts
+++ b/packages/runtime-core/__tests__/componentEmits.spec.ts
@@ -283,15 +283,23 @@ describe('component: emit', () => {
   })
 
   test('isEmitListener', () => {
-    const options = { click: null }
+    const options = {
+      click: null,
+      'test-event': null,
+      fooBar: null,
+      FooBaz: null
+    }
     expect(isEmitListener(options, 'onClick')).toBe(true)
     expect(isEmitListener(options, 'onclick')).toBe(false)
     expect(isEmitListener(options, 'onBlick')).toBe(false)
     // .once listeners
     expect(isEmitListener(options, 'onClickOnce')).toBe(true)
     expect(isEmitListener(options, 'onclickOnce')).toBe(false)
-    // kebab-case listener
-    const kebabOptions = { 'test-event': null }
-    expect(isEmitListener(kebabOptions, 'onTestEvent')).toBe(true)
+    // kebab-case option
+    expect(isEmitListener(options, 'onTestEvent')).toBe(true)
+    // camelCase option
+    expect(isEmitListener(options, 'onFooBar')).toBe(true)
+    // PascalCase option
+    expect(isEmitListener(options, 'onFooBaz')).toBe(true)
   })
 })

--- a/packages/runtime-core/__tests__/componentEmits.spec.ts
+++ b/packages/runtime-core/__tests__/componentEmits.spec.ts
@@ -290,5 +290,8 @@ describe('component: emit', () => {
     // .once listeners
     expect(isEmitListener(options, 'onClickOnce')).toBe(true)
     expect(isEmitListener(options, 'onclickOnce')).toBe(false)
+    // kebab-case listener
+    const kebabOptions = { 'test-event': null }
+    expect(isEmitListener(kebabOptions, 'onTestEvent')).toBe(true)
   })
 })

--- a/packages/runtime-core/src/componentEmits.ts
+++ b/packages/runtime-core/src/componentEmits.ts
@@ -201,10 +201,6 @@ export function isEmitListener(
   if (!options || !isOn(key)) {
     return false
   }
-  key = key.replace(/Once$/, '')
-  return (
-    hasOwn(options, key[2].toLowerCase() + key.slice(3)) ||
-    hasOwn(options, key.slice(2)) ||
-    hasOwn(options, hyphenate(key.slice(2)))
-  )
+  key = key.slice(2).replace(/Once$/, '')
+  return hasOwn(options, hyphenate(key)) || hasOwn(options, key)
 }

--- a/packages/runtime-core/src/componentEmits.ts
+++ b/packages/runtime-core/src/componentEmits.ts
@@ -204,6 +204,7 @@ export function isEmitListener(
   key = key.replace(/Once$/, '')
   return (
     hasOwn(options, key[2].toLowerCase() + key.slice(3)) ||
-    hasOwn(options, key.slice(2))
+    hasOwn(options, key.slice(2)) ||
+    hasOwn(options, hyphenate(key.slice(2)))
   )
 }

--- a/packages/runtime-core/src/componentEmits.ts
+++ b/packages/runtime-core/src/componentEmits.ts
@@ -202,5 +202,9 @@ export function isEmitListener(
     return false
   }
   key = key.slice(2).replace(/Once$/, '')
-  return hasOwn(options, hyphenate(key)) || hasOwn(options, key)
+  return (
+    hasOwn(options, key[0].toLowerCase() + key.slice(1)) ||
+    hasOwn(options, hyphenate(key)) ||
+    hasOwn(options, key)
+  )
 }


### PR DESCRIPTION
See #2540 , `isEmitListener` function will not work when using kebab-case event.
So I fix the `isEmitListener` function and now it works correctly.

Close #2540 