### PR TITLE
feat(compiler-sfc): support inferring Date from defineProps w/ type

### DIFF
--- a/packages/compiler-sfc/__tests__/__snapshots__/compileScript.spec.ts.snap
+++ b/packages/compiler-sfc/__tests__/__snapshots__/compileScript.spec.ts.snap
@@ -705,6 +705,7 @@ export default _defineComponent({
     fn: { type: Function, required: true },
     functionRef: { type: Function, required: true },
     objectRef: { type: Object, required: true },
+    dateRef: { type: Date, required: true },
     array: { type: Array, required: true },
     arrayRef: { type: Array, required: true },
     tuple: { type: Array, required: true },
@@ -728,6 +729,7 @@ export default _defineComponent({
         fn: (n: number) => void
         functionRef: Function
         objectRef: Object
+        dateRef: Date
         array: string[]
         arrayRef: Array<any>
         tuple: [number, number]

--- a/packages/compiler-sfc/__tests__/compileScript.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileScript.spec.ts
@@ -437,6 +437,7 @@ const emit = defineEmit(['a', 'b'])
         fn: (n: number) => void
         functionRef: Function
         objectRef: Object
+        dateRef: Date
         array: string[]
         arrayRef: Array<any>
         tuple: [number, number]
@@ -462,6 +463,7 @@ const emit = defineEmit(['a', 'b'])
       expect(content).toMatch(`fn: { type: Function, required: true }`)
       expect(content).toMatch(`functionRef: { type: Function, required: true }`)
       expect(content).toMatch(`objectRef: { type: Object, required: true }`)
+      expect(content).toMatch(`dateRef: { type: Date, required: true }`)
       expect(content).toMatch(`array: { type: Array, required: true }`)
       expect(content).toMatch(`arrayRef: { type: Array, required: true }`)
       expect(content).toMatch(`tuple: { type: Array, required: true }`)
@@ -490,6 +492,7 @@ const emit = defineEmit(['a', 'b'])
         fn: BindingTypes.PROPS,
         functionRef: BindingTypes.PROPS,
         objectRef: BindingTypes.PROPS,
+        dateRef: BindingTypes.PROPS,
         array: BindingTypes.PROPS,
         arrayRef: BindingTypes.PROPS,
         tuple: BindingTypes.PROPS,

--- a/packages/compiler-sfc/src/compileScript.ts
+++ b/packages/compiler-sfc/src/compileScript.ts
@@ -1233,6 +1233,7 @@ function inferRuntimeType(
           case 'Map':
           case 'WeakSet':
           case 'WeakMap':
+          case 'Date':
             return [node.typeName.name]
           case 'Record':
           case 'Partial':


### PR DESCRIPTION
Due to #2668, it would be great to be able to infer `Date` from the `defineProps<type>`.