### PR TITLE
fix(runtime-core): ensure keep-alive deep-watches include/exlude props (fix #2550)

### DIFF
--- a/packages/runtime-core/src/components/KeepAlive.ts
+++ b/packages/runtime-core/src/components/KeepAlive.ts
@@ -179,7 +179,7 @@ const KeepAliveImpl = {
         exclude && pruneCache(name => !matches(exclude, name))
       },
       // prune post-render after `current` has been updated
-      { flush: 'post' }
+      { flush: 'post', deep: true }
     )
 
     // cache sub tree after render


### PR DESCRIPTION
We currently watch components like this:

`watch(() => [props.include, props.exclude], ....)`

Which works when `include` / `exclude` are eithe refs or receive immutable values.

If either is a `reactive([])`, the watch would not be triggered.

Addind `deep: true` fixes the issue.