### PR TITLE
fix(SFC-playground): Prevents browser default save behavior when saving in the editor

### DIFF
--- a/packages/sfc-playground/src/codemirror/codemirror.ts
+++ b/packages/sfc-playground/src/codemirror/codemirror.ts
@@ -1,3 +1,4 @@
+import { NOOP } from '@vue/shared'
 import CodeMirror from 'codemirror'
 import './codemirror.css'
 
@@ -15,5 +16,8 @@ import 'codemirror/addon/fold/foldgutter.js'
 import 'codemirror/addon/fold/brace-fold.js'
 import 'codemirror/addon/fold/indent-fold.js'
 import 'codemirror/addon/fold/comment-fold.js'
+
+// @ts-ignore
+CodeMirror.commands.save = NOOP
 
 export default CodeMirror


### PR DESCRIPTION
The browser's default save behavior affects the experience a bit.