### PR TITLE
docs(type): remove unmount parameters

### DIFF
--- a/packages/runtime-core/__tests__/apiCreateApp.spec.ts
+++ b/packages/runtime-core/__tests__/apiCreateApp.spec.ts
@@ -60,12 +60,12 @@ describe('api: createApp', () => {
     const app = createApp(Comp)
 
     // warning
-    app.unmount(root)
+    app.unmount()
     expect(`that is not mounted`).toHaveBeenWarned()
 
     app.mount(root)
 
-    app.unmount(root)
+    app.unmount()
     expect(serializeInner(root)).toBe(``)
   })
 

--- a/packages/runtime-core/src/apiCreateApp.ts
+++ b/packages/runtime-core/src/apiCreateApp.ts
@@ -29,7 +29,7 @@ export interface App<HostElement = any> {
     rootContainer: HostElement | string,
     isHydrate?: boolean
   ): ComponentPublicInstance
-  unmount(rootContainer: HostElement | string): void
+  unmount(): void
   provide<T>(key: InjectionKey<T> | string, value: T): this
 
   // internal, but we need to expose these for the server-renderer and devtools


### PR DESCRIPTION
Updated `app.unmount()` type declaration.

`unmount()` doesn't actually take in any parameters, but the type declaration claimed that it does.

close #2922
