### PR TITLE
fix(compiler-core): fix slot source location

### DIFF
--- a/packages/compiler-core/src/parse.ts
+++ b/packages/compiler-core/src/parse.ts
@@ -623,7 +623,7 @@ function parseAttribute(
 
     if (match[2]) {
       const isSlot = dirName === 'slot'
-      const startOffset = name.indexOf(match[2])
+      const startOffset = name.lastIndexOf(match[2])
       const loc = getSelection(
         context,
         getNewPosition(context, start, startOffset),


### PR DESCRIPTION
If slot name is part of `v-slot`, `indexOf` get incorrect source location range, for example:

```
<template v-slot:slo />
            ^^^
```