### PR TITLE
[Vue warn]: Property undefined was accessed during render but is not defined on instance.

### DIFF
--- a/packages/runtime-core/__tests__/componentProxy.spec.ts
+++ b/packages/runtime-core/__tests__/componentProxy.spec.ts
@@ -240,6 +240,6 @@ describe('component: proxy', () => {
       `Property ${JSON.stringify(
         Symbol.unscopables
       )} was accessed during render ` + `but is not defined on instance.`
-    ).toHaveBeenWarned()
+    ).not.toHaveBeenWarned()
   })
 })

--- a/packages/runtime-core/src/componentPublicInstance.ts
+++ b/packages/runtime-core/src/componentPublicInstance.ts
@@ -241,7 +241,7 @@ export interface ComponentRenderContext {
 }
 
 export const PublicInstanceProxyHandlers: ProxyHandler<any> = {
-  get({ _: instance }: ComponentRenderContext, key: string) {
+  get({ _: instance }: ComponentRenderContext, keyOrSymbol: string | symbol) {
     const {
       ctx,
       setupState,
@@ -251,10 +251,16 @@ export const PublicInstanceProxyHandlers: ProxyHandler<any> = {
       type,
       appContext
     } = instance
+    const key = keyOrSymbol as string
 
     // let @vue/reactivity know it should never observe Vue public instances.
     if (key === ReactiveFlags.SKIP) {
       return true
+    }
+
+    // this seems to come from the `with(_ctx) {}` used in render functions
+    if (keyOrSymbol === Symbol.unscopables) {
+      return undefined
     }
 
     // for internal formatters to know that this is a Vue instance


### PR DESCRIPTION
Without this change, I'm getting a _lot_ of this error:

https://prnt.sc/wchiz8

Related to #2270 , but I'm already using `@vue/compiler-dom`.