### PR TITLE
fix: crashes when v-on expression is not a function (#2605)

### DIFF
--- a/packages/compiler-core/__tests__/transforms/__snapshots__/hoistStatic.spec.ts.snap
+++ b/packages/compiler-core/__tests__/transforms/__snapshots__/hoistStatic.spec.ts.snap
@@ -209,7 +209,7 @@ export function render(_ctx, _cache) {
   return (_openBlock(), _createBlock(\\"div\\", null, [
     _createVNode(\\"div\\", null, [
       _createVNode(\\"div\\", {
-        onClick: _cache[1] || (_cache[1] = (...args) => (_ctx.foo(...args)))
+        onClick: _cache[1] || (_cache[1] = (...args) => ( (() => { if (typeof _ctx.foo === 'function') { return _ctx.foo } else { console.warn('v-on expression is not a function.') return () => { } } })()(...args)))
       })
     ])
   ]))

--- a/packages/compiler-core/src/errors.ts
+++ b/packages/compiler-core/src/errors.ts
@@ -70,6 +70,7 @@ export const enum ErrorCodes {
   X_V_FOR_TEMPLATE_KEY_PLACEMENT,
   X_V_BIND_NO_EXPRESSION,
   X_V_ON_NO_EXPRESSION,
+  X_V_ON_EXPRESSION_NOT_FUNCTION,
   X_V_SLOT_UNEXPECTED_DIRECTIVE_ON_SLOT_OUTLET,
   X_V_SLOT_MIXED_SLOT_USAGE,
   X_V_SLOT_DUPLICATE_SLOT_NAMES,
@@ -144,6 +145,7 @@ export const errorMessages: { [code: number]: string } = {
   [ErrorCodes.X_V_FOR_TEMPLATE_KEY_PLACEMENT]: `<template v-for> key should be placed on the <template> tag.`,
   [ErrorCodes.X_V_BIND_NO_EXPRESSION]: `v-bind is missing expression.`,
   [ErrorCodes.X_V_ON_NO_EXPRESSION]: `v-on is missing expression.`,
+  [ErrorCodes.X_V_ON_EXPRESSION_NOT_FUNCTION]: `v-on expression is not a function.`,
   [ErrorCodes.X_V_SLOT_UNEXPECTED_DIRECTIVE_ON_SLOT_OUTLET]: `Unexpected custom directive on <slot> outlet.`,
   [ErrorCodes.X_V_SLOT_MIXED_SLOT_USAGE]:
     `Mixed v-slot usage on both the component and nested <template>.` +


### PR DESCRIPTION
Close #2605

Assert if expression is a function by wraping it into a IIFE when the expression is a Instance member, if not warning and return `NOOP`.

Which expression are instance members:
- `@blur="test"`
- `@blur="funs.test"`

I am not sure that this PR is the best solution.