### PR TITLE
fix(event): Compatible with Firefox 53 and earlier.

### DIFF
--- a/packages/runtime-dom/src/modules/events.ts
+++ b/packages/runtime-dom/src/modules/events.ts
@@ -25,8 +25,8 @@ let _getNow: () => number = Date.now
 if (
   typeof document !== 'undefined' &&
   (_getNow() > document.createEvent('Event').timeStamp ||
-    _getNow().toString.length -
-      (document.createEvent('Event').timeStamp / 1000).toString.length >=
+    _getNow().toString().length -
+      (document.createEvent('Event').timeStamp / 1000).toString().length >=
       0)
 ) {
   // if the low-res timestamp which is bigger than the event timestamp

--- a/packages/runtime-dom/src/modules/events.ts
+++ b/packages/runtime-dom/src/modules/events.ts
@@ -19,9 +19,15 @@ let _getNow: () => number = Date.now
 // timestamp can either be hi-res (relative to page load) or low-res
 // (relative to UNIX epoch), so in order to compare time we have to use the
 // same timestamp type when saving the flush timestamp.
+
+// #2937, in firefox 53 and earlier versions, the timestamp is microseconds
+// of the current time, resulting in the binding event not being triggered
 if (
   typeof document !== 'undefined' &&
-  _getNow() > document.createEvent('Event').timeStamp
+  (_getNow() > document.createEvent('Event').timeStamp ||
+    _getNow().toString.length -
+      (document.createEvent('Event').timeStamp / 1000).toString.length >=
+      0)
 ) {
   // if the low-res timestamp which is bigger than the event timestamp
   // (which is evaluated AFTER) it means the event is using a hi-res timestamp,


### PR DESCRIPTION
In firefox 53 and earlier versions, the timestamp is microseconds of the current time, resulting in the binding event not being triggered.

close #2937