### PR TITLE
fix(runtime-core): avoid infinite loop rendering caused by setting props multiple times

### DIFF
--- a/packages/runtime-core/src/componentProps.ts
+++ b/packages/runtime-core/src/componentProps.ts
@@ -312,6 +312,7 @@ function setFullProps(
 ) {
   const [options, needCastKeys] = instance.propsOptions
   let hasAttrsChanged = false
+  const rawCurrentProps = extend({}, toRaw(props))
   if (rawProps) {
     for (let key in rawProps) {
       // key, ref are reserved and never passed down
@@ -337,7 +338,7 @@ function setFullProps(
       // kebab -> camel conversion here we need to camelize the key.
       let camelKey
       if (options && hasOwn(options, (camelKey = camelize(key)))) {
-        props[camelKey] = value
+        rawCurrentProps[camelKey] = value
       } else if (!isEmitListener(instance.emitsOptions, key)) {
         // Any non-declared (either as a prop or an emitted event) props are put
         // into a separate `attrs` object for spreading. Make sure to preserve
@@ -358,7 +359,6 @@ function setFullProps(
   }
 
   if (needCastKeys) {
-    const rawCurrentProps = toRaw(props)
     for (let i = 0; i < needCastKeys.length; i++) {
       const key = needCastKeys[i]
       props[key] = resolvePropValue(
@@ -370,7 +370,12 @@ function setFullProps(
       )
     }
   }
-
+  if (options) {
+    for (const key in rawCurrentProps) {
+      if (!needCastKeys || !needCastKeys.includes(key))
+        props[key] = rawCurrentProps[key]
+    }
+  }
   return hasAttrsChanged
 }
 


### PR DESCRIPTION
Fix: #3371 

I made a minimal reproduction https://codesandbox.io/s/vigilant-euler-7q6j0?file=/src/index.ts. Open the link and check the comments in the code

1. The `Parent` component accesses the props of the `Child` component and is tracked by the `Child` component's props.
2. When rendering the `Child` component, the `Child` component modifies the reactivity data of the `Parent` component.
3. The `Parent` component re-rendering and [checks whether the Child component needs to be updated](https://github.com/vuejs/vue-next/blob/master/packages/runtime-core/src/componentRenderUtils.ts#L341-L345).
4. `Child` component needs to be updated, and [set the full props](https://github.com/vuejs/vue-next/blob/master/packages/runtime-core/src/componentProps.ts#L217)
5. For the `props.foo`, it needs to be cast to a boolean value
6. So the `props.foo` been modified twice, once is set to the empty string, and another is set to a boolean value. [here](https://github.com/vuejs/vue-next/blob/master/packages/runtime-core/src/componentProps.ts#L288) and [here](https://github.com/vuejs/vue-next/blob/master/packages/runtime-core/src/componentProps.ts#L302)