### PR TITLE
fix(tsx runtime) property does not exist on type IntrinsicAttributes

### DIFF
--- a/packages/runtime-dom/types/jsx.d.ts
+++ b/packages/runtime-dom/types/jsx.d.ts
@@ -1315,12 +1315,26 @@ type EventHandlers<E> = {
 // named imports.
 import * as RuntimeCore from '@vue/runtime-core'
 
+export type VueNode = RuntimeCore.VNodeChild | JSX.Element
+
+export interface SlotsProps {
+  [name: string]: () => VueNode;
+}
+
 type ReservedProps = {
   key?: string | number
   ref?:
     | string
     | RuntimeCore.Ref
     | ((ref: Element | RuntimeCore.ComponentInternalInstance | null) => void)
+  id?: string | number
+  name?: string | number
+  vModel?: unknown
+  vModels?: unknown
+  vCustom?: unknown
+  vShow?: boolean
+  vHtml?: string | VueNode
+  vSlots?: SlotsProps
 }
 
 type ElementAttrs<T> = T & ReservedProps
@@ -1330,6 +1344,8 @@ type NativeElements = {
     IntrinsicElementAttributes[K]
   >
 }
+
+type JsxAttributes = EventHandlers<Events> & ReservedProps
 
 declare global {
   namespace JSX {
@@ -1345,7 +1361,7 @@ declare global {
       // @ts-ignore suppress ts:2374 = Duplicate string index signature.
       [name: string]: any
     }
-    interface IntrinsicAttributes extends ReservedProps {}
+    interface IntrinsicAttributes extends JsxAttributes {}
   }
 }
 


### PR DESCRIPTION
* The tsx component supports global id and name instead of props
* The tsx component supports global vue-jsx directive declaration
* The tsx component supports all events. Frequently used events are tedious defined by props and Some events are not component functions and should not be defined by props