### PR TITLE
types: export RefSymbol

### DIFF
--- a/packages/reactivity/src/ref.ts
+++ b/packages/reactivity/src/ref.ts
@@ -4,7 +4,7 @@ import { isArray, isObject, hasChanged } from '@vue/shared'
 import { reactive, isProxy, toRaw, isReactive } from './reactive'
 import { CollectionTypes } from './collectionHandlers'
 
-declare const RefSymbol: unique symbol
+export declare const RefSymbol: unique symbol
 
 export interface Ref<T = any> {
   value: T


### PR DESCRIPTION
If you decide to use `readonly` from `vue` you will face the following issue:

<img width="689" alt="image" src="https://user-images.githubusercontent.com/1734873/109319814-0dc86e00-782e-11eb-8fb7-7e293f93b2c7.png">

The issue is that `RefSymbol` is not exported.

Another example using it directly inside `setup`:

<img width="451" alt="image" src="https://user-images.githubusercontent.com/1734873/109320899-55032e80-782f-11eb-9c5b-bb28bfb3c6a4.png">