### PR TITLE
fix(compiler-sfc): avoid bindings metadata for css vars in normal script

### DIFF
--- a/packages/compiler-sfc/__tests__/__snapshots__/cssVars.spec.ts.snap
+++ b/packages/compiler-sfc/__tests__/__snapshots__/cssVars.spec.ts.snap
@@ -109,3 +109,32 @@ return { color, size, ref }
 
 }"
 `;
+
+exports[`CSS vars injection w/ <script> do not use binding analysis 1`] = `
+"
+        import { ref } from 'vue'
+        const __default__ = {
+          props: {
+            foo: String
+          },
+          setup() {
+            const color = 'red'
+            const size = ref('10px')
+            return { color, size }
+          }
+        }
+        
+import { useCssVars as _useCssVars } from 'vue'
+const __injectCSSVars__ = () => {
+_useCssVars(_ctx => ({
+  \\"xxxxxxxx-color\\": (_ctx.color),
+  \\"xxxxxxxx-size\\": (_ctx.size),
+  \\"xxxxxxxx-foo\\": (_ctx.foo)
+}))}
+const __setup__ = __default__.setup
+__default__.setup = __setup__
+  ? (props, ctx) => { __injectCSSVars__();return __setup__(props, ctx) }
+  : __injectCSSVars__
+
+export default __default__"
+`;

--- a/packages/compiler-sfc/src/compileScript.ts
+++ b/packages/compiler-sfc/src/compileScript.ts
@@ -127,7 +127,6 @@ export function compileScript(
         if (cssVars.length) {
           content += genNormalScriptCssVarsCode(
             cssVars,
-            bindings,
             scopeId,
             !!options.isProd
           )
@@ -828,9 +827,9 @@ export function compileScript(
       startOffset,
       `\n${genCssVarsCode(
         cssVars,
-        bindingMetadata,
         scopeId,
-        !!options.isProd
+        !!options.isProd,
+        bindingMetadata
       )}\n`
     )
   }

--- a/packages/compiler-sfc/src/cssVars.ts
+++ b/packages/compiler-sfc/src/cssVars.ts
@@ -66,16 +66,16 @@ export const cssVarsPlugin = postcss.plugin<CssVarsPluginOptions>(
 
 export function genCssVarsCode(
   vars: string[],
-  bindings: BindingMetadata,
   id: string,
-  isProd: boolean
+  isProd: boolean,
+  bindings?: BindingMetadata
 ) {
   const varsExp = genCssVarsFromList(vars, id, isProd)
   const exp = createSimpleExpression(varsExp, false)
   const context = createTransformContext(createRoot([]), {
     prefixIdentifiers: true,
-    inline: true,
-    bindingMetadata: bindings
+    inline: !!bindings,
+    bindingMetadata: bindings || {}
   })
   const transformed = processExpression(exp, context)
   const transformedString =
@@ -96,7 +96,6 @@ export function genCssVarsCode(
 // this is only for single normal <script>
 export function genNormalScriptCssVarsCode(
   cssVars: string[],
-  bindings: BindingMetadata,
   id: string,
   isProd: boolean
 ): string {
@@ -104,7 +103,6 @@ export function genNormalScriptCssVarsCode(
     `\nimport { ${CSS_VARS_HELPER} as _${CSS_VARS_HELPER} } from 'vue'\n` +
     `const __injectCSSVars__ = () => {\n${genCssVarsCode(
       cssVars,
-      bindings,
       id,
       isProd
     )}}\n` +


### PR DESCRIPTION
For normal <script>, the bindings metadata was being forwarded to `genCssVarsCode` and from there to `processExpression` together with `inline: true` option. For the test case added in this PR, the result was:
```js
_useCssVars(_ctx => ({
  "xxxxxxxx-color": (color),
  "xxxxxxxx-size": (size.value),
  "xxxxxxxx-foo": (__props.foo)
})
```
This is what is expected for inline mode inside setup, for normal script only _ctx is available. Using `inline: false` together with forwarded bindings generates instead:
```js
_useCssVars(_ctx => ({
  "xxxxxxxx-color": ($setup.color),
  "xxxxxxxx-size": ($setup.size),
  "xxxxxxxx-foo": ($props.foo)
})
```
I think this may be what was intended, but I am unsure if the `useCssVars` callback should be extended with `$setup` and `$props`. For the moment, this PR fixes the issue by falling back to always use `_ctx` by avoiding forwarding the binding metadata to `genCssVarsCode` for normal scripts (and in that case, also using `inline: false` for `processExpression` resulting in:
```js
_useCssVars(_ctx => ({
  "xxxxxxxx-color": (_ctx.color),
  "xxxxxxxx-size": (_ctx.size),
  "xxxxxxxx-foo": (_ctx.foo)
})
```