### PR TITLE
fix(reactivity): avoid duplication proxy

### DIFF
--- a/.github/workflows/size-check.yml
+++ b/.github/workflows/size-check.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: bahmutov/npm-install@v1
 
-      - uses: posva/size-check-action@v1.1.0
+      - uses: posva/size-check-action@v1.1.2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           build_script: size

--- a/packages/reactivity/__tests__/readonly.spec.ts
+++ b/packages/reactivity/__tests__/readonly.spec.ts
@@ -325,12 +325,18 @@ describe('reactivity/readonly', () => {
     })
   })
 
-  test('calling reactive on an readonly should return readonly', () => {
+  test('calling reactive on an readonly should return reactive', () => {
     const a = readonly({})
     const b = reactive(a)
-    expect(isReadonly(b)).toBe(true)
+    expect(isReactive(b)).toBe(true)
     // should point to same original
     expect(toRaw(a)).toBe(toRaw(b))
+  })
+
+  test('calling reactive on an nesting object, if the object property is readonly, get the value of the property will get the readonly version', () => {
+    const a = readonly({})
+    const b = reactive({ a: a })
+    expect(isReadonly(b.a)).toBe(true)
   })
 
   test('calling readonly on a reactive object should return readonly', () => {

--- a/packages/reactivity/src/baseHandlers.ts
+++ b/packages/reactivity/src/baseHandlers.ts
@@ -118,7 +118,7 @@ function createGetter(isReadonly = false, shallow = false) {
       // Convert returned value into a proxy as well. we do the isObject check
       // here to avoid invalid value warning. Also need to lazy access readonly
       // and reactive here to avoid circular dependency.
-      return isReadonly ? readonly(res) : reactive(res)
+      return isReadonly ? readonly(res, false) : reactive(res, false)
     }
 
     return res

--- a/packages/reactivity/src/collectionHandlers.ts
+++ b/packages/reactivity/src/collectionHandlers.ts
@@ -18,10 +18,10 @@ type MapTypes = Map<any, any> | WeakMap<any, any>
 type SetTypes = Set<any> | WeakSet<any>
 
 const toReactive = <T extends unknown>(value: T): T =>
-  isObject(value) ? reactive(value) : value
+  isObject(value) ? reactive(value, false) : value
 
 const toReadonly = <T extends unknown>(value: T): T =>
-  isObject(value) ? readonly(value as Record<any, any>) : value
+  isObject(value) ? readonly(value as Record<any, any>, false) : value
 
 const toShallow = <T extends unknown>(value: T): T => value
 

--- a/packages/reactivity/src/reactive.ts
+++ b/packages/reactivity/src/reactive.ts
@@ -96,14 +96,20 @@ type UnwrapNestedRefs<T> = T extends Ref ? T : UnwrapRef<T>
  * ```
  */
 export function reactive<T extends object>(target: T): UnwrapNestedRefs<T>
-export function reactive(target: object) {
+
+export function reactive<T extends object>(
+  target: T,
+  force: boolean
+): UnwrapNestedRefs<T>
+
+export function reactive(target: object, force: boolean = true) {
   return createReactiveObject(
     target,
     false,
     false,
     mutableHandlers,
     mutableCollectionHandlers,
-    false
+    force
   )
 }
 
@@ -112,14 +118,17 @@ export function reactive(target: object) {
  * level properties are reactive. It also does not auto-unwrap refs (even at the
  * root level).
  */
-export function shallowReactive<T extends object>(target: T): T {
+export function shallowReactive<T extends object>(
+  target: T,
+  force: boolean = true
+): T {
   return createReactiveObject(
     target,
     false,
     true,
     shallowReactiveHandlers,
     shallowCollectionHandlers,
-    false
+    force
   )
 }
 
@@ -150,7 +159,8 @@ export type DeepReadonly<T> = T extends Builtin
  * made reactive, but `readonly` can be called on an already reactive object.
  */
 export function readonly<T extends object>(
-  target: T
+  target: T,
+  force: boolean = true
 ): DeepReadonly<UnwrapNestedRefs<T>> {
   return createReactiveObject(
     target,
@@ -158,7 +168,7 @@ export function readonly<T extends object>(
     false,
     readonlyHandlers,
     readonlyCollectionHandlers,
-    false
+    force
   )
 }
 
@@ -169,7 +179,8 @@ export function readonly<T extends object>(
  * This is used for creating the props proxy object for stateful components.
  */
 export function shallowReadonly<T extends object>(
-  target: T
+  target: T,
+  force: boolean = true
 ): Readonly<{ [K in keyof T]: UnwrapNestedRefs<T[K]> }> {
   return createReactiveObject(
     target,
@@ -177,7 +188,7 @@ export function shallowReadonly<T extends object>(
     true,
     shallowReadonlyHandlers,
     readonlyCollectionHandlers,
-    false
+    force
   )
 }
 
@@ -187,7 +198,7 @@ function createReactiveObject(
   shallow: boolean,
   baseHandlers: ProxyHandler<any>,
   collectionHandlers: ProxyHandler<any>,
-  force: Boolean = false
+  force: boolean
 ) {
   if (!isObject(target)) {
     if (__DEV__) {

--- a/packages/reactivity/src/reactive.ts
+++ b/packages/reactivity/src/reactive.ts
@@ -102,7 +102,8 @@ export function reactive(target: object) {
     false,
     false,
     mutableHandlers,
-    mutableCollectionHandlers
+    mutableCollectionHandlers,
+    false
   )
 }
 
@@ -117,7 +118,8 @@ export function shallowReactive<T extends object>(target: T): T {
     false,
     true,
     shallowReactiveHandlers,
-    shallowCollectionHandlers
+    shallowCollectionHandlers,
+    false
   )
 }
 
@@ -155,7 +157,8 @@ export function readonly<T extends object>(
     true,
     false,
     readonlyHandlers,
-    readonlyCollectionHandlers
+    readonlyCollectionHandlers,
+    false
   )
 }
 
@@ -173,7 +176,8 @@ export function shallowReadonly<T extends object>(
     true,
     true,
     shallowReadonlyHandlers,
-    readonlyCollectionHandlers
+    readonlyCollectionHandlers,
+    false
   )
 }
 
@@ -182,7 +186,8 @@ function createReactiveObject(
   isReadonly: boolean,
   shallow: boolean,
   baseHandlers: ProxyHandler<any>,
-  collectionHandlers: ProxyHandler<any>
+  collectionHandlers: ProxyHandler<any>,
+  force: Boolean = false
 ) {
   if (!isObject(target)) {
     if (__DEV__) {
@@ -206,10 +211,14 @@ function createReactiveObject(
       return target
     }
     if (!isReadonly || !target[ReactiveFlags.IS_REACTIVE]) {
-      target = toRaw(target)
-      const existingProxy = proxyMap.get(target)
-      if (existingProxy) {
-        return existingProxy
+      if (!force) {
+        return target
+      } else {
+        target = toRaw(target)
+        const existingProxy = proxyMap.get(target)
+        if (existingProxy) {
+          return existingProxy
+        }
       }
     }
   }

--- a/packages/reactivity/src/reactive.ts
+++ b/packages/reactivity/src/reactive.ts
@@ -83,10 +83,6 @@ type UnwrapNestedRefs<T> = T extends Ref ? T : UnwrapRef<T>
  */
 export function reactive<T extends object>(target: T): UnwrapNestedRefs<T>
 export function reactive(target: object) {
-  // if trying to observe a readonly proxy, return the readonly version.
-  if (target && (target as Target)[ReactiveFlags.IS_READONLY]) {
-    return target
-  }
   return createReactiveObject(
     target,
     false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -882,9 +882,9 @@
   integrity sha1-aaI6OtKcrwCX8G7aWbNh7i8GOfY=
 
 "@types/node@*", "@types/node@^14.10.1":
-  version "14.14.14"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.14.tgz#f7fd5f3cc8521301119f63910f0fb965c7d761ae"
-  integrity sha512-UHnOPWVWV1z+VV8k6L1HhG7UbGBgIdghqF3l9Ny9ApPghbjICXkUJSd/b9gOgQfjM1r+37cipdw/HJ3F6ICEnQ==
+  version "14.14.16"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.16.tgz#3cc351f8d48101deadfed4c9e4f116048d437b4b"
+  integrity sha512-naXYePhweTi+BMv11TgioE2/FXU4fSl29HAH1ffxVciNsH3rYXjNP2yM8wqmSm7jS20gM8TIklKiTen+1iVncw==
 
 "@types/node@10.17.13":
   version "10.17.13"

--- a/yarn.lock
+++ b/yarn.lock
@@ -938,35 +938,35 @@
     "@types/yargs-parser" "*"
 
 "@typescript-eslint/parser@^4.1.1":
-  version "4.11.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.11.0.tgz#1dd3d7e42708c10ce9f3aa64c63c0ab99868b4e2"
-  integrity sha512-NBTtKCC7ZtuxEV5CrHUO4Pg2s784pvavc3cnz6V+oJvVbK4tH9135f/RBP6eUA2KHiFKAollSrgSctQGmHbqJQ==
+  version "4.11.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.11.1.tgz#981e18de2e019d6ca312596615f92e8f6f6598ed"
+  integrity sha512-BJ3jwPQu1jeynJ5BrjLuGfK/UJu6uwHxJ/di7sanqmUmxzmyIcd3vz58PMR7wpi8k3iWq2Q11KMYgZbUpRoIPw==
   dependencies:
-    "@typescript-eslint/scope-manager" "4.11.0"
-    "@typescript-eslint/types" "4.11.0"
-    "@typescript-eslint/typescript-estree" "4.11.0"
+    "@typescript-eslint/scope-manager" "4.11.1"
+    "@typescript-eslint/types" "4.11.1"
+    "@typescript-eslint/typescript-estree" "4.11.1"
     debug "^4.1.1"
 
-"@typescript-eslint/scope-manager@4.11.0":
-  version "4.11.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.11.0.tgz#2d906537db8a3a946721699e4fc0833810490254"
-  integrity sha512-6VSTm/4vC2dHM3ySDW9Kl48en+yLNfVV6LECU8jodBHQOhO8adAVizaZ1fV0QGZnLQjQ/y0aBj5/KXPp2hBTjA==
+"@typescript-eslint/scope-manager@4.11.1":
+  version "4.11.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.11.1.tgz#72dc2b60b0029ab0888479b12bf83034920b4b69"
+  integrity sha512-Al2P394dx+kXCl61fhrrZ1FTI7qsRDIUiVSuN6rTwss6lUn8uVO2+nnF4AvO0ug8vMsy3ShkbxLu/uWZdTtJMQ==
   dependencies:
-    "@typescript-eslint/types" "4.11.0"
-    "@typescript-eslint/visitor-keys" "4.11.0"
+    "@typescript-eslint/types" "4.11.1"
+    "@typescript-eslint/visitor-keys" "4.11.1"
 
-"@typescript-eslint/types@4.11.0":
-  version "4.11.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.11.0.tgz#86cf95e7eac4ccfd183f9fcf1480cece7caf4ca4"
-  integrity sha512-XXOdt/NPX++txOQHM1kUMgJUS43KSlXGdR/aDyEwuAEETwuPt02Nc7v+s57PzuSqMbNLclblQdv3YcWOdXhQ7g==
+"@typescript-eslint/types@4.11.1":
+  version "4.11.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.11.1.tgz#3ba30c965963ef9f8ced5a29938dd0c465bd3e05"
+  integrity sha512-5kvd38wZpqGY4yP/6W3qhYX6Hz0NwUbijVsX2rxczpY6OXaMxh0+5E5uLJKVFwaBM7PJe1wnMym85NfKYIh6CA==
 
-"@typescript-eslint/typescript-estree@4.11.0":
-  version "4.11.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.11.0.tgz#1144d145841e5987d61c4c845442a24b24165a4b"
-  integrity sha512-eA6sT5dE5RHAFhtcC+b5WDlUIGwnO9b0yrfGa1mIOIAjqwSQCpXbLiFmKTdRbQN/xH2EZkGqqLDrKUuYOZ0+Hg==
+"@typescript-eslint/typescript-estree@4.11.1":
+  version "4.11.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.11.1.tgz#a4416b4a65872a48773b9e47afabdf7519eb10bc"
+  integrity sha512-tC7MKZIMRTYxQhrVAFoJq/DlRwv1bnqA4/S2r3+HuHibqvbrPcyf858lNzU7bFmy4mLeIHFYr34ar/1KumwyRw==
   dependencies:
-    "@typescript-eslint/types" "4.11.0"
-    "@typescript-eslint/visitor-keys" "4.11.0"
+    "@typescript-eslint/types" "4.11.1"
+    "@typescript-eslint/visitor-keys" "4.11.1"
     debug "^4.1.1"
     globby "^11.0.1"
     is-glob "^4.0.1"
@@ -974,12 +974,12 @@
     semver "^7.3.2"
     tsutils "^3.17.1"
 
-"@typescript-eslint/visitor-keys@4.11.0":
-  version "4.11.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.11.0.tgz#906669a50f06aa744378bb84c7d5c4fdbc5b7d51"
-  integrity sha512-tRYKyY0i7cMk6v4UIOCjl1LhuepC/pc6adQqJk4Is3YcC6k46HvsV9Wl7vQoLbm9qADgeujiT7KdLrylvFIQ+A==
+"@typescript-eslint/visitor-keys@4.11.1":
+  version "4.11.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.11.1.tgz#4c050a4c1f7239786e2dd4e69691436143024e05"
+  integrity sha512-IrlBhD9bm4bdYcS8xpWarazkKXlE7iYb1HzRuyBP114mIaj5DJPo11Us1HgH60dTt41TCZXMaTCAW+OILIYPOg==
   dependencies:
-    "@typescript-eslint/types" "4.11.0"
+    "@typescript-eslint/types" "4.11.1"
     eslint-visitor-keys "^2.0.0"
 
 "@zeit/schemas@2.6.0":


### PR DESCRIPTION
in vue3, designing reactiveMap and readonlyMap is for cache the proxy version if the target has the proxy or the target is a proxy, but in you pr, the code below will cause the cache useless
```javascript
let proxy = reactive(origin)
let shallowProxy = shallowProxy(origin)

let proxyCopy = reactive(shallowProxy)
proxyCopy === proxy // false
```
in code above, i want to make proxyCopy === proxy returns true
in order to solve the problem,the createReactiveObject function may modify follow below
```javascript
function createReactiveObject(
  target: Target,
  isReadonly: boolean,
  shallow: boolean,
  baseHandlers: ProxyHandler<any>,
  collectionHandlers: ProxyHandler<any>
) {
  if (!isObject(target)) {
    if (__DEV__) {
      console.warn(`value cannot be made reactive: ${String(target)}`)
    }
    return target
  }
  const proxyMap = getProxyMap(isReadonly, shallow)
  // target already has corresponding Proxy
  const existingProxy = proxyMap.get(target)
  if (existingProxy) {
    return existingProxy
  }
  // target is already a Proxy, return it.
  // exception: calling readonly() on a reactive object
  if (target[ReactiveFlags.RAW]) {
    if (
      target[ReactiveFlags.IS_READONLY] === isReadonly &&
      target[ReactiveFlags.IS_SHALLOW] === shallow
    ) {
      return target
    }
    if (!isReadonly || !target[ReactiveFlags.IS_REACTIVE]) {
      target = toRaw(target)
      const existingProxy = proxyMap.get(target)
      if (existingProxy) {
        return existingProxy
      }
    }
  }
  // only a whitelist of value types can be observed.
  const targetType = getTargetType(target)
  if (targetType === TargetType.INVALID) {
    return target
  }
  const proxy = new Proxy(
    target,
    targetType === TargetType.COLLECTION ? collectionHandlers : baseHandlers
  )
  proxyMap.set(target, proxy)
  return proxy
}
```