### PR TITLE
fix(types): add a type-only differentiator to assist Mixin's type infer

### DIFF
--- a/packages/runtime-core/src/apiDefineComponent.ts
+++ b/packages/runtime-core/src/apiDefineComponent.ts
@@ -71,7 +71,10 @@ export type DefineComponent<
     EE,
     Defaults
   > &
-  PP
+  PP & {
+    // type-only, used to assist Mixin's type inference
+    __differentiator?: keyof D | keyof C | keyof M
+  }
 
 // defineComponent is a utility that is primarily used for type inference
 // when declaring components. Type inference is provided in the component

--- a/packages/runtime-core/src/apiDefineComponent.ts
+++ b/packages/runtime-core/src/apiDefineComponent.ts
@@ -71,10 +71,7 @@ export type DefineComponent<
     EE,
     Defaults
   > &
-  PP & {
-    // type-only, used to assist Mixin's type inference
-    __differentiator?: keyof D | keyof C | keyof M
-  }
+  PP
 
 // defineComponent is a utility that is primarily used for type inference
 // when declaring components. Type inference is provided in the component

--- a/packages/runtime-core/src/componentOptions.ts
+++ b/packages/runtime-core/src/componentOptions.ts
@@ -424,6 +424,16 @@ interface LegacyOptions<
 
   // runtime compile only
   delimiters?: [string, string]
+
+  /**
+   * #3468
+   *
+   * type-only, used to assist Mixin's type inference,
+   * typescript will try to simplify the inferred `Mixin` type,
+   * with the `__differenciator`, typescript won't be able to combine different mixins,
+   * because the `__differenciator` will be different
+   */
+  __differentiator?: keyof D | keyof C | keyof M
 }
 
 export type OptionTypesKeys = 'P' | 'B' | 'D' | 'C' | 'M' | 'Defaults'

--- a/test-dts/defineComponent.test-d.tsx
+++ b/test-dts/defineComponent.test-d.tsx
@@ -750,22 +750,22 @@ describe('extends with mixins', () => {
     }
   })
   const CompWithM = defineComponent({ methods: { foo() {} } })
-  const CompEnpty = defineComponent({})
+  const CompEmpty = defineComponent({})
 
   defineComponent({
-    mixins: [CompWithD, CompEnpty],
+    mixins: [CompWithD, CompEmpty],
     mounted() {
       expectType<number>(this.foo)
     }
   })
   defineComponent({
-    mixins: [CompWithC, CompEnpty],
+    mixins: [CompWithC, CompEmpty],
     mounted() {
       expectType<number>(this.foo)
     }
   })
   defineComponent({
-    mixins: [CompWithM, CompEnpty],
+    mixins: [CompWithM, CompEmpty],
     mounted() {
       expectType<() => void>(this.foo)
     }

--- a/test-dts/defineComponent.test-d.tsx
+++ b/test-dts/defineComponent.test-d.tsx
@@ -735,6 +735,41 @@ describe('extends with mixins', () => {
   expectError(<MyComponent p2={'wrong type'} z={'z'} />)
   // @ts-expect-error
   expectError(<MyComponent mP1={3} />)
+
+  // #3468
+  const CompWithD = defineComponent({
+    data() {
+      return { foo: 1 }
+    }
+  })
+  const CompWithC = defineComponent({
+    computed: {
+      foo() {
+        return 1
+      }
+    }
+  })
+  const CompWithM = defineComponent({ methods: { foo() {} } })
+  const CompEnpty = defineComponent({})
+
+  defineComponent({
+    mixins: [CompWithD, CompEnpty],
+    mounted() {
+      expectType<number>(this.foo)
+    }
+  })
+  defineComponent({
+    mixins: [CompWithC, CompEnpty],
+    mounted() {
+      expectType<number>(this.foo)
+    }
+  })
+  defineComponent({
+    mixins: [CompWithM, CompEnpty],
+    mounted() {
+      expectType<() => void>(this.foo)
+    }
+  })
 })
 
 describe('compatibility w/ createApp', () => {


### PR DESCRIPTION
Fix: #3468

I noticed that when the mixins contain empty components:

```js
defineComponent({
  mixins: [
    defineComponent({ methods: { foo() {} } }),
    // empty component
    defineComponent({})
  ]
})
```

Or they have the same type pattern:

```js
defineComponent({
  mixins: [
    defineComponent({ props: [], methods: { foo() {} } }),
    // props type are same
    defineComponent({ props: [] })
  ]
})
```

Then the [Mixin type](https://github.com/vuejs/vue-next/blob/master/packages/runtime-core/src/apiDefineComponent.ts#L110) is not inferred as the Unions type of the two components. So my idea is to add a type-only differentiator to help infer the type of `Mixin`.