### PR TITLE
fix(compiler-dom): ensure global build filename matches the one defined in package.json (close #3181)

### DIFF
--- a/packages/compiler-dom/package.json
+++ b/packages/compiler-dom/package.json
@@ -5,8 +5,8 @@
   "main": "index.js",
   "module": "dist/compiler-dom.esm-bundler.js",
   "types": "dist/compiler-dom.d.ts",
-  "unpkg": "dist/compiler-dom/global.js",
-  "jsdelivr": "dist/compiler-dom/global.js",
+  "unpkg": "dist/compiler-dom/compiler-dom.global.js",
+  "jsdelivr": "dist/compiler-dom/compiler-dom.global.js",
   "files": [
     "index.js",
     "dist"


### PR DESCRIPTION
`package.json` currently states:

```
  "unpkg": "dist/compiler-dom/global.js",
  "jsdelivr": "dist/compiler-dom/global.js",
````

but the filename in /dist is `compiler-dom.global.js`

this PR adjusts the names in package.json

closes #3181