### PR TITLE
fix(runtime-dom): reuse hostNode without cloning (#2623)

### DIFF
--- a/packages/runtime-dom/src/nodeOps.ts
+++ b/packages/runtime-dom/src/nodeOps.ts
@@ -47,7 +47,7 @@ export const nodeOps: Omit<RendererOptions<Node, Element>, 'patchProp'> = {
   },
 
   cloneNode(el) {
-    return el.cloneNode(true)
+    return el
   },
 
   // __UNSAFE__


### PR DESCRIPTION
This change seems to have no impact on the test results. For #2623 