### PR TITLE
fix: remove superfluous spaces when normalizing class

### DIFF
--- a/packages/shared/__tests__/normalizeProp.spec.ts
+++ b/packages/shared/__tests__/normalizeProp.spec.ts
@@ -1,0 +1,17 @@
+import { normalizeClass } from '../src'
+
+describe('normalizeClass', () => {
+  test('handles string correctly', () => {
+    expect(normalizeClass('foo')).toEqual('foo')
+  })
+
+  test('handles array correctly', () => {
+    expect(normalizeClass(['foo', undefined, true, false, 'bar'])).toEqual('foo bar')
+  })
+
+  test('handles object correctly', () => {
+    expect(normalizeClass({ foo: true, bar: false, baz: true })).toEqual(
+      'foo baz'
+    )
+  })
+})

--- a/packages/shared/src/normalizeProp.ts
+++ b/packages/shared/src/normalizeProp.ts
@@ -62,7 +62,10 @@ export function normalizeClass(value: unknown): string {
     res = value
   } else if (isArray(value)) {
     for (let i = 0; i < value.length; i++) {
-      res += normalizeClass(value[i]) + ' '
+      const normalized = normalizeClass(value[i])
+      if (normalized.length) {
+        res += normalized + ' '
+      }
     }
   } else if (isObject(value)) {
     for (const name in value) {

--- a/packages/shared/src/normalizeProp.ts
+++ b/packages/shared/src/normalizeProp.ts
@@ -63,7 +63,7 @@ export function normalizeClass(value: unknown): string {
   } else if (isArray(value)) {
     for (let i = 0; i < value.length; i++) {
       const normalized = normalizeClass(value[i])
-      if (normalized.length) {
+      if (normalized) {
         res += normalized + ' '
       }
     }


### PR DESCRIPTION
Having any other primitive value than string in an array sent to `normalizeClass` results in extra spaces. In v2 there are no extra spaces.

```js
h('div', {
  class: ['foo', undefined, false, 'bar'],
})

<div class="foo   bar"/>
```