### PR TITLE
perf(reactivity): should not track `__isVue`

### DIFF
--- a/packages/reactivity/src/baseHandlers.ts
+++ b/packages/reactivity/src/baseHandlers.ts
@@ -22,9 +22,12 @@ import {
   hasChanged,
   isArray,
   isIntegerKey,
-  extend
+  extend,
+  makeMap
 } from '@vue/shared'
 import { isRef } from './ref'
+
+const isNonTrackableKeys = /*#__PURE__*/ makeMap(`__proto__,__v_isRef,__isVue`)
 
 const builtInSymbols = new Set(
   Object.getOwnPropertyNames(Symbol)
@@ -93,7 +96,7 @@ function createGetter(isReadonly = false, shallow = false) {
     if (
       isSymbol(key)
         ? builtInSymbols.has(key as symbol)
-        : key === `__proto__` || key === `__v_isRef`
+        : isNonTrackableKeys(key)
     ) {
       return res
     }


### PR DESCRIPTION
In DEV mode, the [custom formatter](https://github.com/vuejs/vue-next/blob/master/packages/runtime-core/src/customFormatter.ts#L26) will read the `__isVue`, which causes it to be tracked. I think it’s ok to not track it in the production environment.