### PR TITLE
fix(runtime-core): render the empty string as a comment to avoid hydrate failure during SSR

### DIFF
--- a/packages/runtime-core/__tests__/hydration.spec.ts
+++ b/packages/runtime-core/__tests__/hydration.spec.ts
@@ -53,6 +53,16 @@ describe('SSR hydration', () => {
     expect(vnode.el.nodeType).toBe(8) // comment
   })
 
+  test('empty string', async () => {
+    const Comp = { render: () => '' }
+    const { vnode, container } = mountWithHydration('<div><!----></div>', () =>
+      h('div', h(Comp))
+    )
+    expect(vnode.el).toBe(container.firstChild)
+    expect(vnode.el.childNodes.length).toBe(1)
+    expect(vnode.el.childNodes[0].nodeType).toBe(8) // comment
+  })
+
   test('static', () => {
     const html = '<div><span>hello</span></div>'
     const { vnode, container } = mountWithHydration(html, () =>

--- a/packages/runtime-core/src/vnode.ts
+++ b/packages/runtime-core/src/vnode.ts
@@ -561,7 +561,10 @@ export function normalizeVNode(child: VNodeChild): VNode {
     return child.el === null ? child : cloneVNode(child)
   } else {
     // strings and numbers
-    return createVNode(Text, null, String(child))
+    // render the empty string as a comment to avoid hydrate failure during SSR
+    return child === ''
+      ? createVNode(Comment)
+      : createVNode(Text, null, String(child))
   }
 }
 


### PR DESCRIPTION
When a component just renders an empty string:

```js
const Comp = { render: () => '' }
```

the ssr result is: **nothing**

the client rendering result is: **Text Node**

This causes hydration failure, it can be reproduced with the test case shown below:

```js
  test('empty string', async () => {
    const Comp = { render: () => '' }
    // hydration failure
    mountWithHydration('<div></div>', () =>
      h('div', h(Comp))
    )
  })
```