### PR TITLE
feat(compiler-sfc): ignore empty blocks

### DIFF
--- a/packages/compiler-sfc/__tests__/parse.spec.ts
+++ b/packages/compiler-sfc/__tests__/parse.spec.ts
@@ -119,8 +119,13 @@ h1 { color: red }
 
   test('should ignore other nodes with no content', () => {
     expect(parse(`<script/>`).descriptor.script).toBe(null)
+    expect(parse(`<script> \n\t  </script>`).descriptor.script).toBe(null)
     expect(parse(`<style/>`).descriptor.styles.length).toBe(0)
+    expect(parse(`<style> \n\t </style>`).descriptor.styles.length).toBe(0)
     expect(parse(`<custom/>`).descriptor.customBlocks.length).toBe(0)
+    expect(
+      parse(`<custom> \n\t </custom>`).descriptor.customBlocks.length
+    ).toBe(0)
   })
 
   test('handle empty nodes with src attribute', () => {

--- a/packages/compiler-sfc/src/parse.ts
+++ b/packages/compiler-sfc/src/parse.ts
@@ -143,7 +143,8 @@ export function parse(
     if (node.type !== NodeTypes.ELEMENT) {
       return
     }
-    if (!node.children.length && !hasSrc(node) && node.tag !== 'template') {
+    // we only want to keep the nodes that are not empty (when the tag is not a template)
+    if (node.tag !== 'template' && isEmpty(node) && !hasSrc(node)) {
       return
     }
     switch (node.tag) {
@@ -373,4 +374,16 @@ function hasSrc(node: ElementNode) {
     }
     return p.name === 'src'
   })
+}
+
+/**
+ * Returns true if the node has no children
+ * once the empty text nodes (trimmed content) have been filtered out.
+ */
+function isEmpty(node: ElementNode) {
+  return (
+    node.children.filter(
+      child => child.type !== NodeTypes.TEXT || child.content.trim() !== ''
+    ).length === 0
+  )
 }


### PR DESCRIPTION
The current implementation ignores `<script/>` and `<styles/>` but not empty blocks like `<script>  \n\t</script>`.
This results in unnecessary code generated for a component when these blocks are actually empty.

This commit filters such nodes in the SFC compiler, resulting in less code generated.

For example, this component:
```vue
<template>
  <h1>{{ msg }}</h1>
</template>

<script setup>

</script>

<style scoped>
  
</style>
```

currently produces:
```js
/* Analyzed bindings: {} */
import { toDisplayString as _toDisplayString, openBlock as _openBlock, createBlock as _createBlock, withScopeId as _withScopeId } from "vue"
const _withId = /*#__PURE__*/_withScopeId("data-v-f13b4d11")


const __sfc__ = {
  expose: [],
  setup(__props) {



return /*#__PURE__*/_withId((_ctx, _cache) => {
  return (_openBlock(), _createBlock("h1", null, _toDisplayString(_ctx.msg), 1 /* TEXT */))
})
}

}
__sfc__.__scopeId = "data-v-f13b4d11"
__sfc__.__file = "App.vue"
export default __sfc__
```

(see https://sfc.vuejs.org/#eyJBcHAudnVlIjoiPHRlbXBsYXRlPlxuICA8aDE+e3sgbXNnIH19PC9oMT5cbjwvdGVtcGxhdGU+XG5cbjxzY3JpcHQgc2V0dXA+XG5cbjwvc2NyaXB0PlxuXG48c3R5bGUgc2NvcGVkPlxuXG48L3N0eWxlPiJ9)

With this commit, it produces:
```js
const __sfc__ = {}
import { toDisplayString as _toDisplayString, openBlock as _openBlock, createBlock as _createBlock } from "vue"
function render(_ctx, _cache) {
  return (_openBlock(), _createBlock("h1", null, _toDisplayString(_ctx.msg), 1 /* TEXT */))
}
__sfc__.render = render
__sfc__.__file = "App.vue"
export default __sfc__
```

