### PR TITLE
fix(runtime-dom): the original array should be manipulated when checkbox binds the array value

### DIFF
--- a/packages/runtime-dom/src/directives/vModel.ts
+++ b/packages/runtime-dom/src/directives/vModel.ts
@@ -111,11 +111,9 @@ export const vModelCheckbox: ModelDirective<HTMLInputElement> = {
         const index = looseIndexOf(modelValue, elementValue)
         const found = index !== -1
         if (checked && !found) {
-          assign(modelValue.concat(elementValue))
+          modelValue.push(elementValue)
         } else if (!checked && found) {
-          const filtered = [...modelValue]
-          filtered.splice(index, 1)
-          assign(filtered)
+          modelValue.splice(index, 1)
         }
       } else if (isSet(modelValue)) {
         if (checked) {


### PR DESCRIPTION
close: #2662 

According to the current behavior, if we bind a value of type `Set`, then the original `Set` will already be manipulated, so I think it is ok to manipulate the original array here.