### PR TITLE
fix(reactivity): ensure that shallow and normal proxies are tracked seperately (close #2843)

### DIFF
--- a/packages/reactivity/__tests__/readonly.spec.ts
+++ b/packages/reactivity/__tests__/readonly.spec.ts
@@ -1,7 +1,6 @@
 import {
   reactive,
   readonly,
-  shallowReadonly,
   toRaw,
   isReactive,
   isReadonly,
@@ -454,24 +453,5 @@ describe('reactivity/readonly', () => {
     expect(
       'Set operation on key "randomProperty" failed: target is readonly.'
     ).toHaveBeenWarned()
-  })
-
-  // to retain 2.x behavior.
-  test('should NOT make nested properties readonly', () => {
-    const props = shallowReadonly({ n: { foo: 1 } })
-    // @ts-ignore
-    props.n.foo = 2
-    expect(props.n.foo).toBe(2)
-    expect(
-      `Set operation on key "foo" failed: target is readonly.`
-    ).not.toHaveBeenWarned()
-  })
-
-  test('should allow shallow und normal reactive for same target', () => {
-    const target = { foo: 1 }
-    const shallowProxy = shallowReadonly(target)
-    const normalProxy = readonly(target)
-
-    expect(normalProxy).not.toBe(shallowProxy)
   })
 })

--- a/packages/reactivity/__tests__/readonly.spec.ts
+++ b/packages/reactivity/__tests__/readonly.spec.ts
@@ -1,6 +1,7 @@
 import {
   reactive,
   readonly,
+  shallowReadonly,
   toRaw,
   isReactive,
   isReadonly,
@@ -453,5 +454,24 @@ describe('reactivity/readonly', () => {
     expect(
       'Set operation on key "randomProperty" failed: target is readonly.'
     ).toHaveBeenWarned()
+  })
+
+  // to retain 2.x behavior.
+  test('should NOT make nested properties readonly', () => {
+    const props = shallowReadonly({ n: { foo: 1 } })
+    // @ts-ignore
+    props.n.foo = 2
+    expect(props.n.foo).toBe(2)
+    expect(
+      `Set operation on key "foo" failed: target is readonly.`
+    ).not.toHaveBeenWarned()
+  })
+
+  test('should allow shallow und normal reactive for same target', () => {
+    const target = { foo: 1 }
+    const shallowProxy = shallowReadonly(target)
+    const normalProxy = readonly(target)
+
+    expect(normalProxy).not.toBe(shallowProxy)
   })
 })

--- a/packages/reactivity/__tests__/shallowReactive.spec.ts
+++ b/packages/reactivity/__tests__/shallowReactive.spec.ts
@@ -14,12 +14,14 @@ describe('shallowReactive', () => {
     expect(isReactive(props.n)).toBe(true)
   })
 
-  test('should allow shallow und normal reactive for same target', () => {
-    const target = { foo: 1 }
-    const shallowProxy = shallowReactive(target)
-    const normalProxy = reactive(target)
-
-    expect(normalProxy).not.toBe(shallowProxy)
+  // #2843
+  test('should allow shallow und normal reactive for same target', async () => {
+    const original = { foo: {} }
+    const shallowProxy = shallowReactive(original)
+    const reactiveProxy = reactive(original)
+    expect(shallowProxy).not.toBe(reactiveProxy)
+    expect(isReactive(shallowProxy.foo)).toBe(false)
+    expect(isReactive(reactiveProxy.foo)).toBe(true)
   })
 
   describe('collections', () => {

--- a/packages/reactivity/__tests__/shallowReactive.spec.ts
+++ b/packages/reactivity/__tests__/shallowReactive.spec.ts
@@ -1,4 +1,5 @@
-import { shallowReactive, isReactive, reactive } from '../src/reactive'
+import { isReactive, reactive, shallowReactive } from '../src/reactive'
+
 import { effect } from '../src/effect'
 
 describe('shallowReactive', () => {
@@ -11,6 +12,14 @@ describe('shallowReactive', () => {
     const props: any = shallowReactive({ n: reactive({ foo: 1 }) })
     props.n = reactive({ foo: 2 })
     expect(isReactive(props.n)).toBe(true)
+  })
+
+  test('should allow shallow und normal reactive for same target', () => {
+    const target = { foo: 1 }
+    const shallowProxy = shallowReactive(target)
+    const normalProxy = reactive(target)
+
+    expect(normalProxy).not.toBe(shallowProxy)
   })
 
   describe('collections', () => {

--- a/packages/reactivity/__tests__/shallowReadonly.spec.ts
+++ b/packages/reactivity/__tests__/shallowReadonly.spec.ts
@@ -1,4 +1,4 @@
-import { isReactive, isReadonly, shallowReadonly } from '../src'
+import { isReactive, isReadonly, readonly, shallowReadonly } from '../src'
 
 describe('reactivity/shallowReadonly', () => {
   test('should not make non-reactive properties reactive', () => {
@@ -25,6 +25,16 @@ describe('reactivity/shallowReadonly', () => {
     expect(
       `Set operation on key "foo" failed: target is readonly.`
     ).not.toHaveBeenWarned()
+  })
+
+  // #2843
+  test('should differentiate from normal readonly calls', async () => {
+    const original = { foo: {} }
+    const shallowProxy = shallowReadonly(original)
+    const reactiveProxy = readonly(original)
+    expect(shallowProxy).not.toBe(reactiveProxy)
+    expect(isReadonly(shallowProxy.foo)).toBe(false)
+    expect(isReadonly(reactiveProxy.foo)).toBe(true)
   })
 
   describe('collection/Map', () => {

--- a/packages/reactivity/src/baseHandlers.ts
+++ b/packages/reactivity/src/baseHandlers.ts
@@ -5,7 +5,9 @@ import {
   ReactiveFlags,
   Target,
   readonlyMap,
-  reactiveMap
+  reactiveMap,
+  shallowReactiveMap,
+  shallowReadonlyMap
 } from './reactive'
 import { TrackOpTypes, TriggerOpTypes } from './operations'
 import {
@@ -80,7 +82,15 @@ function createGetter(isReadonly = false, shallow = false) {
       return isReadonly
     } else if (
       key === ReactiveFlags.RAW &&
-      receiver === (isReadonly ? readonlyMap : reactiveMap).get(target)
+      receiver ===
+        (isReadonly
+          ? shallow
+            ? shallowReadonlyMap
+            : readonlyMap
+          : shallow
+            ? shallowReactiveMap
+            : reactiveMap
+        ).get(target)
     ) {
       return target
     }

--- a/packages/reactivity/src/reactive.ts
+++ b/packages/reactivity/src/reactive.ts
@@ -28,7 +28,9 @@ export interface Target {
 }
 
 export const reactiveMap = new WeakMap<Target, any>()
+export const shallowReactiveMap = new WeakMap<Target, any>()
 export const readonlyMap = new WeakMap<Target, any>()
+export const shallowReadonlyMap = new WeakMap<Target, any>()
 
 const enum TargetType {
   INVALID = 0,
@@ -92,7 +94,8 @@ export function reactive(target: object) {
     target,
     false,
     mutableHandlers,
-    mutableCollectionHandlers
+    mutableCollectionHandlers,
+    reactiveMap
   )
 }
 
@@ -106,7 +109,8 @@ export function shallowReactive<T extends object>(target: T): T {
     target,
     false,
     shallowReactiveHandlers,
-    shallowCollectionHandlers
+    shallowCollectionHandlers,
+    shallowReactiveMap
   )
 }
 
@@ -143,7 +147,8 @@ export function readonly<T extends object>(
     target,
     true,
     readonlyHandlers,
-    readonlyCollectionHandlers
+    readonlyCollectionHandlers,
+    readonlyMap
   )
 }
 
@@ -160,7 +165,8 @@ export function shallowReadonly<T extends object>(
     target,
     true,
     shallowReadonlyHandlers,
-    shallowReadonlyCollectionHandlers
+    shallowReadonlyCollectionHandlers,
+    shallowReadonlyMap
   )
 }
 
@@ -168,7 +174,8 @@ function createReactiveObject(
   target: Target,
   isReadonly: boolean,
   baseHandlers: ProxyHandler<any>,
-  collectionHandlers: ProxyHandler<any>
+  collectionHandlers: ProxyHandler<any>,
+  proxyMap: WeakMap<Target, any>
 ) {
   if (!isObject(target)) {
     if (__DEV__) {
@@ -185,7 +192,6 @@ function createReactiveObject(
     return target
   }
   // target already has corresponding Proxy
-  const proxyMap = isReadonly ? readonlyMap : reactiveMap
   const existingProxy = proxyMap.get(target)
   if (existingProxy) {
     return existingProxy


### PR DESCRIPTION
This fixes #2843

We currently track reactive proxies in one WeakMap, not differentiating between normal and shallow Proxies. the same is true for readonly proxies.

This means that for each target, only one kind of proxy can be created, because we use these WeakMaps to re-use existing proxies for each known target. 

```js
const target = { some: 'value' }
const normalProxy = reactive(target)
const shallowProxy = shallowReactive(target)

expect(normalProxy).not.toBe(shallowProxy)
```

The above test fails - `shallowProxy` will in fact be the same proxy as `normalProxy`.

This PR adds separate WeakMaps to track shallow Proxies on their own, which makes the above test pass.