### PR TITLE
fix(compiler-ssr): should generate the correct hoists expression

### DIFF
--- a/packages/compiler-sfc/__tests__/__snapshots__/compileTemplate.spec.ts.snap
+++ b/packages/compiler-sfc/__tests__/__snapshots__/compileTemplate.spec.ts.snap
@@ -1,5 +1,44 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`should generate the correct hoists expression 1`] = `
+"import { resolveComponent as _resolveComponent, withCtx as _withCtx, createVNode as _createVNode } from \\"vue\\"
+import { ssrRenderAttr as _ssrRenderAttr, ssrRenderComponent as _ssrRenderComponent } from \\"@vue/server-renderer\\"
+import _imports_0 from './img/foo.svg'
+import _imports_1 from './img/bar.svg'
+
+
+const _hoisted_1 = _imports_0
+const _hoisted_2 = _imports_1
+const _hoisted_3 = _imports_1
+
+export function ssrRender(_ctx, _push, _parent, _attrs) {
+  const _component_router_link = _resolveComponent(\\"router-link\\")
+
+  _push(\`<!--[--><picture><source\${_ssrRenderAttr(\\"srcset\\", _hoisted_1)}></picture>\`)
+  _push(_ssrRenderComponent(_component_router_link, null, {
+    default: _withCtx((_, _push, _parent, _scopeId) => {
+      if (_push) {
+        _push(\`<picture\${
+          _scopeId
+        }><source\${
+          _ssrRenderAttr(\\"srcset\\", _hoisted_2)
+        }\${
+          _scopeId
+        }></picture>\`)
+      } else {
+        return [
+          _createVNode(\\"picture\\", null, [
+            _createVNode(\\"source\\", { srcset: _hoisted_3 })
+          ])
+        ]
+      }
+    }),
+    _: 1 /* STABLE */
+  }, _parent))
+  _push(\`<!--]-->\`)
+}"
+`;
+
 exports[`source map 1`] = `
 Object {
   "mappings": ";;;wBACE,aAA8B;IAAzB,aAAmB,4BAAbA,WAAM",

--- a/packages/compiler-sfc/__tests__/compileTemplate.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileTemplate.spec.ts
@@ -153,3 +153,22 @@ test('should generate the correct imports expression', () => {
   expect(code).toMatch(`_ssrRenderAttr(\"src\", _imports_1)`)
   expect(code).toMatch(`_createVNode(\"img\", { src: _imports_1 })`)
 })
+
+// #3536
+test('should generate the correct hoists expression', () => {
+  const { code } = compile({
+    filename: 'example.vue',
+    source: `
+    <picture>
+      <source srcset="./img/foo.svg"/>
+    </picture>
+    <router-link>
+      <picture>
+        <source srcset="./img/bar.svg"/>
+      </picture>
+    </router-link>
+    `,
+    ssr: true
+  })
+  expect(code).toMatchSnapshot()
+})

--- a/packages/compiler-ssr/src/transforms/ssrTransformComponent.ts
+++ b/packages/compiler-ssr/src/transforms/ssrTransformComponent.ts
@@ -294,6 +294,7 @@ function subTransform(
   childContext.scopes = { ...parentContext.scopes }
   childContext.identifiers = { ...parentContext.identifiers }
   childContext.imports = parentContext.imports
+  childContext.hoists = parentContext.hoists
   // traverse
   traverseNode(childRoot, childContext)
   // merge helpers/components/directives into parent context
@@ -314,7 +315,6 @@ function subTransform(
   // imports/hoists are not merged because:
   // - imports are only used for asset urls and should be consistent between
   //   node/client branches
-  // - hoists are not enabled for the client branch here
 }
 
 function clone(v: any): any {


### PR DESCRIPTION
Fix: #3536 

Looking at the test snapshot in this PR, you can see that it generated duplicate hoists expressions:

```js
const _hoisted_2 = _imports_1
const _hoisted_3 = _imports_1
```

For the current implementation, this is expected. And I think @edison1105 's PR(https://github.com/vuejs/vue-next/pull/3215) can improve it