### PR TITLE
fix(runtime-core): optimization the logic of setting `__props`  (close #2651)

### DIFF
--- a/packages/runtime-core/__tests__/componentEmits.spec.ts
+++ b/packages/runtime-core/__tests__/componentEmits.spec.ts
@@ -1,7 +1,13 @@
 // Note: emits and listener fallthrough is tested in
 // ./rendererAttrsFallthrough.spec.ts.
 
-import { render, defineComponent, h, nodeOps } from '@vue/runtime-test'
+import {
+  createApp,
+  render,
+  defineComponent,
+  h,
+  nodeOps
+} from '@vue/runtime-test'
 import { isEmitListener } from '../src/componentEmits'
 
 describe('component: emit', () => {
@@ -126,6 +132,37 @@ describe('component: emit', () => {
     expect(
       `Component emitted event "bar" but it is neither declared`
     ).toHaveBeenWarned()
+  })
+
+  // #2651
+  test('should not warning if app mixin an empty object', () => {
+    const Foo = defineComponent({
+      props: ['modelValue'],
+      render() {},
+      created() {
+        // @ts-ignore
+        this.$emit('update:modelValue')
+      }
+    })
+
+    const Root = defineComponent({
+      components: {
+        Foo
+      },
+      render() {
+        return h('div', [h(Foo)])
+      }
+    })
+
+    const app = createApp(Root)
+    app.mixin({})
+
+    const root = nodeOps.createElement('div')
+    app.mount(root)
+
+    expect(
+      `Component emitted event "update:modelValue" but it is neither declared`
+    ).not.toHaveBeenWarned()
   })
 
   test('should not warn if has equivalent onXXX prop', () => {

--- a/packages/runtime-core/src/apiCreateApp.ts
+++ b/packages/runtime-core/src/apiCreateApp.ts
@@ -176,6 +176,11 @@ export function createAppAPI<HostElement>(
 
       mixin(mixin: ComponentOptions) {
         if (__FEATURE_OPTIONS_API__) {
+          // #2651
+          if (Object.keys(mixin).length === 0) {
+            return app
+          }
+
           if (!context.mixins.includes(mixin)) {
             context.mixins.push(mixin)
             // global mixin with props/emits de-optimizes props/emits

--- a/packages/runtime-core/src/apiCreateApp.ts
+++ b/packages/runtime-core/src/apiCreateApp.ts
@@ -176,11 +176,6 @@ export function createAppAPI<HostElement>(
 
       mixin(mixin: ComponentOptions) {
         if (__FEATURE_OPTIONS_API__) {
-          // // #2651
-          // if (Object.keys(mixin).length === 0) {
-          //   return app
-          // }
-
           if (!context.mixins.includes(mixin)) {
             context.mixins.push(mixin)
             // global mixin with props/emits de-optimizes props/emits

--- a/packages/runtime-core/src/apiCreateApp.ts
+++ b/packages/runtime-core/src/apiCreateApp.ts
@@ -176,10 +176,10 @@ export function createAppAPI<HostElement>(
 
       mixin(mixin: ComponentOptions) {
         if (__FEATURE_OPTIONS_API__) {
-          // #2651
-          if (Object.keys(mixin).length === 0) {
-            return app
-          }
+          // // #2651
+          // if (Object.keys(mixin).length === 0) {
+          //   return app
+          // }
 
           if (!context.mixins.includes(mixin)) {
             context.mixins.push(mixin)

--- a/packages/runtime-core/src/componentEmits.ts
+++ b/packages/runtime-core/src/componentEmits.ts
@@ -188,8 +188,9 @@ export function normalizeEmitsOptions(
   } else {
     extend(normalized, raw)
   }
-  // #2651 if raw is undefined should return null
-  return (comp.__emits = raw ? normalized : null)
+  // #2651 if normalized is empty should return null
+  return (comp.__emits =
+    Object.keys(normalized).length === 0 ? null : normalized)
 }
 
 // Check if an incoming prop key is a declared emit event listener.

--- a/packages/runtime-core/src/componentEmits.ts
+++ b/packages/runtime-core/src/componentEmits.ts
@@ -188,7 +188,7 @@ export function normalizeEmitsOptions(
   } else {
     extend(normalized, raw)
   }
-  return (comp.__emits = normalized)
+  return (comp.__emits = raw ? normalized : null)
 }
 
 // Check if an incoming prop key is a declared emit event listener.

--- a/packages/runtime-core/src/componentEmits.ts
+++ b/packages/runtime-core/src/componentEmits.ts
@@ -169,7 +169,11 @@ export function normalizeEmitsOptions(
       extend(normalized, normalizeEmitsOptions(raw, appContext, true))
     }
     if (!asMixin && appContext.mixins.length) {
-      appContext.mixins.forEach(extendEmits)
+      appContext.mixins.forEach(raw => {
+        if (Object.keys(raw).length) {
+          extendEmits(raw)
+        }
+      })
     }
     if (comp.extends) {
       extendEmits(comp.extends)
@@ -188,9 +192,7 @@ export function normalizeEmitsOptions(
   } else {
     extend(normalized, raw)
   }
-  // #2651 if normalized is empty and !raw should return null
-  return (comp.__emits =
-    !Object.keys(normalized).length && !raw ? null : normalized)
+  return (comp.__emits = normalized)
 }
 
 // Check if an incoming prop key is a declared emit event listener.

--- a/packages/runtime-core/src/componentEmits.ts
+++ b/packages/runtime-core/src/componentEmits.ts
@@ -188,6 +188,7 @@ export function normalizeEmitsOptions(
   } else {
     extend(normalized, raw)
   }
+  // #2651 if raw is undefined should return null
   return (comp.__emits = raw ? normalized : null)
 }
 

--- a/packages/runtime-core/src/componentEmits.ts
+++ b/packages/runtime-core/src/componentEmits.ts
@@ -190,7 +190,7 @@ export function normalizeEmitsOptions(
   }
   // #2651 if normalized is empty should return null
   return (comp.__emits =
-    Object.keys(normalized).length === 0 ? null : normalized)
+    !Object.keys(normalized).length && !raw ? null : normalized)
 }
 
 // Check if an incoming prop key is a declared emit event listener.

--- a/packages/runtime-core/src/componentEmits.ts
+++ b/packages/runtime-core/src/componentEmits.ts
@@ -188,7 +188,7 @@ export function normalizeEmitsOptions(
   } else {
     extend(normalized, raw)
   }
-  // #2651 if normalized is empty should return null
+  // #2651 if normalized is empty and !raw should return null
   return (comp.__emits =
     !Object.keys(normalized).length && !raw ? null : normalized)
 }

--- a/packages/runtime-core/src/componentProps.ts
+++ b/packages/runtime-core/src/componentProps.ts
@@ -378,7 +378,7 @@ export function normalizePropsOptions(
   }
 
   if (!raw && !hasExtends) {
-    return (comp.__props = EMPTY_ARR as any)
+    return EMPTY_ARR as any
   }
 
   if (isArray(raw)) {


### PR DESCRIPTION
close #2651

if `app.mixin({})` called, app.mixins will be `[{}]` .
It will become `[{__props:[]}]` after `normalizePropsOptions` called.