### PR TITLE
chore(runtime-core): change the position of the mountChildren parameter

### DIFF
--- a/packages/runtime-core/src/renderer.ts
+++ b/packages/runtime-core/src/renderer.ts
@@ -866,8 +866,8 @@ function baseCreateRenderer(
     parentComponent,
     parentSuspense,
     isSVG,
-    optimized,
     slotScopeIds,
+    optimized,
     start = 0
   ) => {
     for (let i = start; i < children.length; i++) {
@@ -882,8 +882,8 @@ function baseCreateRenderer(
         parentComponent,
         parentSuspense,
         isSVG,
-        optimized,
-        slotScopeIds
+        slotScopeIds,
+        optimized
       )
     }
   }


### PR DESCRIPTION
The parameter position of `mountChildren` is not consistent with other methods, which affects reading.