### PR TITLE
fix(reactive): delete useless code in function reactive

### DIFF
--- a/packages/reactivity/src/reactive.ts
+++ b/packages/reactivity/src/reactive.ts
@@ -83,10 +83,6 @@ type UnwrapNestedRefs<T> = T extends Ref ? T : UnwrapRef<T>
  */
 export function reactive<T extends object>(target: T): UnwrapNestedRefs<T>
 export function reactive(target: object) {
-  // if trying to observe a readonly proxy, return the readonly version.
-  if (target && (target as Target)[ReactiveFlags.IS_READONLY]) {
-    return target
-  }
   return createReactiveObject(
     target,
     false,


### PR DESCRIPTION
delete useless code in function reactive(#2951)
i think the code above i delete is useless, because in function createReactiveObject will solve the situation that if trying to observe a readonly proxy, return the readonly version, becasuse in createReactiveObject , except readonly() on a reactive object,
as long as the target is a proxy, the function createReactiveObject will return the target, so the code is repleat, and when i delete
the code above i mentioned, when i run 'npm test', it can pass and has no errors