### PR TITLE
chore(reactivity): update deleteProperty method

### DIFF
--- a/packages/reactivity/src/baseHandlers.ts
+++ b/packages/reactivity/src/baseHandlers.ts
@@ -166,9 +166,9 @@ function createSetter(shallow = false) {
 
 function deleteProperty(target: object, key: string | symbol): boolean {
   const hadKey = hasOwn(target, key)
-  const oldValue = (target as any)[key]
   const result = Reflect.deleteProperty(target, key)
-  if (result && hadKey) {
+  if (hadKey && result) {
+    const oldValue = (target as any)[key]
     trigger(target, TriggerOpTypes.DELETE, key, undefined, oldValue)
   }
   return result


### PR DESCRIPTION
1. since the `&&` has short-circuit attribute, so the hasKey should take priority
2. should evaluate when needed