### PR TITLE
fix(runtime-core): inject function support self-inject

### DIFF
--- a/packages/runtime-core/src/apiInject.ts
+++ b/packages/runtime-core/src/apiInject.ts
@@ -38,10 +38,23 @@ export function inject<T>(
   defaultValue: T | (() => T),
   treatDefaultAsFactory: true
 ): T
+export function inject<T>(
+  key: InjectionKey<T> | string,
+  defaultValue: T,
+  treatDefaultAsFactory: false,
+  selfInject?: boolean
+): T
+export function inject<T>(
+  key: InjectionKey<T> | string,
+  defaultValue: T | (() => T),
+  treatDefaultAsFactory: true,
+  selfInject?: boolean
+): T
 export function inject(
   key: InjectionKey<any> | string,
   defaultValue?: unknown,
-  treatDefaultAsFactory = false
+  treatDefaultAsFactory = false,
+  selfInject = false
 ) {
   // fallback to `currentRenderingInstance` so that this can be called in
   // a functional component
@@ -50,8 +63,9 @@ export function inject(
     // #2400
     // to support `app.use` plugins,
     // fallback to appContext's `provides` if the intance is at root
-    const provides =
-      instance.parent == null
+    const provides = selfInject
+      ? instance.provides
+      : instance.parent == null
         ? instance.vnode.appContext && instance.vnode.appContext.provides
         : instance.parent.provides
 


### PR DESCRIPTION
Before this pull request, I have read #1818 and #2400. And I think self-inject feature is required.

I wrote a vue3 plugin that depends on self-inject. Without self-inject feature, every container component must be splited into two components. 

We can learn from angular.  In angular, we can define component scope providers. By default we can self-inject.
And we can use `@Skip` to inject from parent.

WARNING!!! In this pull request, by default we inject from parent, and use `selfInject` parameter to control whether or not self-inject.

By the way. I don't think v3.0.2 is a patch update. It should be a minor update at least. It is not a  compatible update.
![image](https://user-images.githubusercontent.com/4965664/104687179-a6e96c80-5739-11eb-9e5b-5a7afc72d54f.png)

@CyberAP @69hunter 