### PR TITLE
fix(runtime-core/scheduler): should also flush the preFlushCbs when needed

### DIFF
--- a/packages/runtime-core/__tests__/scheduler.spec.ts
+++ b/packages/runtime-core/__tests__/scheduler.spec.ts
@@ -134,6 +134,22 @@ describe('scheduler', () => {
       await nextTick()
       expect(calls).toEqual(['cb1', 'cb2'])
     })
+
+    it('queuePreFlushCb inside postFlushCbs', async () => {
+      const calls: string[] = []
+      const job1 = () => {
+        calls.push('job1')
+      }
+      const cb1 = () => {
+        // queuePreFlushCb in postFlushCbs
+        calls.push('cb1')
+        queuePreFlushCb(job1)
+      }
+
+      queuePostFlushCb(cb1)
+      await nextTick()
+      expect(calls).toEqual(['cb1', 'job1'])
+    })
   })
 
   describe('queueJob w/ queuePreFlushCb', () => {

--- a/packages/runtime-core/src/scheduler.ts
+++ b/packages/runtime-core/src/scheduler.ts
@@ -227,7 +227,11 @@ function flushJobs(seen?: CountMap) {
     currentFlushPromise = null
     // some postFlushCb queued jobs!
     // keep flushing until it drains.
-    if (queue.length || pendingPostFlushCbs.length) {
+    if (
+      queue.length ||
+      pendingPostFlushCbs.length ||
+      pendingPreFlushCbs.length
+    ) {
       flushJobs(seen)
     }
   }


### PR DESCRIPTION
close: #2730 