### PR TITLE
fix(compiler-sfc): the empty lang attribute should be treated as no lang specified

### DIFF
--- a/packages/compiler-sfc/__tests__/parse.spec.ts
+++ b/packages/compiler-sfc/__tests__/parse.spec.ts
@@ -139,6 +139,15 @@ h1 { color: red }
     expect(descriptor.template!.content).toBe(content)
   })
 
+  test('treat empty lang attribute as the html', () => {
+    const content = `<div><template v-if="ok">ok</template></div>`
+    const { descriptor, errors } = parse(
+      `<template lang="">${content}</template>`
+    )
+    expect(descriptor.template!.content).toBe(content)
+    expect(errors.length).toBe(0)
+  })
+
   // #1120
   test('alternative template lang should be treated as plain text', () => {
     const content = `p(v-if="1 < 2") test`

--- a/packages/compiler-sfc/src/parse.ts
+++ b/packages/compiler-sfc/src/parse.ts
@@ -121,6 +121,7 @@ export function parse(
               p.type === NodeTypes.ATTRIBUTE &&
               p.name === 'lang' &&
               p.value &&
+              p.value.content &&
               p.value.content !== 'html'
           ))
       ) {


### PR DESCRIPTION
close: #3046 