### PR TITLE
perf(runtime-core): optimize the performance of `getTypeIndex`

### DIFF
--- a/packages/runtime-core/src/componentProps.ts
+++ b/packages/runtime-core/src/componentProps.ts
@@ -446,11 +446,7 @@ function getTypeIndex(
   expectedTypes: PropType<any> | void | null | true
 ): number {
   if (isArray(expectedTypes)) {
-    for (let i = 0, len = expectedTypes.length; i < len; i++) {
-      if (isSameType(expectedTypes[i], type)) {
-        return i
-      }
-    }
+    return expectedTypes.findIndex(t => isSameType(t, type))
   } else if (isFunction(expectedTypes)) {
     return isSameType(expectedTypes, type) ? 0 : -1
   }


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/3705199/107363106-a82d6f80-6b14-11eb-9b72-2971f1c70f98.png)


see https://www.measurethat.net/Benchmarks/Show/11546/0/fastfindindex
