### PR TITLE
fix(runtime-dom): use `setAttribute` to set DOM prop

### DIFF
--- a/packages/runtime-dom/__tests__/patchProps.spec.ts
+++ b/packages/runtime-dom/__tests__/patchProps.spec.ts
@@ -93,18 +93,6 @@ describe('runtime-dom: props patching', () => {
     expect(el.srcObject).toBe(initialValue)
   })
 
-  test('catch and warn prop set TypeError', () => {
-    const el = document.createElement('div')
-    Object.defineProperty(el, 'someProp', {
-      set() {
-        throw new TypeError('Invalid type')
-      }
-    })
-    patchProp(el, 'someProp', null, 'foo')
-
-    expect(`Failed setting prop "someProp" on <div>`).toHaveBeenWarnedLast()
-  })
-
   // #1576
   test('remove attribute when value is falsy', () => {
     const el = document.createElement('div')

--- a/packages/runtime-dom/src/modules/props.ts
+++ b/packages/runtime-dom/src/modules/props.ts
@@ -34,8 +34,8 @@ export function patchDOMProp(
     return
   }
 
+  const type = typeof el[key]
   if (value === '' || value == null) {
-    const type = typeof el[key]
     if (type === 'boolean') {
       // e.g. <select multiple> compiles to { multiple: '' } or { multiple: false }
       el[key] = value != null
@@ -53,5 +53,9 @@ export function patchDOMProp(
     }
   }
 
-  el.setAttribute(key, value)
+  if (type === 'function') {
+    el[key] = value
+  } else {
+    el.setAttribute(key, value)
+  }
 }

--- a/packages/runtime-dom/src/modules/props.ts
+++ b/packages/runtime-dom/src/modules/props.ts
@@ -2,8 +2,6 @@
 // Reason: potentially setting innerHTML.
 // This can come from explicit usage of v-html or innerHTML as a prop in render
 
-import { warn } from '@vue/runtime-core'
-
 // functions. The user is responsible for using them with only trusted content.
 export function patchDOMProp(
   el: any,
@@ -38,9 +36,9 @@ export function patchDOMProp(
 
   if (value === '' || value == null) {
     const type = typeof el[key]
-    if (value === '' && type === 'boolean') {
-      // e.g. <select multiple> compiles to { multiple: '' }
-      el[key] = true
+    if (type === 'boolean') {
+      // e.g. <select multiple> compiles to { multiple: '' } or { multiple: false }
+      el[key] = value != null
       return
     } else if (value == null && type === 'string') {
       // e.g. <div :id="null">
@@ -55,16 +53,5 @@ export function patchDOMProp(
     }
   }
 
-  // some properties perform value validation and throw
-  try {
-    el[key] = value
-  } catch (e) {
-    if (__DEV__) {
-      warn(
-        `Failed setting prop "${key}" on <${el.tagName.toLowerCase()}>: ` +
-          `value ${value} is invalid.`,
-        e
-      )
-    }
-  }
+  el.setAttribute(key, value)
 }


### PR DESCRIPTION
close #2801 
I don't know why not use setAttribute here,Is there any special reason?
and why should warn prop set TypeError?