### PR TITLE
fix(reactivity): make it possible to get the computed's value in the unmounted hook

### DIFF
--- a/packages/reactivity/__tests__/effect.spec.ts
+++ b/packages/reactivity/__tests__/effect.spec.ts
@@ -730,6 +730,30 @@ describe('reactivity/effect', () => {
     expect(dummy).toBe(1)
   })
 
+  // #3099
+  it('create an effect with allowInactiveRun', () => {
+    let dummy
+    const obj = reactive({ prop: 1 })
+    const queue: (() => void)[] = []
+    const runner = effect(
+      () => {
+        dummy = obj.prop
+      },
+      {
+        scheduler: e => queue.push(e),
+        allowInactiveRun: true
+      }
+    )
+    obj.prop = 2
+    expect(dummy).toBe(1)
+    expect(queue.length).toBe(1)
+    stop(runner)
+
+    // an effect with allowInactiveRun should be executed even after it is stopped
+    queue.forEach(e => e())
+    expect(dummy).toBe(2)
+  })
+
   it('events: onStop', () => {
     const onStop = jest.fn()
     const runner = effect(() => {}, {

--- a/packages/reactivity/src/computed.ts
+++ b/packages/reactivity/src/computed.ts
@@ -41,7 +41,8 @@ class ComputedRefImpl<T> {
           this._dirty = true
           trigger(toRaw(this), TriggerOpTypes.SET, 'value')
         }
-      }
+      },
+      allowInactiveRun: true
     })
 
     this[ReactiveFlags.IS_READONLY] = isReadonly


### PR DESCRIPTION
Fix: #3099 

#3099 is caused by this commit https://github.com/vuejs/vue-next/commit/29be536b1f0b7f7f7c1e6cd5a84e12bb4c48b87c, and this commit https://github.com/vuejs/vue-next/commit/29be536b1f0b7f7f7c1e6cd5a84e12bb4c48b87c used to solve problem #910. 

In this PR, I introduced the new effect option `allowInactiveRun`, so that we can specify whether a side effect fn can be executed in inactive