### PR TITLE
fix(toRef): ref created from union typed prop can't be used in watch

### DIFF
--- a/packages/reactivity/src/ref.ts
+++ b/packages/reactivity/src/ref.ts
@@ -20,7 +20,7 @@ export interface Ref<T = any> {
   _shallow?: boolean
 }
 
-export type ToRef<T> = T extends Ref ? T : Ref<UnwrapRef<T>>
+export type ToRef<T> = [T] extends [Ref] ? T : Ref<UnwrapRef<T>>
 export type ToRefs<T = any> = {
   // #2687: somehow using ToRef<T[K]> here turns the resulting type into
   // a union of multiple Ref<*> types instead of a single Ref<* | *> type.

--- a/test-dts/ref.test-d.ts
+++ b/test-dts/ref.test-d.ts
@@ -9,7 +9,8 @@ import {
   proxyRefs,
   toRef,
   toRefs,
-  ToRefs
+  ToRefs,
+  watch
 } from './index'
 
 function plainType(arg: number | Ref<number>) {
@@ -164,6 +165,14 @@ const obj = {
 }
 expectType<Ref<number>>(toRef(obj, 'a'))
 expectType<Ref<number>>(toRef(obj, 'b'))
+
+const objWithUnionProp: { a: string | number } = {
+  a: 1
+}
+
+watch(toRef(objWithUnionProp, 'a'), value => {
+  expectType<string | number>(value)
+})
 
 // toRefs
 const objRefs = toRefs(obj)


### PR DESCRIPTION
Currently `toRef` may create wrong type for `watch` when prop is union typed.

Reproduction:
![image](https://user-images.githubusercontent.com/18677354/104933035-59902800-59e3-11eb-8f90-68935c281fcc.png)
https://codesandbox.io/s/wild-wood-vxm5j?file=/src/index.ts

Related Info:
https://www.typescriptlang.org/docs/handbook/2/conditional-types.html#distributive-conditional-types


