### PR TITLE
fix(runtime-core): check the DEV_ROOT_FRAGMENT flag correctly in the dev environment

### DIFF
--- a/packages/runtime-core/src/componentRenderUtils.ts
+++ b/packages/runtime-core/src/componentRenderUtils.ts
@@ -119,7 +119,11 @@ export function renderComponentRoot(
     // to have comments along side the root element which makes it a fragment
     let root = result
     let setRoot: ((root: VNode) => void) | undefined = undefined
-    if (__DEV__ && result.patchFlag & PatchFlags.DEV_ROOT_FRAGMENT) {
+    if (
+      __DEV__ &&
+      result.patchFlag > 0 &&
+      result.patchFlag & PatchFlags.DEV_ROOT_FRAGMENT
+    ) {
       ;[root, setRoot] = getChildRoot(result)
     }
 


### PR DESCRIPTION
close: #2741 , #3133
According to #2741 , I think he should not use `renderSlot` directly, but the cause of the problem lies in:
```js
result.patchFlag & PatchFlags.DEV_ROOT_FRAGMENT
```
When `result.patchFlag` is negative(e.g. `-2` BAIL), this condition is always true.