### PR TITLE
fix(compiler-sfc): duplicated injected css var with repeated vars

### DIFF
--- a/packages/compiler-sfc/__tests__/__snapshots__/cssVars.spec.ts.snap
+++ b/packages/compiler-sfc/__tests__/__snapshots__/cssVars.spec.ts.snap
@@ -66,6 +66,25 @@ return { color }
 }"
 `;
 
+exports[`CSS vars injection codegen w/ <script setup> using the same var multiple times 1`] = `
+"import { useCssVars as _useCssVars, unref as _unref } from 'vue'
+
+export default {
+  expose: [],
+  setup(__props) {
+
+_useCssVars(_ctx => ({
+  \\"xxxxxxxx-color\\": (color)
+}))
+
+        const color = 'red'
+        
+return { color }
+}
+
+}"
+`;
+
 exports[`CSS vars injection generating correct code for nested paths 1`] = `
 "const a = 1
 const __default__ = {}

--- a/packages/compiler-sfc/__tests__/cssVars.spec.ts
+++ b/packages/compiler-sfc/__tests__/cssVars.spec.ts
@@ -136,5 +136,26 @@ describe('CSS vars injection', () => {
         ).content
       )
     })
+
+    test('w/ <script setup> using the same var multiple times', () => {
+      const { content } = compileSFCScript(
+        `<script setup>
+        const color = 'red'
+        </script>\n` +
+          `<style>
+          div {
+            color: v-bind(color);
+          }
+          p {
+            color: v-bind(color);
+          }
+        </style>`
+      )
+      // color should only be injected once, even if it is twice in style
+      expect(content).toMatch(`_useCssVars(_ctx => ({
+  "${mockId}-color": (color)
+})`)
+      assertCode(content)
+    })
   })
 })

--- a/packages/compiler-sfc/src/cssVars.ts
+++ b/packages/compiler-sfc/src/cssVars.ts
@@ -37,7 +37,10 @@ export function parseCssVars(sfc: SFCDescriptor): string[] {
   sfc.styles.forEach(style => {
     let match
     while ((match = cssVarRE.exec(style.content))) {
-      vars.push(match[1] || match[2] || match[3])
+      const variable = match[1] || match[2] || match[3]
+      if (!vars.includes(variable)) {
+        vars.push(variable)
+      }
     }
   })
   return vars


### PR DESCRIPTION
When the same css var was used multiple times in <style>, that var was injected several times in the <script>

For the added test case it was generating
```js
_useCssVars(_ctx => ({
  "xxxxxxxx-color": (color),
  "xxxxxxxx-color": (color)
}))
```
This PR removes duplicated vars in `parseCssVars` so we get
```js
_useCssVars(_ctx => ({
  "xxxxxxxx-color": (color)
}))
```