### PR TITLE
fix(runtime-dom): ensure readonly type prop on textarea is handled patched as attribute (close #2766)

### DIFF
--- a/packages/runtime-dom/__tests__/patchProps.spec.ts
+++ b/packages/runtime-dom/__tests__/patchProps.spec.ts
@@ -146,4 +146,11 @@ describe('runtime-dom: props patching', () => {
     expect(el.form).toBe(null)
     expect(el.getAttribute('form')).toBe('foo')
   })
+
+  test('readonly type prop on textarea', () => {
+    const el = document.createElement('textarea')
+    // just to verify that it doesn't throw when i.e. switching a dynamic :is from an 'input' to a 'textarea'
+    // see https://github.com/vuejs/vue-next/issues/2766
+    patchProp(el, 'type', 'text', null)
+  })
 })

--- a/packages/runtime-dom/src/patchProp.ts
+++ b/packages/runtime-dom/src/patchProp.ts
@@ -109,5 +109,10 @@ function shouldSetAsProp(
     return false
   }
 
+  // DOMprop "type" is readonly on textarea elements: https://github.com/vuejs/vue-next/issues/2766
+  if (key === 'type' && el.tagName === 'TEXTAREA') {
+    return false
+  }
+
   return key in el
 }


### PR DESCRIPTION
the `type` prop is readonly on textareas but writeable for other form inputs. When swithcing between different input elements in dynamic components, the renderer might attempt do unset the `type` attribute, which throws when done through a DOMprop, but silently fails (as we want) when done with `setAttribute`, so we want the latter to be used.

close #2766