### PR TITLE
fix(runtime-dom): fix the event listeners call in firefox <= 53

### DIFF
--- a/packages/runtime-dom/src/modules/events.ts
+++ b/packages/runtime-dom/src/modules/events.ts
@@ -1,4 +1,4 @@
-import { hyphenate, isArray } from '@vue/shared'
+import { hyphenate, isArray, isFF } from '@vue/shared'
 import {
   ComponentInternalInstance,
   callWithAsyncErrorHandling
@@ -111,7 +111,13 @@ function createInvoker(
     // and the handler would only fire if the event passed to it was fired
     // AFTER it was attached.
     const timeStamp = e.timeStamp || _getNow()
-    if (timeStamp >= invoker.attached - 1) {
+
+    if (
+      timeStamp >= invoker.attached - 1 ||
+      // #3485: Firefox <= 53 has incorrect Event.timeStamp implementation
+      // and does not fire microtasks in between event propagation, so safe to exclude.
+      (isFF && Number(isFF[1]) <= 53)
+    ) {
       callWithAsyncErrorHandling(
         patchStopImmediatePropagation(e, invoker.value),
         instance,

--- a/packages/runtime-dom/src/modules/events.ts
+++ b/packages/runtime-dom/src/modules/events.ts
@@ -1,4 +1,4 @@
-import { hyphenate, isArray, isFF } from '@vue/shared'
+import { hyphenate, isArray } from '@vue/shared'
 import {
   ComponentInternalInstance,
   callWithAsyncErrorHandling
@@ -15,18 +15,23 @@ type EventValue = Function | Function[]
 // Async edge case fix requires storing an event listener's attach timestamp.
 let _getNow: () => number = Date.now
 
-// Determine what event timestamp the browser is using. Annoyingly, the
-// timestamp can either be hi-res (relative to page load) or low-res
-// (relative to UNIX epoch), so in order to compare time we have to use the
-// same timestamp type when saving the flush timestamp.
-if (
-  typeof document !== 'undefined' &&
-  _getNow() > document.createEvent('Event').timeStamp
-) {
-  // if the low-res timestamp which is bigger than the event timestamp
-  // (which is evaluated AFTER) it means the event is using a hi-res timestamp,
-  // and we need to use the hi-res version for event listeners as well.
-  _getNow = () => performance.now()
+let skipTimestampCheck = false
+
+if (typeof window !== 'undefined') {
+  // Determine what event timestamp the browser is using. Annoyingly, the
+  // timestamp can either be hi-res (relative to page load) or low-res
+  // (relative to UNIX epoch), so in order to compare time we have to use the
+  // same timestamp type when saving the flush timestamp.
+  if (_getNow() > document.createEvent('Event').timeStamp) {
+    // if the low-res timestamp which is bigger than the event timestamp
+    // (which is evaluated AFTER) it means the event is using a hi-res timestamp,
+    // and we need to use the hi-res version for event listeners as well.
+    _getNow = () => performance.now()
+  }
+  // #3485: Firefox <= 53 has incorrect Event.timeStamp implementation
+  // and does not fire microtasks in between event propagation, so safe to exclude.
+  const ffMatch = navigator.userAgent.match(/firefox\/(\d+)/i)
+  skipTimestampCheck = !!(ffMatch && Number(ffMatch[1]) <= 53)
 }
 
 // To avoid the overhead of repeatedly calling performance.now(), we cache
@@ -112,12 +117,7 @@ function createInvoker(
     // AFTER it was attached.
     const timeStamp = e.timeStamp || _getNow()
 
-    if (
-      timeStamp >= invoker.attached - 1 ||
-      // #3485: Firefox <= 53 has incorrect Event.timeStamp implementation
-      // and does not fire microtasks in between event propagation, so safe to exclude.
-      (isFF && Number(isFF[1]) <= 53)
-    ) {
+    if (skipTimestampCheck || timeStamp >= invoker.attached - 1) {
       callWithAsyncErrorHandling(
         patchStopImmediatePropagation(e, invoker.value),
         instance,

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -180,7 +180,3 @@ export const getGlobalThis = (): any => {
               : {})
   )
 }
-
-const UA =
-  typeof window !== 'undefined' && window.navigator.userAgent.toLowerCase()
-export const isFF = UA && UA.match(/firefox\/(\d+)/)

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -180,3 +180,7 @@ export const getGlobalThis = (): any => {
               : {})
   )
 }
+
+const UA =
+  typeof window !== 'undefined' && window.navigator.userAgent.toLowerCase()
+export const isFF = UA && UA.match(/firefox\/(\d+)/)


### PR DESCRIPTION
Fix: #3485

Find relevant information here https://github.com/erdong-fe/vue/commit/d3ce9d31221949cb367c38fa4c09dc3d2f6bef5c

I tested multiple scenarios in FF 52 and it works correctly