### PR TITLE
fix(compiler-ssr): keep the order of imports expression for the fallback branch of SSR

### DIFF
--- a/packages/compiler-sfc/__tests__/compileTemplate.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileTemplate.spec.ts
@@ -137,3 +137,19 @@ test('preprocessor errors', () => {
     `The end of the string reached with no closing bracket ) found.`
   )
 })
+
+// #3447
+test('should generate the correct imports expression', () => {
+  const { code } = compile({
+    filename: 'example.vue',
+    source: `
+      <img src="./foo.svg"/>
+      <Comp>
+        <img src="./bar.svg"/>
+      </Comp>
+    `,
+    ssr: true
+  })
+  expect(code).toMatch(`_ssrRenderAttr(\"src\", _imports_1)`)
+  expect(code).toMatch(`_createVNode(\"img\", { src: _imports_1 })`)
+})

--- a/packages/compiler-ssr/src/transforms/ssrTransformComponent.ts
+++ b/packages/compiler-ssr/src/transforms/ssrTransformComponent.ts
@@ -293,6 +293,7 @@ function subTransform(
   // inherit parent scope analysis state
   childContext.scopes = { ...parentContext.scopes }
   childContext.identifiers = { ...parentContext.identifiers }
+  childContext.imports = parentContext.imports
   // traverse
   traverseNode(childRoot, childContext)
   // merge helpers/components/directives into parent context


### PR DESCRIPTION
Fix: #3447 