### PR TITLE
fix(runtime-core): InjectionKey compatible with symbol type

### DIFF
--- a/packages/runtime-core/src/apiInject.ts
+++ b/packages/runtime-core/src/apiInject.ts
@@ -3,7 +3,7 @@ import { currentInstance } from './component'
 import { currentRenderingInstance } from './componentRenderUtils'
 import { warn } from './warning'
 
-export interface InjectionKey<T> extends Symbol {}
+export type InjectionKey<T> = symbol
 
 export function provide<T>(key: InjectionKey<T> | string | number, value: T) {
   if (!currentInstance) {

--- a/test-dts/inject.test-d.ts
+++ b/test-dts/inject.test-d.ts
@@ -13,3 +13,6 @@ expectType<number>(inject(key, () => 1, true /* treatDefaultAsFactory */))
 expectType<() => number>(inject('foo', () => 1))
 expectType<() => number>(inject('foo', () => 1, false))
 expectType<number>(inject('foo', () => 1, true))
+
+// InjectionKey should be compatible with the `symbol` type
+expectType<Record<symbol, number>>({ [key]: 2 })


### PR DESCRIPTION
The current type of `InjectionKey` does not allow to use it as an ES computed property.
This is problematic as the API of `mount` in VTU lets you add providers with `provide: { key: value }`.
If you want to use a key defined as:

    export const storeKey: InjectionKey<Store<State>> = Symbol();

Then you currently have to cast the key as symbol:

    const wrapper = mount(App, { global: { provide: { [storeKey as symbol]: store } } });

This commit allows to use:

    const wrapper = mount(AppWithVuex, { global: { provide: { [storeKey]: store } } });