### PR TITLE
fix(runtime-core): cache the value returned from the default factory to avoid unnecessary watcher trigger

### DIFF
--- a/packages/runtime-core/__tests__/componentProps.spec.ts
+++ b/packages/runtime-core/__tests__/componentProps.spec.ts
@@ -10,7 +10,8 @@ import {
   serializeInner,
   createApp,
   provide,
-  inject
+  inject,
+  watch
 } from '@vue/runtime-test'
 import { render as domRender, nextTick } from 'vue'
 
@@ -402,5 +403,44 @@ describe('component props', () => {
     )
 
     expect(serializeInner(root)).toMatch('<div>60000000100000111</div>')
+  })
+
+  // #3474
+  test('should cache the value returned from the default factory to avoid unnecessary watcher trigger', async () => {
+    let count = 0
+    const Comp = {
+      props: {
+        foo: {
+          type: Object,
+          default: () => ({ val: 1 })
+        },
+        bar: Number
+      },
+      setup(props: any) {
+        watch(
+          () => props.foo,
+          () => {
+            count++
+          }
+        )
+        return () => h('h1', [props.foo.val, props.bar])
+      }
+    }
+
+    const foo = ref()
+    const bar = ref(0)
+    const app = createApp({
+      render: () => h(Comp, { foo: foo.value, bar: bar.value })
+    })
+
+    const root = nodeOps.createElement('div')
+    app.mount(root)
+    expect(serializeInner(root)).toMatch(`<h1>10</h1>`)
+    expect(count).toBe(0)
+
+    bar.value++
+    await nextTick()
+    expect(serializeInner(root)).toMatch(`<h1>11</h1>`)
+    expect(count).toBe(0)
   })
 })

--- a/packages/runtime-core/src/component.ts
+++ b/packages/runtime-core/src/component.ts
@@ -302,6 +302,11 @@ export interface ComponentInternalInstance {
    * @internal
    */
   emitted: Record<string, boolean> | null
+  /**
+   * used for cache the value returned from the default factory to avoid unnecessary watcher trigger
+   * @internal
+   */
+  propsDefaultValue: Data
 
   /**
    * setup related
@@ -439,6 +444,9 @@ export function createComponentInstance(
     // emit
     emit: null as any, // to be set immediately
     emitted: null,
+
+    // props default value
+    propsDefaultValue: EMPTY_OBJ,
 
     // state
     ctx: EMPTY_OBJ,

--- a/packages/runtime-core/src/component.ts
+++ b/packages/runtime-core/src/component.ts
@@ -303,11 +303,11 @@ export interface ComponentInternalInstance {
    */
   emitted: Record<string, boolean> | null
   /**
-   * used for cache the value returned from the default factory to avoid unnecessary watcher trigger
+   * used for caching the value returned from props default factory functions to
+   * avoid unnecessary watcher trigger
    * @internal
    */
-  propsDefaultValue: Data
-
+  propsDefaults: Data
   /**
    * setup related
    * @internal
@@ -446,7 +446,7 @@ export function createComponentInstance(
     emitted: null,
 
     // props default value
-    propsDefaultValue: EMPTY_OBJ,
+    propsDefaults: EMPTY_OBJ,
 
     // state
     ctx: EMPTY_OBJ,

--- a/packages/runtime-core/src/componentProps.ts
+++ b/packages/runtime-core/src/componentProps.ts
@@ -137,7 +137,9 @@ export function initProps(
   const props: Data = {}
   const attrs: Data = {}
   def(attrs, InternalObjectKey, 1)
-  instance.propsDefaultValue = Object.create(null)
+
+  instance.propsDefaults = Object.create(null)
+
   setFullProps(instance, rawProps, props, attrs)
   // validation
   if (__DEV__) {
@@ -318,7 +320,6 @@ function resolvePropValue(
   value: unknown,
   instance: ComponentInternalInstance
 ) {
-  const { propsDefaultValue } = instance
   const opt = options[key]
   if (opt != null) {
     const hasDefault = hasOwn(opt, 'default')
@@ -326,11 +327,12 @@ function resolvePropValue(
     if (hasDefault && value === undefined) {
       const defaultValue = opt.default
       if (opt.type !== Function && isFunction(defaultValue)) {
-        if (propsDefaultValue[key] !== undefined) {
-          value = propsDefaultValue[key]
+        const { propsDefaults } = instance
+        if (key in propsDefaults) {
+          value = propsDefaults[key]
         } else {
           setCurrentInstance(instance)
-          value = propsDefaultValue[key] = defaultValue(props)
+          value = propsDefaults[key] = defaultValue(props)
           setCurrentInstance(null)
         }
       } else {

--- a/packages/runtime-core/src/componentProps.ts
+++ b/packages/runtime-core/src/componentProps.ts
@@ -121,6 +121,8 @@ type NormalizedProp =
   | (PropOptions & {
       [BooleanFlags.shouldCast]?: boolean
       [BooleanFlags.shouldCastTrue]?: boolean
+      // cache the return value from the default factory to avoid unnecessary watcher trigger
+      _defaultValue?: unknown
     })
 
 // normalized value is a tuple of the actual normalized options
@@ -324,9 +326,13 @@ function resolvePropValue(
     if (hasDefault && value === undefined) {
       const defaultValue = opt.default
       if (opt.type !== Function && isFunction(defaultValue)) {
-        setCurrentInstance(instance)
-        value = defaultValue(props)
-        setCurrentInstance(null)
+        if (opt._defaultValue) {
+          value = opt._defaultValue
+        } else {
+          setCurrentInstance(instance)
+          value = opt._defaultValue = defaultValue(props)
+          setCurrentInstance(null)
+        }
       } else {
         value = defaultValue
       }


### PR DESCRIPTION
Fix: #3471 
We should cache the return value from the default factory to avoid unnecessary watcher triggering, which is what Vue2 does.