### PR TITLE
fix(runtime-core): schedulerJob skip correctly

### DIFF
--- a/packages/runtime-core/__tests__/scheduler.spec.ts
+++ b/packages/runtime-core/__tests__/scheduler.spec.ts
@@ -373,19 +373,24 @@ describe('scheduler', () => {
     }
     const job3 = () => {
       calls.push('job3')
+      invalidateJob(job1)
     }
     const job4 = () => {
       calls.push('job4')
+    }
+    const job5 = () => {
+      calls.push('job5')
     }
     // queue all jobs
     queueJob(job1)
     queueJob(job2)
     queueJob(job3)
-    queuePostFlushCb(job4)
+    queueJob(job4)
+    queuePostFlushCb(job5)
     expect(calls).toEqual([])
     await nextTick()
     // job2 should be called only once
-    expect(calls).toEqual(['job1', 'job2', 'job3', 'job4'])
+    expect(calls).toEqual(['job1', 'job2', 'job3', 'job4', 'job5'])
   })
 
   test('sort job based on id', async () => {

--- a/packages/runtime-core/src/scheduler.ts
+++ b/packages/runtime-core/src/scheduler.ts
@@ -86,6 +86,7 @@ function queueFlush() {
 
 export function invalidateJob(job: SchedulerJob) {
   const i = queue.indexOf(job)
+  // skip job if it's not flush yet
   if (i > flushIndex) {
     queue.splice(i, 1)
   }

--- a/packages/runtime-core/src/scheduler.ts
+++ b/packages/runtime-core/src/scheduler.ts
@@ -86,7 +86,7 @@ function queueFlush() {
 
 export function invalidateJob(job: SchedulerJob) {
   const i = queue.indexOf(job)
-  if (i > -1) {
+  if (i > flushIndex) {
     queue.splice(i, 1)
   }
 }


### PR DESCRIPTION
close #2768 
close #2829
caused by this https://github.com/vuejs/vue-next/commit/af9560455d9719a4c5f0d6588d04bfb4c06c8654

after `queue.splice(i,1)` in `invalidateJob`,the length of `queue` will change, resulting in incomplete job execution in `flushJobs`