### PR TITLE
fix(types): Allow tabindex to be a string

### DIFF
--- a/packages/runtime-dom/types/jsx.d.ts
+++ b/packages/runtime-dom/types/jsx.d.ts
@@ -265,7 +265,7 @@ export interface HTMLAttributes extends AriaAttributes, EventHandlers<Events> {
   lang?: string
   placeholder?: string
   spellcheck?: Booleanish
-  tabindex?: number
+  tabindex?: number | string
   title?: string
   translate?: 'yes' | 'no'
 


### PR DESCRIPTION
Right now, this is invalid:

```
<div tabindex="0">Tabbable due to tabindex.</div>
```

and will result in a type error.

That is because all Vue attributes are `string`.