### PR TITLE
fix(baseHandlers): trigger will called two times when set the same proxy value

### DIFF
--- a/packages/reactivity/__tests__/effect.spec.ts
+++ b/packages/reactivity/__tests__/effect.spec.ts
@@ -6,7 +6,8 @@ import {
   TrackOpTypes,
   TriggerOpTypes,
   DebuggerEvent,
-  markRaw
+  markRaw,
+  shallowReactive
 } from '../src/index'
 import { ITERATE_KEY } from '../src/effect'
 
@@ -821,5 +822,14 @@ describe('reactivity/effect', () => {
 
     observed.obj = obj
     expect(fnSpy).toHaveBeenCalledTimes(1)
+
+    const obj2 = reactive({ foo: 1 })
+    const observed2: any = shallowReactive({ obj2 })
+    const fnSpy2 = jest.fn(() => observed2.obj2)
+
+    effect(fnSpy2)
+
+    observed2.obj2 = obj2
+    expect(fnSpy2).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/reactivity/__tests__/effect.spec.ts
+++ b/packages/reactivity/__tests__/effect.spec.ts
@@ -811,4 +811,15 @@ describe('reactivity/effect', () => {
     expect(dummy).toBe(0)
     expect(record).toBeUndefined()
   })
+
+  it('should trigger once effect when set the equal proxy', () => {
+    const obj = reactive({ foo: 1 })
+    const observed: any = reactive({ obj })
+    const fnSpy = jest.fn(() => observed.obj)
+
+    effect(fnSpy)
+
+    observed.obj = obj
+    expect(fnSpy).toHaveBeenCalledTimes(1)
+  })
 })

--- a/packages/reactivity/src/baseHandlers.ts
+++ b/packages/reactivity/src/baseHandlers.ts
@@ -133,9 +133,10 @@ function createSetter(shallow = false) {
     value: unknown,
     receiver: object
   ): boolean {
-    const oldValue = (target as any)[key]
+    let oldValue = (target as any)[key]
     if (!shallow) {
       value = toRaw(value)
+      oldValue = toRaw(oldValue)
       if (!isArray(target) && isRef(oldValue) && !isRef(value)) {
         oldValue.value = value
         return true
@@ -153,7 +154,7 @@ function createSetter(shallow = false) {
     if (target === toRaw(receiver)) {
       if (!hadKey) {
         trigger(target, TriggerOpTypes.ADD, key, value)
-      } else if (hasChanged(toRaw(value), toRaw(oldValue))) {
+      } else if (hasChanged(value, oldValue)) {
         trigger(target, TriggerOpTypes.SET, key, value, oldValue)
       }
     }

--- a/packages/reactivity/src/baseHandlers.ts
+++ b/packages/reactivity/src/baseHandlers.ts
@@ -134,8 +134,9 @@ function createSetter(shallow = false) {
     receiver: object
   ): boolean {
     const oldValue = (target as any)[key]
+    value = toRaw(value)
+
     if (!shallow) {
-      value = toRaw(value)
       if (!isArray(target) && isRef(oldValue) && !isRef(value)) {
         oldValue.value = value
         return true

--- a/packages/reactivity/src/baseHandlers.ts
+++ b/packages/reactivity/src/baseHandlers.ts
@@ -153,7 +153,7 @@ function createSetter(shallow = false) {
     if (target === toRaw(receiver)) {
       if (!hadKey) {
         trigger(target, TriggerOpTypes.ADD, key, value)
-      } else if (hasChanged(value, oldValue)) {
+      } else if (hasChanged(value, toRaw(oldValue))) {
         trigger(target, TriggerOpTypes.SET, key, value, oldValue)
       }
     }

--- a/packages/reactivity/src/baseHandlers.ts
+++ b/packages/reactivity/src/baseHandlers.ts
@@ -134,9 +134,8 @@ function createSetter(shallow = false) {
     receiver: object
   ): boolean {
     const oldValue = (target as any)[key]
-    value = toRaw(value)
-
     if (!shallow) {
+      value = toRaw(value)
       if (!isArray(target) && isRef(oldValue) && !isRef(value)) {
         oldValue.value = value
         return true
@@ -154,7 +153,7 @@ function createSetter(shallow = false) {
     if (target === toRaw(receiver)) {
       if (!hadKey) {
         trigger(target, TriggerOpTypes.ADD, key, value)
-      } else if (hasChanged(value, toRaw(oldValue))) {
+      } else if (hasChanged(toRaw(value), toRaw(oldValue))) {
         trigger(target, TriggerOpTypes.SET, key, value, oldValue)
       }
     }


### PR DESCRIPTION
```js
import { reactive, toRaw, watchEffect } from 'vue'

const a = reactive({
  a: 1,
})

const b = reactive({
  b: 1,
})

const d = reactive([a, b])

watchEffect(() => {
  console.log('d', d[0]) // Will consoled two times
})

d[0] = a
```