### PR TITLE
fix(rumtime-core): custom dom props should be cloned when cloning a hoisted DOM

### DIFF
--- a/packages/runtime-core/src/renderer.ts
+++ b/packages/runtime-core/src/renderer.ts
@@ -712,7 +712,7 @@ function baseCreateRenderer(
       // Only static vnodes can be reused, so its mounted DOM nodes should be
       // exactly the same, and we can simply do a clone here.
       // only do this in production since cloned trees cannot be HMR updated.
-      vnode.el = hostCloneNode(vnode.el)
+      el = vnode.el = hostCloneNode(vnode.el)
     } else {
       el = vnode.el = hostCreateElement(
         vnode.type as string,

--- a/packages/runtime-core/src/renderer.ts
+++ b/packages/runtime-core/src/renderer.ts
@@ -712,14 +712,7 @@ function baseCreateRenderer(
       // Only static vnodes can be reused, so its mounted DOM nodes should be
       // exactly the same, and we can simply do a clone here.
       // only do this in production since cloned trees cannot be HMR updated.
-      el = hostCloneNode(vnode.el)
-      // #3072
-      // should clone custom DOM props,
-      // one of the use cases is that the input tag or other form tags are hoisted,
-      // and for performance reasons, we intentionally avoid using the hostPatchProp
-      el._value = vnode.el._value
-
-      vnode.el = el
+      vnode.el = hostCloneNode(vnode.el)
     } else {
       el = vnode.el = hostCreateElement(
         vnode.type as string,

--- a/packages/runtime-core/src/renderer.ts
+++ b/packages/runtime-core/src/renderer.ts
@@ -712,7 +712,14 @@ function baseCreateRenderer(
       // Only static vnodes can be reused, so its mounted DOM nodes should be
       // exactly the same, and we can simply do a clone here.
       // only do this in production since cloned trees cannot be HMR updated.
-      el = vnode.el = hostCloneNode(vnode.el)
+      el = hostCloneNode(vnode.el)
+      // #3072
+      // should clone custom DOM props,
+      // one of the use cases is that the input tag or other form tags are hoisted,
+      // and for performance reasons, we intentionally avoid using the hostPatchProp
+      el._value = vnode.el._value
+
+      vnode.el = el
     } else {
       el = vnode.el = hostCreateElement(
         vnode.type as string,

--- a/packages/runtime-dom/__tests__/nodeOps.spec.ts
+++ b/packages/runtime-dom/__tests__/nodeOps.spec.ts
@@ -1,0 +1,12 @@
+import { nodeOps } from '../src/nodeOps'
+
+describe('nodeOps', () => {
+  test('the _value property should be cloned', () => {
+    const el = nodeOps.createElement('input') as HTMLDivElement & {
+      _value: any
+    }
+    el._value = 1
+    const cloned = nodeOps.cloneNode!(el) as HTMLDivElement & { _value: any }
+    expect(cloned._value).toBe(1)
+  })
+})

--- a/packages/runtime-dom/src/nodeOps.ts
+++ b/packages/runtime-dom/src/nodeOps.ts
@@ -47,7 +47,17 @@ export const nodeOps: Omit<RendererOptions<Node, Element>, 'patchProp'> = {
   },
 
   cloneNode(el) {
-    return el.cloneNode(true)
+    const cloned = el.cloneNode(true)
+    // #3072
+    // should clone the custom DOM props,
+    // in `patchDOMProp`, we store the actual value in the `el._value` property,
+    // but these elements may be hoisted, and the hoisted elements will be cloned in the prod env,
+    // so we should keep it when cloning, and in the future,
+    // we may clone more custom DOM props when necessary, not just `_value`.
+    if (cloned.nodeType === Node.ELEMENT_NODE) {
+      ;(cloned as any)._value = (el as any)._value
+    }
+    return cloned
   },
 
   // __UNSAFE__


### PR DESCRIPTION
close: #3072 
related: https://github.com/vuejs/vue-next/issues/3091