### PR TITLE
types(plugin): support for type safe plugins

### DIFF
--- a/packages/runtime-core/src/apiCreateApp.ts
+++ b/packages/runtime-core/src/apiCreateApp.ts
@@ -19,7 +19,29 @@ import { version } from '.'
 export interface App<HostElement = any> {
   version: string
   config: AppConfig
-  use(plugin: Plugin, ...options: any[]): this
+
+  // plugin function
+  use<T extends PluginInstallFunction>(
+    plugin: T,
+    ...options: T extends PluginInstallFunction<infer O> ? O : unknown
+  ): this
+
+  // plugin install object
+  use<F extends PluginInstallFunction>(
+    plugin: {
+      install: F
+    },
+    ...options: F extends PluginInstallFunction<infer O> ? O : unknown
+  ): this
+
+  // Plugin type
+  use<F extends PluginInstallFunction>(
+    plugin: {
+      install?: F
+    },
+    ...options: F extends PluginInstallFunction<infer O> ? O : unknown
+  ): this
+
   mixin(mixin: ComponentOptions): this
   component(name: string): Component | undefined
   component(name: string, component: Component): this
@@ -86,13 +108,20 @@ export interface AppContext {
   reload?: () => void
 }
 
-type PluginInstallFunction = (app: App, ...options: any[]) => any
+export type PluginInstallFunction<TOptions extends Array<unknown> = any[]> = (
+  app: App,
+  ...options: TOptions
+) => any
+
+export type PluginInstall<
+  T extends PluginInstallFunction<any> = PluginInstallFunction<any>
+> = {
+  install: T
+}
 
 export type Plugin =
-  | PluginInstallFunction & { install?: PluginInstallFunction }
-  | {
-      install: PluginInstallFunction
-    }
+  | (PluginInstallFunction & { install?: PluginInstallFunction })
+  | PluginInstall
 
 export function createAppContext(): AppContext {
   return {

--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -148,6 +148,8 @@ export {
   AppConfig,
   AppContext,
   Plugin,
+  PluginInstall,
+  PluginInstallFunction,
   CreateAppFunction,
   OptionMergeFunction
 } from './apiCreateApp'

--- a/test-dts/createApp.test-d.ts
+++ b/test-dts/createApp.test-d.ts
@@ -1,0 +1,124 @@
+import { App, Plugin } from './index'
+
+declare const app: App
+
+describe('plugin options', () => {
+  interface PluginOptions {
+    test: string
+    num: number
+    config: {
+      t: string
+    }
+    c?: number
+  }
+
+  const plugin = {
+    install(
+      app: App,
+      option: PluginOptions,
+      other: { a: number; b?: string }
+    ) {}
+  }
+
+  // @ts-expect-error needs options
+  app.use(plugin)
+  // @ts-expect-error invalid options provided
+  app.use(plugin, {}, {})
+
+  // @ts-expect-error invalid number of options
+  app.use(plugin, {
+    test: 'x',
+    num: 1,
+    config: {
+      t: ''
+    }
+  })
+
+  app.use(
+    plugin,
+    {
+      test: 'x',
+      num: 1,
+      config: {
+        t: ''
+      }
+    },
+    { a: 1 }
+  )
+
+  //@ts-expect-error invalid option type
+  app.use(
+    plugin,
+    {
+      test: 'x',
+      num: 1,
+      config: {
+        t: ''
+      }
+    },
+    { a: '1' }
+  )
+
+  app.use(
+    //@ts-expect-error invalid number of arguments
+    plugin,
+    {
+      test: 'x',
+      num: 1,
+      config: {
+        t: ''
+      }
+    },
+    { a: 1 },
+    'test'
+  )
+})
+
+describe('plugin function', () => {
+  const plugin = (app: App, config: { num: number; url: string }) => {}
+
+  // @ts-expect-error no arguments
+  app.use(plugin)
+
+  // @ts-expect-error invalid arguments
+  app.use(plugin, {})
+
+  // @ts-expect-error invalid type
+  app.use(plugin, {
+    num: '',
+    url: ''
+  })
+
+  app.use(plugin, {
+    num: 1,
+    url: ''
+  })
+
+  app.use(
+    // @ts-expect-error too many arguments
+    plugin,
+    {
+      num: 1,
+      url: ''
+    },
+    true
+  )
+})
+
+describe('no argument', () => {
+  const plugin = (app: App) => {}
+
+  app.use(plugin)
+
+  // @ts-expect-error too many arguments
+  app.use(plugin, {})
+})
+
+describe('using plugin type', () => {
+  const plugin = ({} as unknown) as Plugin
+
+  app.use(plugin)
+  app.use(plugin, true)
+  app.use(plugin, {})
+  app.use(plugin, 1, 'string', {}, () => {})
+})


### PR DESCRIPTION
Allow type safe plugins configurations.

The only issue is the parameters name are not respected, aside from that it should support just a simple object with install function or by using the provided types