### PR TITLE
chore: fix ownKeys signature

### DIFF
--- a/packages/reactivity/src/baseHandlers.ts
+++ b/packages/reactivity/src/baseHandlers.ts
@@ -182,7 +182,7 @@ function has(target: object, key: string | symbol): boolean {
   return result
 }
 
-function ownKeys(target: object): (string | number | symbol)[] {
+function ownKeys(target: object): (string | symbol)[] {
   track(target, TrackOpTypes.ITERATE, isArray(target) ? 'length' : ITERATE_KEY)
   return Reflect.ownKeys(target)
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7281,7 +7281,12 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^4.1.3, typescript@~4.1.3:
+typescript@^4.1.3:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.2.tgz#1450f020618f872db0ea17317d16d8da8ddb8c4c"
+  integrity sha512-tbb+NVrLfnsJy3M59lsDgrzWIflR4d4TIUjz+heUnHZwdF7YsrMTKoRERiIvI2lvBG95dfpLxB21WZhys1bgaQ==
+
+typescript@~4.1.3:
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.5.tgz#123a3b214aaff3be32926f0d8f1f6e704eb89a72"
   integrity sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA==


### PR DESCRIPTION
This is a required fix to update to TS 4.2.2. `Reflet.ownKeys` does now return `(string | symbol)[]` since https://github.com/microsoft/TypeScript/commit/562237dfda3ab270a9f91d0e4e4d411ff7bbd844.

Without this commit, we run into the following compilation error:
```
packages/reactivity/src/baseHandlers.ts:195:3 - error TS2322: Type '(target: object) => (string | number | symbol)[]' is not assignable to type '(target: object) => ArrayLike<string | symbol>'.
      Type '(string | number | symbol)[]' is not assignable to type 'ArrayLike<string | symbol>'.
        Index signatures are incompatible.
          Type 'string | number | symbol' is not assignable to type 'string | symbol'.
            Type 'number' is not assignable to type 'string | symbol'.
```

This allows #3293 to land