### PR TITLE
fix(runtime-core): ensure computed has a value when applyOptions

### DIFF
--- a/packages/runtime-core/src/component.ts
+++ b/packages/runtime-core/src/component.ts
@@ -669,6 +669,7 @@ function finishComponentSetup(
 ) {
   const Component = instance.type as ComponentOptions
 
+  // #2791
   if (!Component.computed) {
     Component.computed = Object.create(null)
   }

--- a/packages/runtime-core/src/component.ts
+++ b/packages/runtime-core/src/component.ts
@@ -669,6 +669,10 @@ function finishComponentSetup(
 ) {
   const Component = instance.type as ComponentOptions
 
+  if (!Component.computed) {
+    Component.computed = Object.create(null)
+  }
+
   // template / render function normalization
   if (__NODE_JS__ && isSSR) {
     if (Component.render) {


### PR DESCRIPTION
close #2791.
if `computed` is not has a value. the `options ` is not updated when `this.$options` has changed.
I'm not sure if this is the best way.