### PR TITLE
fix(runtime-core): allow overriding properties other than props

### DIFF
--- a/packages/runtime-core/__tests__/componentProps.spec.ts
+++ b/packages/runtime-core/__tests__/componentProps.spec.ts
@@ -295,6 +295,10 @@ describe('component props', () => {
       ;(instance!.proxy as any).foo = 2
     }).toThrow(TypeError)
     expect(`Attempting to mutate prop "foo"`).toHaveBeenWarned()
+    // should not throw when overriding properties other than props
+    expect(() => {
+      ;(instance!.proxy as any).hasOwnProperty = () => {}
+    }).not.toThrow(TypeError)
   })
 
   test('merging props from mixins and extends', () => {

--- a/packages/runtime-core/src/componentPublicInstance.ts
+++ b/packages/runtime-core/src/componentPublicInstance.ts
@@ -368,7 +368,7 @@ export const PublicInstanceProxyHandlers: ProxyHandler<any> = {
       setupState[key] = value
     } else if (data !== EMPTY_OBJ && hasOwn(data, key)) {
       data[key] = value
-    } else if (key in instance.props) {
+    } else if (hasOwn(instance.props, key)) {
       __DEV__ &&
         warn(
           `Attempting to mutate prop "${key}". Props are readonly.`,


### PR DESCRIPTION
You currently can't add properties like `hasOwnProperty` to the proxied objects as the check uses `in` to verify if it is not a prop mutation.

This is useful for testing, as Jest can't spy on an object without `hasOwnProperty`.
VTU can add it, but this commit is needed first.

Related https://github.com/vuejs/vue-test-utils-next/pull/310