### PR TITLE
fix(runtime-core): ensure app instance can be garbage collected after unmount. (close #2907)

### DIFF
--- a/packages/reactivity/__tests__/readonly.spec.ts
+++ b/packages/reactivity/__tests__/readonly.spec.ts
@@ -1,14 +1,14 @@
 import {
-  reactive,
-  readonly,
-  toRaw,
+  effect,
+  isProxy,
   isReactive,
   isReadonly,
   markRaw,
-  effect,
+  reactive,
+  readonly,
   ref,
   shallowReadonly,
-  isProxy
+  toRaw
 } from '../src'
 
 /**
@@ -460,6 +460,14 @@ describe('reactivity/readonly', () => {
       expect(
         `Set operation on key "foo" failed: target is readonly.`
       ).not.toHaveBeenWarned()
+    })
+
+    test('should allow shallow und normal reactive for same target', () => {
+      const target = { foo: 1 }
+      const shallowProxy = shallowReadonly(target)
+      const normalProxy = readonly(target)
+
+      expect(normalProxy).not.toBe(shallowProxy)
     })
   })
 })

--- a/packages/reactivity/__tests__/shallowReactive.spec.ts
+++ b/packages/reactivity/__tests__/shallowReactive.spec.ts
@@ -1,4 +1,5 @@
-import { shallowReactive, isReactive, reactive } from '../src/reactive'
+import { isReactive, reactive, shallowReactive } from '../src/reactive'
+
 import { effect } from '../src/effect'
 
 describe('shallowReactive', () => {
@@ -11,6 +12,14 @@ describe('shallowReactive', () => {
     const props: any = shallowReactive({ n: reactive({ foo: 1 }) })
     props.n = reactive({ foo: 2 })
     expect(isReactive(props.n)).toBe(true)
+  })
+
+  test('should allow shallow und normal reactive for same target', () => {
+    const target = { foo: 1 }
+    const shallowProxy = shallowReactive(target)
+    const normalProxy = reactive(target)
+
+    expect(normalProxy).not.toBe(shallowProxy)
   })
 
   describe('collections', () => {

--- a/packages/reactivity/src/baseHandlers.ts
+++ b/packages/reactivity/src/baseHandlers.ts
@@ -1,29 +1,32 @@
 import {
-  reactive,
-  readonly,
-  toRaw,
+  ITERATE_KEY,
+  pauseTracking,
+  resetTracking,
+  track,
+  trigger
+} from './effect'
+import {
   ReactiveFlags,
   Target,
+  reactive,
+  reactiveMap,
+  readonly,
   readonlyMap,
-  reactiveMap
+  shallowReactiveMap,
+  shallowReadonlyMap,
+  toRaw
 } from './reactive'
 import { TrackOpTypes, TriggerOpTypes } from './operations'
 import {
-  track,
-  trigger,
-  ITERATE_KEY,
-  pauseTracking,
-  resetTracking
-} from './effect'
-import {
-  isObject,
-  hasOwn,
-  isSymbol,
+  extend,
   hasChanged,
+  hasOwn,
   isArray,
   isIntegerKey,
-  extend
+  isObject,
+  isSymbol
 } from '@vue/shared'
+
 import { isRef } from './ref'
 
 const builtInSymbols = new Set(
@@ -77,7 +80,15 @@ function createGetter(isReadonly = false, shallow = false) {
       return isReadonly
     } else if (
       key === ReactiveFlags.RAW &&
-      receiver === (isReadonly ? readonlyMap : reactiveMap).get(target)
+      receiver ===
+        (isReadonly
+          ? shallow
+            ? shallowReadonlyMap
+            : readonlyMap
+          : shallow
+            ? shallowReactiveMap
+            : reactiveMap
+        ).get(target)
     ) {
       return target
     }

--- a/packages/runtime-core/src/apiCreateApp.ts
+++ b/packages/runtime-core/src/apiCreateApp.ts
@@ -272,6 +272,7 @@ export function createAppAPI<HostElement>(
           if (__DEV__ || __FEATURE_PROD_DEVTOOLS__) {
             devtoolsUnmountApp(app)
           }
+          delete app._container.__vue_app__
         } else if (__DEV__) {
           warn(`Cannot unmount an app that is not mounted.`)
         }


### PR DESCRIPTION
When unmounting an app, we need to remove the `__vue_app__` property from the container element, otherwise the app instance can't be garbage collected for as long as that element exists.


closes #2907