### PR TITLE
feat(compiler): take the comments option to fully control whether to keep comment nodes

### DIFF
--- a/packages/compiler-core/__tests__/parse.spec.ts
+++ b/packages/compiler-core/__tests__/parse.spec.ts
@@ -377,23 +377,17 @@ describe('compiler: parse', () => {
     })
 
     test('comments option', () => {
-      __DEV__ = false
-      const astDefaultComment = baseParse('<!--abc-->')
-      const astNoComment = baseParse('<!--abc-->', { comments: false })
       const astWithComments = baseParse('<!--abc-->', { comments: true })
-      __DEV__ = true
+      const astNoComment = baseParse('<!--abc-->', { comments: false })
 
-      expect(astDefaultComment.children).toHaveLength(0)
-      expect(astNoComment.children).toHaveLength(0)
       expect(astWithComments.children).toHaveLength(1)
+      expect(astNoComment.children).toHaveLength(0)
     })
 
     // #2217
     test('comments in the <pre> tag should be removed in production mode', () => {
-      __DEV__ = false
       const rawText = `<p/><!-- foo --><p/>`
-      const ast = baseParse(`<pre>${rawText}</pre>`)
-      __DEV__ = true
+      const ast = baseParse(`<pre>${rawText}</pre>`, { comments: false })
 
       expect((ast.children[0] as ElementNode).children).toMatchObject([
         {

--- a/packages/compiler-core/src/options.ts
+++ b/packages/compiler-core/src/options.ts
@@ -50,7 +50,7 @@ export interface ParserOptions {
   decodeEntities?: (rawText: string, asAttr: boolean) => string
   onError?: (error: CompilerError) => void
   /**
-   * Keep comments in the templates AST, even in production
+   * Whether to keep comments in the templates AST
    */
   comments?: boolean
 }

--- a/packages/compiler-core/src/parse.ts
+++ b/packages/compiler-core/src/parse.ts
@@ -241,7 +241,7 @@ function parseChildren(
           node.content = node.content.replace(/[\t\r\n\f ]+/g, ' ')
         }
       }
-      // also remove comment nodes in prod by default
+      // comment nodes handling
       if (node.type === NodeTypes.COMMENT && !context.options.comments) {
         removedWhitespace = true
         nodes[i] = null as any

--- a/packages/compiler-core/src/parse.ts
+++ b/packages/compiler-core/src/parse.ts
@@ -241,9 +241,8 @@ function parseChildren(
         } else {
           node.content = node.content.replace(/[\t\r\n\f ]+/g, ' ')
         }
-      }
-      // comment nodes handling
-      if (node.type === NodeTypes.COMMENT && !context.options.comments) {
+      } else if (node.type === NodeTypes.COMMENT && !context.options.comments) {
+        // comment nodes handling
         removedWhitespace = true
         nodes[i] = null as any
       }

--- a/packages/compiler-core/src/parse.ts
+++ b/packages/compiler-core/src/parse.ts
@@ -59,7 +59,8 @@ export const defaultParserOptions: MergedParserOptions = {
   decodeEntities: (rawText: string): string =>
     rawText.replace(decodeRE, (_, p1) => decodeMap[p1]),
   onError: defaultOnError,
-  comments: false
+  // only keep comment nodes in DEV by default
+  comments: __DEV__
 }
 
 export const enum TextModes {
@@ -101,7 +102,10 @@ function createParserContext(
   const options = extend({}, defaultParserOptions)
   for (const key in rawOptions) {
     // @ts-ignore
-    options[key] = rawOptions[key] || defaultParserOptions[key]
+    options[key] =
+      rawOptions[key] === undefined
+        ? defaultParserOptions[key]
+        : rawOptions[key]
   }
   return {
     options,
@@ -238,11 +242,7 @@ function parseChildren(
         }
       }
       // also remove comment nodes in prod by default
-      if (
-        !__DEV__ &&
-        node.type === NodeTypes.COMMENT &&
-        !context.options.comments
-      ) {
+      if (node.type === NodeTypes.COMMENT && !context.options.comments) {
         removedWhitespace = true
         nodes[i] = null as any
       }

--- a/packages/compiler-core/src/parse.ts
+++ b/packages/compiler-core/src/parse.ts
@@ -100,7 +100,8 @@ function createParserContext(
   rawOptions: ParserOptions
 ): ParserContext {
   const options = extend({}, defaultParserOptions)
-  for (const key in rawOptions) {
+  let key: keyof ParserOptions
+  for (key in rawOptions) {
     // @ts-ignore
     options[key] =
       rawOptions[key] === undefined


### PR DESCRIPTION
Close: #3392 

This PR does not change any default behavior, but allows the `comments` option to fully control comment nodes.