### PR TITLE
Fix the vue-devtools's directory tree not refresh after add components.

### DIFF
--- a/packages/runtime-core/src/component.ts
+++ b/packages/runtime-core/src/component.ts
@@ -56,7 +56,6 @@ import {
   markAttrsAccessed
 } from './componentRenderUtils'
 import { startMeasure, endMeasure } from './profiling'
-import { devtoolsComponentAdded } from './devtools'
 
 export type Data = Record<string, unknown>
 
@@ -485,10 +484,6 @@ export function createComponentInstance(
   }
   instance.root = parent ? parent.root : instance
   instance.emit = emit.bind(null, instance)
-
-  if (__DEV__ || __FEATURE_PROD_DEVTOOLS__) {
-    devtoolsComponentAdded(instance)
-  }
 
   return instance
 }

--- a/packages/runtime-core/src/renderer.ts
+++ b/packages/runtime-core/src/renderer.ts
@@ -72,7 +72,7 @@ import { createHydrationFunctions, RootHydrateFunction } from './hydration'
 import { invokeDirectiveHook } from './directives'
 import { startMeasure, endMeasure } from './profiling'
 import { ComponentPublicInstance } from './componentPublicInstance'
-import { devtoolsComponentRemoved, devtoolsComponentUpdated } from './devtools'
+import { devtoolsComponentRemoved, devtoolsComponentUpdated, devtoolsComponentAdded } from './devtools'
 import { initFeatureFlags } from './featureFlags'
 import { isAsyncWrapper } from './apiAsyncComponent'
 
@@ -1285,6 +1285,10 @@ function baseCreateRenderer(
     if (__DEV__) {
       popWarningContext()
       endMeasure(instance, `mount`)
+    }
+
+    if (__DEV__ || __FEATURE_PROD_DEVTOOLS__) {
+      devtoolsComponentAdded(instance)
     }
   }
 


### PR DESCRIPTION
First of all, by tracking the source code, I found that the issue of https://github.com/vuejs/vue-devtools/issues/1348 was caused by the vue source code sending abnormal data to `vue-devtools`.

Then I adjusted the execution order of `devtoolsComponentAdded`. After adjustment, when vue adds new components, the directory tree of `vue-devools` can respond in real time. (It cannot respond in real time before adjustment).

After adjustment, also has a strange thing when component 1 is added first, then component 2 is added, everything is normal; but if component 2 is added first, then component 1 is added, a bug will appear, and the directory tree of `vue-devtools` only displays component 1.

The above problem seems to be caused by vue sending abnormal data to `vue-devtools`, maybe I should resubmit an issue?


