### PR TITLE
fix(jsx): JSX.Element extends VNode

### DIFF
--- a/packages/runtime-core/src/h.ts
+++ b/packages/runtime-core/src/h.ts
@@ -89,14 +89,13 @@ export function h(
 // text/comment
 export function h(
   type: typeof Text | typeof Comment,
-  children?: RawChildren
+  children?: string
 ): VNode
 export function h(
   type: typeof Text | typeof Comment,
-  props?: RawProps | null,
-  children?: RawChildren | RawSlots
+  props?: null,
+  children?: string
 ): VNode
-
 // fragment
 export function h(type: typeof Fragment, children?: VNodeArrayChildren): VNode
 export function h(

--- a/packages/runtime-core/src/h.ts
+++ b/packages/runtime-core/src/h.ts
@@ -89,12 +89,12 @@ export function h(
 // text/comment
 export function h(
   type: typeof Text | typeof Comment,
-  children?: string
+  children?: string | number | boolean
 ): VNode
 export function h(
   type: typeof Text | typeof Comment,
   props?: null,
-  children?: string
+  children?: string | number | boolean
 ): VNode
 // fragment
 export function h(type: typeof Fragment, children?: VNodeArrayChildren): VNode

--- a/packages/runtime-core/src/h.ts
+++ b/packages/runtime-core/src/h.ts
@@ -5,7 +5,6 @@ import {
   VNodeArrayChildren,
   Fragment,
   Text,
-  Static,
   Comment,
   isVNode
 } from './vnode'

--- a/packages/runtime-core/src/h.ts
+++ b/packages/runtime-core/src/h.ts
@@ -4,6 +4,9 @@ import {
   createVNode,
   VNodeArrayChildren,
   Fragment,
+  Text,
+  Static,
+  Comment,
   isVNode
 } from './vnode'
 import { Teleport, TeleportProps } from './components/Teleport'
@@ -80,6 +83,17 @@ interface Constructor<P = any> {
 export function h(type: string, children?: RawChildren): VNode
 export function h(
   type: string,
+  props?: RawProps | null,
+  children?: RawChildren | RawSlots
+): VNode
+
+// text/comment
+export function h(
+  type: typeof Text | typeof Comment,
+  children?: RawChildren
+): VNode
+export function h(
+  type: typeof Text | typeof Comment,
   props?: RawProps | null,
   children?: RawChildren | RawSlots
 ): VNode

--- a/packages/runtime-dom/types/jsx.d.ts
+++ b/packages/runtime-dom/types/jsx.d.ts
@@ -26,6 +26,7 @@
 //                 Kanitkorn Sujautra <https://github.com/lukyth>
 //                 Sebastian Silbermann <https://github.com/eps1lon>
 
+import { VNode } from '@vue/runtime-core'
 import * as CSS from 'csstype'
 
 export interface CSSProperties extends CSS.Properties<string | number> {
@@ -1338,7 +1339,7 @@ type NativeElements = {
 
 declare global {
   namespace JSX {
-    interface Element {}
+    interface Element extends VNode {}
     interface ElementClass {
       $props: {}
     }

--- a/test-dts/functionalComponent.test-d.tsx
+++ b/test-dts/functionalComponent.test-d.tsx
@@ -1,4 +1,6 @@
 import {
+  h,
+  Text,
   FunctionalComponent,
   expectError,
   expectType,
@@ -6,7 +8,7 @@ import {
 } from './index'
 
 // simple function signature
-const Foo = (props: { foo: number }) => props.foo
+const Foo = (props: { foo: number }) => h(Text, null, props.foo)
 
 // TSX
 expectType<JSX.Element>(<Foo foo={1} />)

--- a/test-dts/tsx.test-d.tsx
+++ b/test-dts/tsx.test-d.tsx
@@ -5,9 +5,11 @@ import {
   Fragment,
   Teleport,
   expectError,
-  expectType
+  expectType,
+  VNode
 } from './index'
 
+expectType<VNode>(<div />)
 expectType<JSX.Element>(<div />)
 expectType<JSX.Element>(<div id="foo" />)
 expectType<JSX.Element>(<input value="foo" />)


### PR DESCRIPTION
JSX is compiled to `createVNode` calls, so should be compatible with functions that accept `VNode`. The functional component tests were invalid because components should return VNodes, I had to add `h` overloads for `Text` nodes to keep the same functionality. 

![image](https://user-images.githubusercontent.com/16421948/107031834-f4bc3680-6806-11eb-862f-7990ea0f2687.png)
