### PR TITLE
fix(docs): change reference to passed deadline

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Please consult the [Migration Guide](https://v3.vuejs.org/guide/migration/introd
 
 ## Supporting Libraries
 
-All of our official libraries and tools now support Vue 3, but most of them are still in beta status and distributed under the `next` dist tag on NPM. **We are planning to stabilize and switch all projects to use the `latest` dist tag by end of 2020.**
+All of our official libraries and tools now support Vue 3, but most of them are still in beta status and distributed under the `next` dist tag on NPM. **We are planning to stabilize and switch all projects to use the `latest` dist tag in early 2021.**
 
 ### Vue CLI
 


### PR DESCRIPTION
mention we plan to drop the next suffix in early
2021 rather than 2020 since that deadline has
passed.

Fixes N/A