### PR TITLE
fix(hmr): set 'component' when registerHMR

### DIFF
--- a/packages/runtime-core/src/hmr.ts
+++ b/packages/runtime-core/src/hmr.ts
@@ -56,6 +56,7 @@ export function registerHMR(instance: ComponentInternalInstance) {
     createRecord(id, instance.type as ComponentOptions)
     record = map.get(id)!
   }
+  if (!record.component) record.component = instance.type as ComponentOptions
   record.instances.add(instance)
 }
 


### PR DESCRIPTION
Since vue-loader hotReloadCode won't set this property, it will be undefined. HMR will fail.  [related commit](https://github.com/vuejs/vue-next/commit/9c23ddf9c593dcf6d20bc911ec95d9b674f23dc8#diff-ccebe74771d12151844d4d2de4cf16c6f7fb7ed6584d30964dae54a23454a942)

Or do it in vue-loader? 

https://github.com/vuejs/vue-loader/blob/6ed553f70b163031457acc961901313390cde9ef/src/hotReload.ts#L13