### PR TITLE
Fix missing whitespace issue in srcsets

### DIFF
--- a/packages/compiler-sfc/__tests__/__snapshots__/templateTransformSrcset.spec.ts.snap
+++ b/packages/compiler-sfc/__tests__/__snapshots__/templateTransformSrcset.spec.ts.snap
@@ -6,13 +6,13 @@ import _imports_0 from './logo.png'
 
 
 const _hoisted_1 = _imports_0
-const _hoisted_2 = _imports_0 + '2x'
-const _hoisted_3 = _imports_0 + '2x'
-const _hoisted_4 = _imports_0 + ', ' + _imports_0 + '2x'
-const _hoisted_5 = _imports_0 + '2x, ' + _imports_0
-const _hoisted_6 = _imports_0 + '2x, ' + _imports_0 + '3x'
-const _hoisted_7 = _imports_0 + ', ' + _imports_0 + '2x, ' + _imports_0 + '3x'
-const _hoisted_8 = \\"/logo.png\\" + ', ' + _imports_0 + '2x'
+const _hoisted_2 = _imports_0 + ' 2x'
+const _hoisted_3 = _imports_0 + ' 2x'
+const _hoisted_4 = _imports_0 + ', ' + _imports_0 + ' 2x'
+const _hoisted_5 = _imports_0 + ' 2x, ' + _imports_0
+const _hoisted_6 = _imports_0 + ' 2x, ' + _imports_0 + ' 3x'
+const _hoisted_7 = _imports_0 + ', ' + _imports_0 + ' 2x, ' + _imports_0 + ' 3x'
+const _hoisted_8 = \\"/logo.png\\" + ', ' + _imports_0 + ' 2x'
 
 export function render(_ctx, _cache) {
   return (_openBlock(), _createBlock(_Fragment, null, [
@@ -124,16 +124,16 @@ import _imports_1 from '/logo.png'
 
 
 const _hoisted_1 = _imports_0
-const _hoisted_2 = _imports_0 + '2x'
-const _hoisted_3 = _imports_0 + '2x'
-const _hoisted_4 = _imports_0 + ', ' + _imports_0 + '2x'
-const _hoisted_5 = _imports_0 + '2x, ' + _imports_0
-const _hoisted_6 = _imports_0 + '2x, ' + _imports_0 + '3x'
-const _hoisted_7 = _imports_0 + ', ' + _imports_0 + '2x, ' + _imports_0 + '3x'
-const _hoisted_8 = _imports_1 + ', ' + _imports_1 + '2x'
-const _hoisted_9 = \\"https://example.com/logo.png\\" + ', ' + \\"https://example.com/logo.png\\" + '2x'
-const _hoisted_10 = _imports_1 + ', ' + _imports_0 + '2x'
-const _hoisted_11 = \\"data:image/png;base64,i\\" + '1x, ' + \\"data:image/png;base64,i\\" + '2x'
+const _hoisted_2 = _imports_0 + ' 2x'
+const _hoisted_3 = _imports_0 + ' 2x'
+const _hoisted_4 = _imports_0 + ', ' + _imports_0 + ' 2x'
+const _hoisted_5 = _imports_0 + ' 2x, ' + _imports_0
+const _hoisted_6 = _imports_0 + ' 2x, ' + _imports_0 + ' 3x'
+const _hoisted_7 = _imports_0 + ', ' + _imports_0 + ' 2x, ' + _imports_0 + ' 3x'
+const _hoisted_8 = _imports_1 + ', ' + _imports_1 + ' 2x'
+const _hoisted_9 = \\"https://example.com/logo.png\\" + ', ' + \\"https://example.com/logo.png\\" + ' 2x'
+const _hoisted_10 = _imports_1 + ', ' + _imports_0 + ' 2x'
+const _hoisted_11 = \\"data:image/png;base64,i\\" + ' 1x, ' + \\"data:image/png;base64,i\\" + ' 2x'
 
 export function render(_ctx, _cache) {
   return (_openBlock(), _createBlock(_Fragment, null, [

--- a/packages/compiler-sfc/package.json
+++ b/packages/compiler-sfc/package.json
@@ -7,6 +7,9 @@
   "files": [
     "dist"
   ],
+  "scripts": {
+    "prepare": "npm run build",
+  },
   "buildOptions": {
     "name": "VueCompilerSFC",
     "formats": [

--- a/packages/compiler-sfc/package.json
+++ b/packages/compiler-sfc/package.json
@@ -7,9 +7,6 @@
   "files": [
     "dist"
   ],
-  "scripts": {
-    "prepare": "npm run build",
-  },
   "buildOptions": {
     "name": "VueCompilerSFC",
     "formats": [

--- a/packages/compiler-sfc/src/templateTransformSrcset.ts
+++ b/packages/compiler-sfc/src/templateTransformSrcset.ts
@@ -132,9 +132,9 @@ export const transformSrcset: NodeTransform = (
             }
             const isNotLast = imageCandidates.length - 1 > index
             if (descriptor && isNotLast) {
-              compoundExpression.children.push(` + '${descriptor}, ' + `)
+              compoundExpression.children.push(` + ' ${descriptor}, ' + `)
             } else if (descriptor) {
-              compoundExpression.children.push(` + '${descriptor}'`)
+              compoundExpression.children.push(` + ' ${descriptor}'`)
             } else if (isNotLast) {
               compoundExpression.children.push(` + ', ' + `)
             }


### PR DESCRIPTION
This pull requests fixes issues #3069, #1626 (as well as #1587) where the generated srcset would be invalid because the space between url and descriptor was missing. This PR aims at resolving this as it makes secret basically unusable.

The solution is to simply add a space in front and has already been used on [line 81](https://github.com/JonasKruckenberg/vue-next/blob/80a904e12517b1d594f6dab0f7bd14be2dbe6158/packages/compiler-sfc/src/templateTransformSrcset.ts#L81) so I think this should be really uncontroversial.
Cheers!