### PR TITLE
types(runtime-core): apiWatch with multiple sources

### DIFF
--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -244,7 +244,7 @@ Test coverage is continuously deployed at https://vue-next-coverage.netlify.app/
 
 This project uses [tsd](https://github.com/SamVerschueren/tsd) to test the built definition files (`*.d.ts`).
 
-Type tests are located in the `test-dts` directory. To run the dts tests, run `yarn test-dts`. Note that the type test requires all relevant `*.d.ts` files to be built first (and the script does it for you). Once the `d.ts` files are built and up-to-date, the tests can be re-run by simply running `yarn test-dts`.
+Type tests are located in the `test-dts` directory. To run the dts tests, run `yarn test-dts`. Note that the type test requires all relevant `*.d.ts` files to be built first (and the script does it for you). Once the `d.ts` files are built and up-to-date, the tests can be re-run by simply running `yarn test-dts-only`.
 
 ## Financial Contribution
 

--- a/packages/runtime-core/src/apiWatch.ts
+++ b/packages/runtime-core/src/apiWatch.ts
@@ -86,7 +86,7 @@ export function watch<
   T extends Readonly<Array<WatchSource<unknown> | object>>,
   Immediate extends Readonly<boolean> = false
 >(
-  sources: T,
+  sources: Readonly<[...T]>,
   cb: WatchCallback<MapSources<T, false>, MapSources<T, Immediate>>,
   options?: WatchOptions<Immediate>
 ): WatchStopHandle

--- a/test-dts/watch.test-d.ts
+++ b/test-dts/watch.test-d.ts
@@ -10,12 +10,13 @@ watch(source, (value, oldValue) => {
   expectType<string>(oldValue)
 })
 
+// const array and normal array will be treated equally
 watch([source, source2, source3], (values, oldValues) => {
-  expectType<(string | number)[]>(values)
-  expectType<(string | number)[]>(oldValues)
+  expectType<[string, string, number]>(values)
+  expectType<[string, string, number]>(oldValues)
 })
 
-// const array
+// const array and normal array will be treated equally
 watch([source, source2, source3] as const, (values, oldValues) => {
   expectType<Readonly<[string, string, number]>>(values)
   expectType<Readonly<[string, string, number]>>(oldValues)
@@ -34,13 +35,15 @@ watch(
 watch(
   [source, source2, source3],
   (values, oldValues) => {
-    expectType<(string | number)[]>(values)
-    expectType<(string | number | undefined)[]>(oldValues)
+    expectType<[string, string, number]>(values)
+    expectType<[string | undefined, string | undefined, number | undefined]>(
+      oldValues
+    )
   },
   { immediate: true }
 )
 
-// const array
+// const array and normal array will be treated equally
 watch(
   [source, source2, source3] as const,
   (values, oldValues) => {


### PR DESCRIPTION
This is a pull request following up on issue #2655, suggesting to adjust the type definition of `watch` when the input is an array. Also in `contributing.md` the correct script to re-run tests for type definitions should be `yarn test-dts-only`, no?

closes #2655 