### PR TITLE
fix(compiler): add not null checking for static slot name

### DIFF
--- a/packages/compiler-core/src/transforms/vSlot.ts
+++ b/packages/compiler-core/src/transforms/vSlot.ts
@@ -199,7 +199,7 @@ export function buildSlots(
 
     // check if name is dynamic.
     let staticSlotName: string | undefined
-    if (isStaticExp(slotName)) {
+    if (!slotName || isStaticExp(slotName)) {
       staticSlotName = slotName ? slotName.content : `default`
     } else {
       hasDynamicSlots = true


### PR DESCRIPTION
There may have very edge case that `slotName` is null, this pr is adding the not null checking for it.