### PR TITLE
fix(runtime-core/scheduler): handle out-of-order invalidateJobs

### DIFF
--- a/packages/runtime-core/__tests__/scheduler.spec.ts
+++ b/packages/runtime-core/__tests__/scheduler.spec.ts
@@ -373,19 +373,24 @@ describe('scheduler', () => {
     }
     const job3 = () => {
       calls.push('job3')
+      invalidateJob(job1)
     }
     const job4 = () => {
       calls.push('job4')
+    }
+    const job5 = () => {
+      calls.push('job5')
     }
     // queue all jobs
     queueJob(job1)
     queueJob(job2)
     queueJob(job3)
-    queuePostFlushCb(job4)
+    queueJob(job4)
+    queuePostFlushCb(job5)
     expect(calls).toEqual([])
     await nextTick()
     // job2 should be called only once
-    expect(calls).toEqual(['job1', 'job2', 'job3', 'job4'])
+    expect(calls).toEqual(['job1', 'job2', 'job3', 'job4', 'job5'])
   })
 
   test('sort job based on id', async () => {

--- a/packages/runtime-core/src/scheduler.ts
+++ b/packages/runtime-core/src/scheduler.ts
@@ -86,7 +86,7 @@ function queueFlush() {
 
 export function invalidateJob(job: SchedulerJob) {
   const i = queue.indexOf(job)
-  if (i > -1) {
+  if (i > flushIndex) {
     queue.splice(i, 1)
   }
 }


### PR DESCRIPTION
In cases where `invalidateJob` is called on a job that has already started (`i <= flushIndex`), the remaining contents of `queue` gets shifted and the job immediately after the current job is skipped.

https://github.com/vuejs/vue-next/blob/af9560455d9719a4c5f0d6588d04bfb4c06c8654/packages/runtime-core/src/scheduler.ts#L87-L92

https://github.com/vuejs/vue-next/blob/af9560455d9719a4c5f0d6588d04bfb4c06c8654/packages/runtime-core/src/scheduler.ts#L211-L219

I haven't been able to come up with a good minimal demo of this bug, but hopefully the modifications to the test case can serve as a sufficient example of a scenario that would cause this bug to occur. If the modified test case is run without the fix, `job1` being invalidated would cause `job4` to be skipped.

For what its worth here's a non-minimal repro:
https://mfro.me/chess/ - built with my fork, includes fix
https://mfro.me/chess-vuerepro/ - built with v3.0.5, no fix
The most noticeable change in behavior is when making 2 consecutive moves on the chess board. The game notation to the right of the board does not update properly for the second or later moves.