### PR TITLE
fix: should prefix `ShadowRoot` with `window.`

### DIFF
--- a/packages/runtime-dom/src/index.ts
+++ b/packages/runtime-dom/src/index.ts
@@ -119,7 +119,7 @@ function normalizeContainer(
   }
   if (
     __DEV__ &&
-    container instanceof ShadowRoot &&
+    container instanceof window.ShadowRoot &&
     container.mode === 'closed'
   ) {
     warn(


### PR DESCRIPTION
Otherwise this expression would throw in environments that do not
support `ShadowRoot`, including the common mocha testing environment
setup that uses `jsdom` and `jsdom-global`.

It is because `ShadowRoot` is not an enumerable property on `window`,
`jsdom-global` fails to expose it on the `global` object.

See the error message at https://app.circleci.com/pipelines/github/vuejs/vue-cli/779/workflows/17d7d7c4-7605-4588-878a-ddb3a6d37102/jobs/24147