### PR TITLE
fix(compiler-sfc): change defineEmit to use function intersection. (fix #2874)

### DIFF
--- a/packages/compiler-sfc/__tests__/__snapshots__/compileScript.spec.ts.snap
+++ b/packages/compiler-sfc/__tests__/__snapshots__/compileScript.spec.ts.snap
@@ -644,7 +644,7 @@ return { a, b, c, d, x }
 }"
 `;
 
-exports[`SFC compile <script setup> with TypeScript defineEmit w/ type (union) 1`] = `
+exports[`SFC compile <script setup> with TypeScript defineEmit w/ type (intersection) 1`] = `
 "import { defineComponent as _defineComponent } from 'vue'
 
       
@@ -652,7 +652,7 @@ export default _defineComponent({
   expose: [],
   emits: [\\"foo\\", \\"bar\\", \\"baz\\"] as unknown as undefined,
   setup(__props, { emit }: {
-        emit: (((e: 'foo' | 'bar') => void) | ((e: 'baz', id: number) => void)),
+        emit: (((e: 'foo' | 'bar') => void) & ((e: 'baz', id: number) => void)),
         slots: any,
         attrs: any
       }) {

--- a/packages/compiler-sfc/__tests__/compileScript.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileScript.spec.ts
@@ -518,8 +518,8 @@ const emit = defineEmit(['a', 'b'])
       expect(content).toMatch(`emits: ["foo", "bar"] as unknown as undefined`)
     })
 
-    test('defineEmit w/ type (union)', () => {
-      const type = `((e: 'foo' | 'bar') => void) | ((e: 'baz', id: number) => void)`
+    test('defineEmit w/ type (intersection)', () => {
+      const type = `((e: 'foo' | 'bar') => void) & ((e: 'baz', id: number) => void)`
       const { content } = compile(`
       <script setup lang="ts">
       import { defineEmit } from 'vue'

--- a/packages/compiler-sfc/src/compileScript.ts
+++ b/packages/compiler-sfc/src/compileScript.ts
@@ -20,7 +20,7 @@ import {
   Statement,
   Expression,
   LabeledStatement,
-  TSUnionType,
+  TSIntersectionType,
   CallExpression
 } from '@babel/types'
 import { walk } from 'estree-walker'
@@ -184,7 +184,7 @@ export function compileScript(
   let propsTypeDecl: TSTypeLiteral | undefined
   let propsIdentifier: string | undefined
   let emitRuntimeDecl: Node | undefined
-  let emitTypeDecl: TSFunctionType | TSUnionType | undefined
+  let emitTypeDecl: TSFunctionType | TSIntersectionType | undefined
   let emitIdentifier: string | undefined
   let hasAwait = false
   let hasInlinedSsrRenderFn = false
@@ -300,13 +300,13 @@ export function compileScript(
         const typeArg = node.typeParameters.params[0]
         if (
           typeArg.type === 'TSFunctionType' ||
-          typeArg.type === 'TSUnionType'
+          typeArg.type === 'TSIntersectionType'
         ) {
           emitTypeDecl = typeArg
         } else {
           error(
             `type argument passed to ${DEFINE_EMIT}() must be a function type ` +
-              `or a union of function types.`,
+              `or an intersection of function types.`,
             typeArg
           )
         }
@@ -1297,10 +1297,10 @@ function toRuntimeTypeString(types: string[]) {
 }
 
 function extractRuntimeEmits(
-  node: TSFunctionType | TSUnionType,
+  node: TSFunctionType | TSIntersectionType,
   emits: Set<string>
 ) {
-  if (node.type === 'TSUnionType') {
+  if (node.type === 'TSIntersectionType') {
     for (let t of node.types) {
       if (t.type === 'TSParenthesizedType') t = t.typeAnnotation
       if (t.type === 'TSFunctionType') {

--- a/test-dts/setupHelpers.test-d.ts
+++ b/test-dts/setupHelpers.test-d.ts
@@ -56,6 +56,18 @@ describe('defineEmit w/ type declaration', () => {
   emit()
   // @ts-expect-error
   emit('bar')
+
+  const emit2 = defineEmit<
+    ((e: 'foo') => void) & ((e: 'bar', num: number) => void)
+  >()
+  emit2('foo')
+  emit2('bar', 123)
+  // @ts-expect-error
+  emit2('foo', 123)
+  // @ts-expect-error
+  emit2('bar')
+  // @ts-expect-error
+  emit2('baz')
 })
 
 describe('defineEmit w/ runtime declaration', () => {


### PR DESCRIPTION
Change the accepted type for defineEmit from function union to function intersection, since function arguments are contravariant.

fix #2874 