### PR TITLE
fix(computed): only execute computed when there's changes

### DIFF
--- a/packages/reactivity/__tests__/computed.spec.ts
+++ b/packages/reactivity/__tests__/computed.spec.ts
@@ -193,4 +193,32 @@ describe('reactivity/computed', () => {
     expect(isReadonly(z)).toBe(false)
     expect(isReadonly(z.value.a)).toBe(false)
   })
+
+  it('should only run on change', () => {
+    const loadingId = ref(0)
+
+    const update = () => {
+      loadingId.value = (loadingId.value + 1) % 3
+    }
+
+    const isLoading = computed(() => (loadingId.value === 0 ? 1 : 0))
+
+    let run = 0
+
+    const myObj = computed(() => {
+      console.log('computation', isLoading.value)
+      run++
+      return {
+        isLoading: isLoading.value
+      }
+    })
+
+    myObj.value
+    update()
+    myObj.value
+    update()
+    myObj.value
+
+    expect(run).toBe(1)
+  })
 })

--- a/packages/reactivity/src/ref.ts
+++ b/packages/reactivity/src/ref.ts
@@ -68,8 +68,9 @@ class RefImpl<T> {
   set value(newVal) {
     if (hasChanged(toRaw(newVal), this._rawValue)) {
       this._rawValue = newVal
+      const prev = this._value
       this._value = this._shallow ? newVal : convert(newVal)
-      trigger(toRaw(this), TriggerOpTypes.SET, 'value', newVal)
+      trigger(toRaw(this), TriggerOpTypes.SET, 'value', newVal, prev)
     }
   }
 }


### PR DESCRIPTION
currently the `computed` will always be marked as `dirty`, so every time we do `.value` when one of the dependencies are "changed"(this change can be the same value assigned)  we will run the `effect`

The correct behaviour should be: 
- When the dependencies value actual change we should run the effect