### PR TITLE
fix(runtime-core): add selector in mount warning

### DIFF
--- a/packages/runtime-dom/src/index.ts
+++ b/packages/runtime-dom/src/index.ts
@@ -107,7 +107,9 @@ function normalizeContainer(container: Element | string): Element | null {
   if (isString(container)) {
     const res = document.querySelector(container)
     if (__DEV__ && !res) {
-      warn(`Failed to mount app: mount target selector returned null.`)
+      warn(
+        `Failed to mount app: mount target selector "${container}" returned null.`
+      )
     }
     return res
   }

--- a/packages/vue/__tests__/index.spec.ts
+++ b/packages/vue/__tests__/index.spec.ts
@@ -205,7 +205,7 @@ describe('compiler + runtime integration', () => {
     createApp(App).mount('#not-exist-id')
 
     expect(
-      '[Vue warn]: Failed to mount app: mount target selector returned null.'
+      '[Vue warn]: Failed to mount app: mount target selector "#not-exist-id" returned null.'
     ).toHaveBeenWarned()
     document.querySelector = origin
   })


### PR DESCRIPTION
Currently when mounting several applications, it is hard to know which one failed with the emitted warning:

    Failed to mount app: mount target selector returned null.

This commit adds the not found selector to the warning message, helping developers to locate which of their application is not mounting properly:

    Failed to mount app: mount target selector "#not-found" returned null.