### PR TITLE
fix props & emits proto

### DIFF
--- a/packages/runtime-core/src/componentEmits.ts
+++ b/packages/runtime-core/src/componentEmits.ts
@@ -159,7 +159,7 @@ export function normalizeEmitsOptions(
   }
 
   const raw = comp.emits
-  let normalized: ObjectEmitsOptions = {}
+  let normalized: ObjectEmitsOptions = Object.create(null)
 
   // apply mixin/extends props
   let hasExtends = false

--- a/packages/runtime-core/src/componentProps.ts
+++ b/packages/runtime-core/src/componentProps.ts
@@ -132,7 +132,7 @@ export function initProps(
   isStateful: number, // result of bitwise flag comparison
   isSSR = false
 ) {
-  const props: Data = {}
+  const props: Data = Object.create(null)
   const attrs: Data = {}
   def(attrs, InternalObjectKey, 1)
   setFullProps(instance, rawProps, props, attrs)


### PR DESCRIPTION
1. props (main):

Any key in `Object.prototype` such as `valueOf` can not be a prop to receive currently.

```js
Vue.createApp({
    template: '<MyComponent />',
    components: {
        MyComponent: {
            template: '<div>{{ valueOf }}<br>{{ toString }}</div>',
            props: {
                valueOf: { default: 'v' },
                toString: { },
            },
        },
    },
}).mount('body');
```

prop will get function value instead of undefined or default option.

2. emits (incidental):

`$emit("__defineGetter__")` may cause bug.
