### PR TITLE
fix(types): allow style to be an array in JSX

### DIFF
--- a/packages/runtime-dom/types/jsx.d.ts
+++ b/packages/runtime-dom/types/jsx.d.ts
@@ -245,11 +245,14 @@ interface AriaAttributes {
   'aria-valuetext'?: string
 }
 
+// Vue's style normalization supports nested arrays
+type StyleValue = string | CSSProperties | Array<StyleValue>
+
 export interface HTMLAttributes extends AriaAttributes, EventHandlers<Events> {
   innerHTML?: string
 
   class?: any
-  style?: string | CSSProperties | Array<string | CSSProperties>
+  style?: StyleValue
 
   // Standard HTML Attributes
   accesskey?: string

--- a/packages/runtime-dom/types/jsx.d.ts
+++ b/packages/runtime-dom/types/jsx.d.ts
@@ -249,7 +249,7 @@ export interface HTMLAttributes extends AriaAttributes, EventHandlers<Events> {
   innerHTML?: string
 
   class?: any
-  style?: string | CSSProperties
+  style?: string | CSSProperties | Array<string | CSSProperties>
 
   // Standard HTML Attributes
   accesskey?: string


### PR DESCRIPTION
Vue supports array of string and CssProperties in style attribute.
![image](https://user-images.githubusercontent.com/47540799/103690507-e5e32980-4fa5-11eb-8a4c-19d6a1b198ef.png)
