### PR TITLE
fix(types/reactivity): error TS4058 caused by `RefSymbol`

### DIFF
--- a/packages/reactivity/src/ref.ts
+++ b/packages/reactivity/src/ref.ts
@@ -4,7 +4,7 @@ import { isArray, isObject, hasChanged } from '@vue/shared'
 import { reactive, isProxy, toRaw, isReactive } from './reactive'
 import { CollectionTypes } from './collectionHandlers'
 
-declare const RefSymbol: unique symbol
+export declare const RefSymbol: unique symbol
 
 export interface Ref<T = any> {
   value: T


### PR DESCRIPTION
I'm use `readonly()` and pass a `Ref` type param, it will cause `error TS4058` when I build it.