### PR TITLE
fix(compiler-sfc): should not treat the reactive call as setup-const

### DIFF
--- a/packages/compiler-core/src/options.ts
+++ b/packages/compiler-core/src/options.ts
@@ -89,6 +89,10 @@ export const enum BindingTypes {
    */
   SETUP_REF = 'setup-ref',
   /**
+   * bindings that are guaranteed to be reactive
+   */
+  SETUP_REACTIVE = 'setup-reactive',
+  /**
    * declared by other options, e.g. computed, inject
    */
   OPTIONS = 'options'

--- a/packages/compiler-sfc/__tests__/compileScript.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileScript.spec.ts
@@ -1123,7 +1123,7 @@ describe('SFC analyze <script> bindings', () => {
   it('works for script setup', () => {
     const { bindings } = compile(`
       <script setup>
-      import { defineProps, ref as r } from 'vue'
+      import { defineProps, ref as r, reactive as rt } from 'vue'
       defineProps({
         foo: String
       })
@@ -1133,16 +1133,19 @@ describe('SFC analyze <script> bindings', () => {
       const c = 3
       const { d } = someFoo()
       let { e } = someBar()
+      const f = rt([])
       </script>
     `)
 
     expect(bindings).toStrictEqual({
       r: BindingTypes.SETUP_CONST,
+      rt: BindingTypes.SETUP_CONST,
       a: BindingTypes.SETUP_REF,
       b: BindingTypes.SETUP_LET,
       c: BindingTypes.SETUP_CONST,
       d: BindingTypes.SETUP_MAYBE_REF,
       e: BindingTypes.SETUP_LET,
+      f: BindingTypes.SETUP_REACTIVE,
       foo: BindingTypes.PROPS
     })
   })

--- a/packages/compiler-sfc/src/compileScript.ts
+++ b/packages/compiler-sfc/src/compileScript.ts
@@ -1036,17 +1036,23 @@ function walkDeclaration(
       )
       if (id.type === 'Identifier') {
         let bindingType
-        if (
-          // if a declaration is a const literal, we can mark it so that
-          // the generated render fn code doesn't need to unref() it
-          isDefineCall ||
-          (isConst &&
-            canNeverBeRef(init!, userImportAlias['reactive'] || 'reactive'))
-        ) {
+        if (isDefineCall) {
           bindingType = BindingTypes.SETUP_CONST
         } else if (isConst) {
           if (isCallOf(init, userImportAlias['ref'] || 'ref')) {
             bindingType = BindingTypes.SETUP_REF
+          } else if (
+            isCallOf(init, userImportAlias['reactive'] || 'reactive')
+          ) {
+            // mark it as setup-reactive and
+            // the generated render fn code doesn't need to unref() it
+            bindingType = BindingTypes.SETUP_REACTIVE
+          } else if (
+            canNeverBeRef(init!, userImportAlias['reactive'] || 'reactive')
+          ) {
+            // if a declaration is a const literal, we can mark it so that
+            // the generated render fn code doesn't need to unref() it
+            bindingType = BindingTypes.SETUP_CONST
           } else {
             bindingType = BindingTypes.SETUP_MAYBE_REF
           }


### PR DESCRIPTION
close: #2972 
I see that it is intentional to treat `const obj = reactive({})` as setup-const. Why? In this PR, a new binding type `setup-reactive` is introduced for future optimization.