### PR TITLE
types: support Once/Capture/OnceCapture events for tsx

### DIFF
--- a/packages/runtime-dom/types/jsx.d.ts
+++ b/packages/runtime-dom/types/jsx.d.ts
@@ -1309,8 +1309,24 @@ export interface Events {
 
 type StringKeyOf<T> = Extract<keyof T, string>
 
+type EventNames<T, K extends string = StringKeyOf<T>> = StringKeyOf<T> | (`${K}Once` | `${K}Capture` | `${K}OnceCapture`)
+
 type EventHandlers<E> = {
-  [K in StringKeyOf<E>]?: E[K] extends Function ? E[K] : (payload: E[K]) => void
+  [K in EventNames<E>]?: K extends `${infer ON}Once`
+    ? ON extends StringKeyOf<E>
+      ? E[ON] extends Function ? E[ON] : (payload: E[ON]) => void
+      : never
+    : K extends `${infer CN}OnceCapture`
+      ? CN extends StringKeyOf<E>
+        ? E[CN] extends Function ? E[CN] : (payload: E[CN]) => void
+        : never
+      : K extends `${infer OCN}Capture`
+        ? OCN extends StringKeyOf<E>
+          ? E[OCN] extends Function ? E[OCN] : (payload: E[OCN]) => void
+          : never
+        : K extends StringKeyOf<E>
+          ? E[K] extends Function ? E[K] : (payload: E[K]) => void
+          : never
 }
 
 // use namespace import to avoid collision with generated types which use

--- a/test-dts/tsx.test-d.tsx
+++ b/test-dts/tsx.test-d.tsx
@@ -54,3 +54,21 @@ expectType<JSX.Element>(
 )
 // @ts-expect-error
 expectError(<Suspense onResolve={123} />)
+
+// Events / onXxxOnce / onXxxCapture / onXxxOnceCapture
+expectType<JSX.Element>(
+  <input
+    onInputOnce={e => {
+      // infer correct event type
+      expectType<EventTarget | null>(e.target)
+    }}
+    onInputOnceCapture={e => {
+      // infer correct event type
+      expectType<EventTarget | null>(e.target)
+    }}
+    onInputCapture={e => {
+      // infer correct event type
+      expectType<EventTarget | null>(e.target)
+    }}
+  />
+)


### PR DESCRIPTION
Inspired by https://github.com/vuejs/vue-next/pull/3039

**important: I skipped code formatting because prettier didn’t support typescript Template Literal Types until version 2.2**