### PR TITLE
chore: add display name for suspense component

### DIFF
--- a/packages/runtime-core/src/components/Suspense.ts
+++ b/packages/runtime-core/src/components/Suspense.ts
@@ -33,6 +33,7 @@ export const isSuspense = (type: any): boolean => type.__isSuspense
 // in the compiler, but internally it's a special built-in type that hooks
 // directly into the renderer.
 export const SuspenseImpl = {
+  name: 'Suspense',
   // In order to make Suspense tree-shakable, we need to avoid importing it
   // directly in the renderer. The renderer checks for the __isSuspense flag
   // on a vnode's type and calls the `process` method, passing in renderer


### PR DESCRIPTION
This is similar to what was done for Transition in d32aed09064d2c5531213682b0d5e02556be969e

It should fix https://github.com/vuejs/vue-test-utils-next/issues/426