### PR TITLE
fix(types): extract the correct props type for the DateConstructor

### DIFF
--- a/packages/runtime-core/src/componentProps.ts
+++ b/packages/runtime-core/src/componentProps.ts
@@ -97,7 +97,9 @@ type InferPropType<T> = T extends null
       ? Record<string, any>
       : T extends BooleanConstructor | { type: BooleanConstructor }
         ? boolean
-        : T extends Prop<infer V, infer D> ? (unknown extends V ? D : V) : T
+        : T extends DateConstructor | { type: DateConstructor }
+          ? Date
+          : T extends Prop<infer V, infer D> ? (unknown extends V ? D : V) : T
 
 export type ExtractPropTypes<O> = O extends object
   ? { [K in RequiredKeys<O>]: InferPropType<O[K]> } &

--- a/test-dts/defineComponent.test-d.tsx
+++ b/test-dts/defineComponent.test-d.tsx
@@ -34,6 +34,7 @@ describe('with object props', () => {
     ggg: 'foo' | 'bar'
     ffff: (a: number, b: string) => { a: boolean }
     validated?: string
+    date?: Date
   }
 
   type GT = string & { __brand: unknown }
@@ -103,7 +104,8 @@ describe('with object props', () => {
         type: String,
         // validator requires explicit annotation
         validator: (val: unknown) => val !== ''
-      }
+      },
+      date: Date
     },
     setup(props) {
       // type assertion. See https://github.com/SamVerschueren/tsd
@@ -125,6 +127,7 @@ describe('with object props', () => {
       expectType<ExpectedProps['ggg']>(props.ggg)
       expectType<ExpectedProps['ffff']>(props.ffff)
       expectType<ExpectedProps['validated']>(props.validated)
+      expectType<ExpectedProps['date']>(props.date)
 
       // @ts-expect-error props should be readonly
       expectError((props.a = 1))


### PR DESCRIPTION
close: #2668 

The reason is in the definition of `DateConstructor`:

```ts
interface DateConstructor {
    ...
    (): string;
    ...
}
```

For simplicity, we can just create a new judgment branch to deal with it.

