### PR TITLE
fix(runtime-core): remove props from SetupContext while in __dev__ mode

### DIFF
--- a/packages/runtime-core/src/component.ts
+++ b/packages/runtime-core/src/component.ts
@@ -780,9 +780,6 @@ export function createSetupContext(
     // We use getters in dev in case libs like test-utils overwrite instance
     // properties (overwrites should not be done in prod)
     return Object.freeze({
-      get props() {
-        return instance.props
-      },
       get attrs() {
         return new Proxy(instance.attrs, attrHandlers)
       },


### PR DESCRIPTION
While in `__dev__` mode `SetupContext` returns an additional `props` key which is not there when in production.

This PR brings the `SetupContext` object returned in `__dev__` mode inline what is returned in production and what is written in the docs.

`SetupContext` being the second argument when calling `setup()` or the result of calling `useContext()`.