### PR TITLE
fix(runtime-core): ensure app instance can be garbage collected after unmount (close #2907)

### DIFF
--- a/packages/runtime-core/src/apiCreateApp.ts
+++ b/packages/runtime-core/src/apiCreateApp.ts
@@ -272,6 +272,7 @@ export function createAppAPI<HostElement>(
           if (__DEV__ || __FEATURE_PROD_DEVTOOLS__) {
             devtoolsUnmountApp(app)
           }
+          delete app._container.__vue_app__
         } else if (__DEV__) {
           warn(`Cannot unmount an app that is not mounted.`)
         }


### PR DESCRIPTION
When unmounting an app, we need to remove the `__vue_app__` property from the container element, otherwise the app instance can't be garbage collected for as long as that element exists.


closes #2907