### PR TITLE
fix(scheduler): fix findInsertionIndex return

### DIFF
--- a/packages/runtime-core/src/scheduler.ts
+++ b/packages/runtime-core/src/scheduler.ts
@@ -63,8 +63,9 @@ export function nextTick(
 // which can prevent the job from being skipped and also can avoid repeated patching.
 function findInsertionIndex(job: SchedulerJob) {
   // the start index should be `flushIndex + 1`
+  let len = queue.length
   let start = flushIndex + 1
-  let end = queue.length
+  let end = len
   const jobId = getId(job)
 
   while (start < end) {
@@ -73,7 +74,7 @@ function findInsertionIndex(job: SchedulerJob) {
     middleJobId < jobId ? (start = middle + 1) : (end = middle)
   }
 
-  return start
+  return start !== len ? start : -1
 }
 
 export function queueJob(job: SchedulerJob) {


### PR DESCRIPTION
# background
`findInsertionIndex` method will never return `-1`, so the `else` branch in `queueJob` will never be executed

# Original code
```ts
// This method will never return -1, so the else branch in `queueJob` will never be executed
function findInsertionIndex(job: SchedulerJob) {
  let start = flushIndex + 1
  let end = queue.length
  const jobId = getId(job)

  while (start < end) {
    const middle = (start + end) >>> 1
    const middleJobId = getId(queue[middle])
    middleJobId < jobId ? (start = middle + 1) : (end = middle)
  }

  return start
}

export function queueJob(job: SchedulerJob) {
  if (
    (!queue.length ||
      !queue.includes(
        job,
        isFlushing && job.allowRecurse ? flushIndex + 1 : flushIndex
      )) &&
    job !== currentPreFlushParentJob
  ) {
    const pos = findInsertionIndex(job)
    if (pos > -1) {
      queue.splice(pos, 0, job)
    } else { // never be executed
      queue.push(job)
    }
    queueFlush()
  }
}
```

# Solution
1. Delete the `else` branch of the `queueJob` method
```ts
export function queueJob(job: SchedulerJob) {
  if (
    (!queue.length ||
      !queue.includes(
        job,
        isFlushing && job.allowRecurse ? flushIndex + 1 : flushIndex
      )) &&
    job !== currentPreFlushParentJob
  ) {
    const pos = findInsertionIndex(job)
    queue.splice(pos, 0, job)

    queueFlush()
  }
}
```
2. Modify the `findInsertionIndex` method to return `-1` when it is not found
```ts
function findInsertionIndex(job: SchedulerJob) {
  let len = queue.length
  let start = flushIndex + 1
  let end = len
  const jobId = getId(job)

  while (start < end) {
    const middle = (start + end) >>> 1
    const middleJobId = getId(queue[middle])
    middleJobId < jobId ? (start = middle + 1) : (end = middle)
  }

  return start !== len ? start : -1
}
```

# Finally
I chose the second solution because `push` performs better than `splice`