### PR TITLE
fix(scopeId): make slotted scopeId work with Transition/TransitionGroup/KeepAlive component

### DIFF
--- a/packages/runtime-core/__tests__/components/KeepAlive.spec.ts
+++ b/packages/runtime-core/__tests__/components/KeepAlive.spec.ts
@@ -809,7 +809,9 @@ describe('KeepAlive', () => {
       __scopeId: 'foo',
       render: withId(() => {
         return h(KeepAlive, null, {
-          default: () => h(views[viewRef.value], { ref: instanceRef })
+          // since the children of the KeepAlive component will not be compiled as slots,
+          // so, the parent's scopeId should be attached to it's children
+          default: withId(() => h(views[viewRef.value], { ref: instanceRef }))
         })
       })
     }

--- a/packages/runtime-core/src/component.ts
+++ b/packages/runtime-core/src/component.ts
@@ -90,6 +90,10 @@ export interface ComponentInternalOptions {
   /**
    * @internal
    */
+  __inheritScopeId?: boolean
+  /**
+   * @internal
+   */
   __cssModules?: Data
   /**
    * @internal

--- a/packages/runtime-core/src/components/BaseTransition.ts
+++ b/packages/runtime-core/src/components/BaseTransition.ts
@@ -113,6 +113,8 @@ const TransitionHookValidator = [Function, Array]
 const BaseTransitionImpl = {
   name: `BaseTransition`,
 
+  __inheritScopeId: true,
+
   props: {
     mode: String,
     appear: Boolean,

--- a/packages/runtime-core/src/components/KeepAlive.ts
+++ b/packages/runtime-core/src/components/KeepAlive.ts
@@ -70,6 +70,8 @@ const KeepAliveImpl = {
   // would prevent it from being tree-shaken.
   __isKeepAlive: true,
 
+  __inheritScopeId: true,
+
   inheritRef: true,
 
   props: {

--- a/packages/runtime-core/src/renderer.ts
+++ b/packages/runtime-core/src/renderer.ts
@@ -799,6 +799,15 @@ function baseCreateRenderer(
     }
   }
 
+  const getTreeOwnerWithScopeId = (
+    parent: ComponentInternalInstance
+  ): ComponentInternalInstance => {
+    if (parent.type.__inheritScopeId && parent.parent) {
+      return getTreeOwnerWithScopeId(parent.parent)
+    }
+    return parent
+  }
+
   const setScopeId = (
     el: RendererElement,
     scopeId: string | false | null,
@@ -809,13 +818,14 @@ function baseCreateRenderer(
       hostSetScopeId(el, scopeId)
     }
     if (parentComponent) {
-      const treeOwnerId = parentComponent.type.__scopeId
+      const treeOwner = getTreeOwnerWithScopeId(parentComponent)
+      const treeOwnerId = treeOwner.type.__scopeId
       // vnode's own scopeId and the current patched component's scopeId is
       // different - this is a slot content node.
       if (treeOwnerId && treeOwnerId !== scopeId) {
         hostSetScopeId(el, treeOwnerId + '-s')
       }
-      let subTree = parentComponent.subTree
+      let subTree = treeOwner.subTree
       if (__DEV__ && subTree.type === Fragment) {
         subTree =
           filterSingleRoot(subTree.children as VNodeArrayChildren) || subTree

--- a/packages/runtime-dom/src/components/Transition.ts
+++ b/packages/runtime-dom/src/components/Transition.ts
@@ -43,6 +43,7 @@ export const Transition: FunctionalComponent<TransitionProps> = (
 ) => h(BaseTransition, resolveTransitionProps(props), slots)
 
 Transition.displayName = 'Transition'
+Transition.__inheritScopeId = true
 
 const DOMTransitionPropsValidators = {
   name: String,

--- a/packages/runtime-dom/src/components/TransitionGroup.ts
+++ b/packages/runtime-dom/src/components/TransitionGroup.ts
@@ -40,6 +40,8 @@ export type TransitionGroupProps = Omit<TransitionProps, 'mode'> & {
 const TransitionGroupImpl = {
   name: 'TransitionGroup',
 
+  __inheritScopeId: true,
+
   props: /*#__PURE__*/ extend({}, TransitionPropsValidators, {
     tag: String,
     moveClass: String


### PR DESCRIPTION
Fix: #2892 
