### PR TITLE
fix(compiler-sfc): removeSpecifier issue when removing initial imports (script-setup)

### DIFF
--- a/packages/compiler-sfc/__tests__/__snapshots__/compileScript.spec.ts.snap
+++ b/packages/compiler-sfc/__tests__/__snapshots__/compileScript.spec.ts.snap
@@ -164,6 +164,25 @@ return { x }
 }"
 `;
 
+exports[`SFC compile <script setup> imports should allow defineProps/Emit at the start of imports 1`] = `
+"import { ref } from 'vue'
+      
+export default {
+  expose: [],
+  props: ['foo'],
+  emits: ['bar'],
+  setup(__props) {
+
+      
+      
+      const r = ref(0)
+      
+return { r, ref }
+}
+
+}"
+`;
+
 exports[`SFC compile <script setup> imports should extract comment for import or type declarations 1`] = `
 "import a from 'a' // comment
         import b from 'b'

--- a/packages/compiler-sfc/__tests__/compileScript.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileScript.spec.ts
@@ -141,6 +141,17 @@ const myEmit = defineEmit(['foo', 'bar'])
       )
     })
 
+    test('should allow defineProps/Emit at the start of imports', () => {
+      assertCode(
+        compile(`<script setup>
+      import { defineProps, defineEmit, ref } from 'vue'
+      defineProps(['foo'])
+      defineEmit(['bar'])
+      const r = ref(0)
+      </script>`).content
+      )
+    })
+
     test('dedupe between user & helper', () => {
       const { content } = compile(`
       <script setup>

--- a/packages/compiler-sfc/__tests__/compileScript.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileScript.spec.ts
@@ -141,6 +141,7 @@ const myEmit = defineEmit(['foo', 'bar'])
       )
     })
 
+    // #2740
     test('should allow defineProps/Emit at the start of imports', () => {
       assertCode(
         compile(`<script setup>


### PR DESCRIPTION
Fixes an issue with `removeSpecifier` in `compilerScript.ts` when there are several initial imports removed.

```ts
import { defineProps, defineEmit, ref } from 'vue'
```
was being compiled to
```ts
import { , ref } from 'vue'
```

Adds a test case in `compileScript.spec.ts`