### PR TITLE
refactor(sfc-playground): modes declaration

### DIFF
--- a/packages/sfc-playground/src/output/Output.vue
+++ b/packages/sfc-playground/src/output/Output.vue
@@ -20,9 +20,9 @@ import CodeMirror from '../codemirror/CodeMirror.vue'
 import { store } from '../store'
 import { ref } from 'vue'
 
-type Modes = 'preview' | 'js' | 'css' | 'ssr'
+const modes = ['preview', 'js', 'css', 'ssr'] as const
 
-const modes: Modes[] = ['preview', 'js', 'css', 'ssr']
+type Modes = typeof modes[number]
 const mode = ref<Modes>('preview')
 </script>
 


### PR DESCRIPTION
This commit is a super nit refactoring and introduces a more idiomatic way to declare the `Modes` type instead of copy/pasting the values.
As this code might be read as an example, it can help other developers to learn the right patterns.