### PR TITLE
fix(runtime-dom): skip set transitionProperty if has no cachedTransition

### DIFF
--- a/packages/runtime-dom/src/components/Transition.ts
+++ b/packages/runtime-dom/src/components/Transition.ts
@@ -163,9 +163,13 @@ export function resolveTransitionProps(
       // the transition starts. This is applied for enter transition as well
       // so that it accounts for `visibility: hidden` cases.
       const cachedTransition = (el as HTMLElement).style.transitionProperty
-      ;(el as HTMLElement).style.transitionProperty = 'none'
+      if (cachedTransition) {
+        ;(el as HTMLElement).style.transitionProperty = 'none'
+      }
       nextFrame(() => {
-        ;(el as HTMLElement).style.transitionProperty = cachedTransition
+        if (cachedTransition) {
+          ;(el as HTMLElement).style.transitionProperty = cachedTransition
+        }
         removeTransitionClass(el, leaveFromClass)
         addTransitionClass(el, leaveToClass)
         if (!(onLeave && onLeave.length > 1)) {


### PR DESCRIPTION
close #2712