### PR TITLE
fix(runtime-core): KeepAlive/BeseTransition should work with setScopeId + slot

### DIFF
--- a/packages/runtime-core/__tests__/components/BaseTransition.spec.ts
+++ b/packages/runtime-core/__tests__/components/BaseTransition.spec.ts
@@ -1100,7 +1100,9 @@ describe('BaseTransition', () => {
       const Child = {
         render: withChildId(function(this: any) {
           return h(BaseTransition, null, {
-            default: withChildId(() => h('div', this.$slots.default()))
+            default: withChildId(() =>
+              h('div', null, h('div', this.$slots.default()))
+            )
           })
         })
       }
@@ -1115,7 +1117,7 @@ describe('BaseTransition', () => {
       const root = nodeOps.createElement('div')
       render(h(App), root)
       expect(serializeInner(root)).toBe(
-        `<div foo root><div root foo-s></div></div>`
+        `<div foo root><div foo><div root foo-s></div></div></div>`
       )
     })
   })

--- a/packages/runtime-core/__tests__/components/KeepAlive.spec.ts
+++ b/packages/runtime-core/__tests__/components/KeepAlive.spec.ts
@@ -825,4 +825,30 @@ describe('KeepAlive', () => {
     await nextTick()
     expect(serializeInner(root)).toBe(`<div foo>changed</div>`)
   })
+
+  // #2892
+  test('should work with slots + scopeId', async () => {
+    const withChildId = withScopeId('foo')
+    const withRootId = withScopeId('root')
+
+    const Child = {
+      render: withChildId(function(this: any) {
+        return h(KeepAlive, null, {
+          default: withChildId(() => h('div', this.$slots.default()))
+        })
+      })
+    }
+
+    const App = {
+      render: withRootId(() =>
+        h(Child, null, {
+          default: withRootId(() => h('div'))
+        })
+      )
+    }
+    render(h(App), root)
+    expect(serializeInner(root)).toBe(
+      `<div foo root><div root foo-s></div></div>`
+    )
+  })
 })

--- a/packages/runtime-core/__tests__/components/KeepAlive.spec.ts
+++ b/packages/runtime-core/__tests__/components/KeepAlive.spec.ts
@@ -834,7 +834,9 @@ describe('KeepAlive', () => {
     const Child = {
       render: withChildId(function(this: any) {
         return h(KeepAlive, null, {
-          default: withChildId(() => h('div', this.$slots.default()))
+          default: withChildId(() =>
+            h('div', null, h('div', this.$slots.default()))
+          )
         })
       })
     }
@@ -848,7 +850,7 @@ describe('KeepAlive', () => {
     }
     render(h(App), root)
     expect(serializeInner(root)).toBe(
-      `<div foo root><div root foo-s></div></div>`
+      `<div foo root><div foo><div root foo-s></div></div></div>`
     )
   })
 })

--- a/packages/runtime-core/src/renderer.ts
+++ b/packages/runtime-core/src/renderer.ts
@@ -805,13 +805,13 @@ function baseCreateRenderer(
       hostSetScopeId(el, scopeId)
     }
     if (parentComponent) {
-      const treeOwnerId = parentComponent.type.__scopeId
+      let subTree = parentComponent.subTree
+      const treeOwnerId = subTree.scopeId
       // vnode's own scopeId and the current patched component's scopeId is
       // different - this is a slot content node.
       if (treeOwnerId && treeOwnerId !== scopeId) {
         hostSetScopeId(el, treeOwnerId + '-s')
       }
-      let subTree = parentComponent.subTree
       if (__DEV__ && subTree.type === Fragment) {
         subTree =
           filterSingleRoot(subTree.children as VNodeArrayChildren) || subTree


### PR DESCRIPTION
close #2892

If slot's `parentComponent` is `KeepAlive` or `Transition`,`parentComponent.type.__scopeId` is null , but `parentComponent.subTree.scopeId` has the correct value.
