### PR TITLE
types: support object as props type

### DIFF
--- a/packages/runtime-core/src/componentProps.ts
+++ b/packages/runtime-core/src/componentProps.ts
@@ -56,7 +56,7 @@ interface PropOptions<T = any, D = T> {
 export type PropType<T> = PropConstructor<T> | PropConstructor<T>[]
 
 type PropConstructor<T = any> =
-  | { new (...args: any[]): T & object }
+  | { new (...args: any[]): T & {} }
   | { (): T }
   | PropMethod<T>
 

--- a/test-dts/component.test-d.ts
+++ b/test-dts/component.test-d.ts
@@ -39,6 +39,7 @@ describe('object props', () => {
     ggg: 'foo' | 'bar'
     ffff: (a: number, b: string) => { a: boolean }
     validated?: string
+    object?: object
   }
 
   describe('defineComponent', () => {
@@ -106,7 +107,8 @@ describe('object props', () => {
           type: String,
           // validator requires explicit annotation
           validator: (val: unknown) => val !== ''
-        }
+        },
+        object: Object as PropType<object>
       },
       setup(props) {
         return {
@@ -140,6 +142,7 @@ describe('object props', () => {
     expectType<ExpectedProps['ggg']>(props.ggg)
     expectType<ExpectedProps['ffff']>(props.ffff)
     expectType<ExpectedProps['validated']>(props.validated)
+    expectType<ExpectedProps['object']>(props.object)
 
     // raw bindings
     expectType<Number>(rawBindings.setupA)
@@ -263,7 +266,8 @@ describe('object props', () => {
           type: String,
           // validator requires explicit annotation
           validator: (val: unknown) => val !== ''
-        }
+        },
+        object: Object as PropType<object>
       },
 
       setup() {
@@ -293,6 +297,7 @@ describe('object props', () => {
     expectType<ExpectedProps['ggg']>(props.ggg)
     // expectType<ExpectedProps['ffff']>(props.ffff) // todo fix
     expectType<ExpectedProps['validated']>(props.validated)
+    expectType<ExpectedProps['object']>(props.object)
 
     // rawBindings
     expectType<Number>(rawBindings.setupA)


### PR DESCRIPTION
```ts
defineComponent({
  name: "PropsTest",
  props: {
    foo: Object as PropType<object>
  },
  setup(props) {
    props.foo // the foo will be unknown type
  }
});
```

See the repro: https://codesandbox.io/s/busy-murdock-s4vf2?file=/src/index.ts:85-226

The root cause is:

```ts
type value = { new (...args: any[]): object } extends { new (...args: any[]): infer T & object } ? T : any

value // unknown
```
For this case, we can use `{}` instead of `object`.
