### PR TITLE
fix(provide): support symbols in applyOptions

### DIFF
--- a/packages/runtime-core/__tests__/apiOptions.spec.ts
+++ b/packages/runtime-core/__tests__/apiOptions.spec.ts
@@ -251,6 +251,7 @@ describe('api: options', () => {
   })
 
   test('provide/inject', () => {
+    const symbolKey = Symbol()
     const Root = defineComponent({
       data() {
         return {
@@ -259,7 +260,8 @@ describe('api: options', () => {
       },
       provide() {
         return {
-          a: this.a
+          a: this.a,
+          [symbolKey]: 2
         }
       },
       render() {
@@ -271,7 +273,9 @@ describe('api: options', () => {
           h(ChildE),
           h(ChildF),
           h(ChildG),
-          h(ChildH)
+          h(ChildH),
+          h(ChildI),
+          h(ChildJ)
         ]
       }
     })
@@ -321,7 +325,15 @@ describe('api: options', () => {
         default: () => 5
       }
     })
-    expect(renderToString(h(Root))).toBe(`11112345`)
+    const ChildI = defineChild({
+      b: symbolKey
+    })
+    const ChildJ = defineChild({
+      b: {
+        from: symbolKey
+      }
+    })
+    expect(renderToString(h(Root))).toBe(`1111234522`)
   })
 
   test('provide accessing data in extends', () => {

--- a/packages/runtime-core/src/apiInject.ts
+++ b/packages/runtime-core/src/apiInject.ts
@@ -5,7 +5,7 @@ import { warn } from './warning'
 
 export interface InjectionKey<T> extends Symbol {}
 
-export function provide<T>(key: InjectionKey<T> | string, value: T) {
+export function provide<T>(key: InjectionKey<T> | string | number, value: T) {
   if (!currentInstance) {
     if (__DEV__) {
       warn(`provide() can only be used inside setup().`)

--- a/packages/runtime-core/src/componentOptions.ts
+++ b/packages/runtime-core/src/componentOptions.ts
@@ -655,9 +655,9 @@ export function applyOptions(
       const provides = isFunction(provideOptions)
         ? provideOptions.call(publicThis)
         : provideOptions
-      for (const key in provides) {
+      Reflect.ownKeys(provides).forEach(key => {
         provide(key, provides[key])
-      }
+      })
     })
   }
 


### PR DESCRIPTION
Fixes https://github.com/vuejs/vue-next/issues/2615