### PR TITLE
fix(runtime-core): RequiredKeys marking defaults as required (fix #3122)

### DIFF
--- a/packages/runtime-core/src/componentProps.ts
+++ b/packages/runtime-core/src/componentProps.ts
@@ -67,7 +67,6 @@ type PropMethod<T, TConstructor = any> = T extends (...args: any) => any // if i
 type RequiredKeys<T> = {
   [K in keyof T]: T[K] extends
     | { required: true }
-    | { default: any }
     // don't mark Boolean props as undefined
     | BooleanConstructor
     | { type: BooleanConstructor }


### PR DESCRIPTION
Remove extension condition check that was marking props with `default` as required, even if `required: false` was explicitly passed.

Reproduction link: https://codesandbox.io/s/stoic-hamilton-t8cft?file=/src/index.ts

![image](https://user-images.githubusercontent.com/4924420/106281365-6a406980-623f-11eb-8437-bedad882d66f.png)
