### PR TITLE
feat: remove useless option  in KeepAlive

### DIFF
--- a/packages/runtime-core/src/components/KeepAlive.ts
+++ b/packages/runtime-core/src/components/KeepAlive.ts
@@ -70,8 +70,6 @@ const KeepAliveImpl = {
   // would prevent it from being tree-shaken.
   __isKeepAlive: true,
 
-  inheritRef: true,
-
   props: {
     include: [String, RegExp, Array],
     exclude: [String, RegExp, Array],


### PR DESCRIPTION
It seems the `inheritRef` option has been deprecated, I can't find any usage somewhere.

I read about the commit which add `inheritRef` and find it was used to put the `ref` into the root vnode of it's render result. Maybe we do need to add some api like `inheritRef`? I created an issue about this  couple days ago in rfcs, https://github.com/vuejs/rfcs/issues/258