### PR TITLE
fix(transformElement): properly transform replaced nodes

### DIFF
--- a/packages/compiler-core/src/transforms/transformElement.ts
+++ b/packages/compiler-core/src/transforms/transformElement.ts
@@ -62,18 +62,21 @@ const directiveImportMap = new WeakMap<DirectiveNode, symbol>()
 
 // generate a JavaScript AST for this element's codegen
 export const transformElement: NodeTransform = (node, context) => {
-  if (
-    !(
-      node.type === NodeTypes.ELEMENT &&
-      (node.tagType === ElementTypes.ELEMENT ||
-        node.tagType === ElementTypes.COMPONENT)
-    )
-  ) {
-    return
-  }
   // perform the work on exit, after all child expressions have been
   // processed and merged.
   return function postTransformElement() {
+    node = context.currentNode!
+
+    if (
+      !(
+        node.type === NodeTypes.ELEMENT &&
+        (node.tagType === ElementTypes.ELEMENT ||
+          node.tagType === ElementTypes.COMPONENT)
+      )
+    ) {
+      return
+    }
+
     const { tag, props } = node
     const isComponent = node.tagType === ElementTypes.COMPONENT
 


### PR DESCRIPTION
#### Problem:

I was trying to make a transform that uses [`replaceNode`](https://github.com/vuejs/vue-next/blob/a8352506f6ee7fee784c47d2a6907071215602fc/packages/compiler-core/src/transform.ts#L189) to replace the `currentNode` with a new element node.

Since I pass in my transform in [`TransformOptions["nodeTransforms"]`](https://github.com/vuejs/vue-next/blob/67d1aac6ae683a3a7291dff15071d1eeacb7d22a/packages/compiler-core/src/options.ts#L143), it comes after all the transforms in [`BaseTransformPreset`](https://github.com/vuejs/vue-next/blob/5d825f318f1c3467dd530e43b09040d9f8793cce/packages/compiler-core/src/compile.ts#L25) which includes [`transformElement`](https://github.com/vuejs/vue-next/blob/a8352506f6ee7fee784c47d2a6907071215602fc/packages/compiler-core/src/transforms/transformElement.ts#L64).

So 
- first, [`transformElement`](https://github.com/vuejs/vue-next/blob/a8352506f6ee7fee784c47d2a6907071215602fc/packages/compiler-core/src/transforms/transformElement.ts#L64) runs, doesn't do much besides providing an [`exitFns`](https://github.com/vuejs/vue-next/blob/a8352506f6ee7fee784c47d2a6907071215602fc/packages/compiler-core/src/transform.ts#L377) named [`postTransformElement`](https://github.com/vuejs/vue-next/blob/a8352506f6ee7fee784c47d2a6907071215602fc/packages/compiler-core/src/transforms/transformElement.ts#L76)
- then my transform runs, replacing the `currentNode` with a new element node
- once all transforms are finished, the [`exitFns`](https://github.com/vuejs/vue-next/blob/a8352506f6ee7fee784c47d2a6907071215602fc/packages/compiler-core/src/transform.ts#L377) start running
- [`postTransformElement`](https://github.com/vuejs/vue-next/blob/a8352506f6ee7fee784c47d2a6907071215602fc/packages/compiler-core/src/transforms/transformElement.ts#L76) runs but uses a reference to the original element node, not the new element node
- my new element node never gets processed by [`postTransformElement`](https://github.com/vuejs/vue-next/blob/a8352506f6ee7fee784c47d2a6907071215602fc/packages/compiler-core/src/transforms/transformElement.ts#L76)

Even though I can create my own codegenNode in my own exit function, I don't think having [`postTransformElement`](https://github.com/vuejs/vue-next/blob/a8352506f6ee7fee784c47d2a6907071215602fc/packages/compiler-core/src/transforms/transformElement.ts#L76) transform a node that is no longer in the tree is the desired behavior.

#### Solution:
Instead of using a reference to the node [`transformElement`](https://github.com/vuejs/vue-next/blob/a8352506f6ee7fee784c47d2a6907071215602fc/packages/compiler-core/src/transforms/transformElement.ts#L64) is first called with, use `context.currentNode`