### PR TITLE
fix(compiler-core): allow unicode to appear in identifiers

### DIFF
--- a/packages/compiler-core/__tests__/transforms/vModel.spec.ts
+++ b/packages/compiler-core/__tests__/transforms/vModel.spec.ts
@@ -507,6 +507,13 @@ describe('compiler: transform v-model', () => {
       )
     })
 
+    test('allow unicode', () => {
+      const onError = jest.fn()
+      parseWithVModel('<span v-model="变.量" />', { onError })
+
+      expect(onError).toHaveBeenCalledTimes(0)
+    })
+
     test('used on scope variable', () => {
       const onError = jest.fn()
       parseWithVModel('<span v-for="i in list" v-model="i" />', {

--- a/packages/compiler-core/src/utils.ts
+++ b/packages/compiler-core/src/utils.ts
@@ -56,7 +56,7 @@ const nonIdentifierRE = /^\d|[^\$\w]/
 export const isSimpleIdentifier = (name: string): boolean =>
   !nonIdentifierRE.test(name)
 
-const memberExpRE = /^[A-Za-z_$][\w$]*(?:\s*\.\s*[A-Za-z_$][\w$]*|\[[^\]]+\])*$/
+const memberExpRE = /^[A-Za-z_$\xA0-\uFFFF][\w$\xA0-\uFFFF]*(?:\s*\.\s*[A-Za-z_$\xA0-\uFFFF][\w$\xA0-\uFFFF]*|\[[^\]]+\])*$/
 export const isMemberExpression = (path: string): boolean => {
   if (!path) return false
   return memberExpRE.test(path.trim())


### PR DESCRIPTION
Fix: #3440

For simplicity, we can just allow non-ascii as part of the identifiers