### PR TITLE
Refactor the assets resolution of the script setup

### DIFF
--- a/packages/compiler-core/__tests__/codegen.spec.ts
+++ b/packages/compiler-core/__tests__/codegen.spec.ts
@@ -35,6 +35,7 @@ import {
 } from '../src/runtimeHelpers'
 import { createElementWithCodegen, genFlagText } from './testUtils'
 import { PatchFlags } from '@vue/shared'
+import { AssetData } from '../src/transform'
 
 function createRoot(options: Partial<RootNode> = {}): RootNode {
   return {
@@ -50,6 +51,13 @@ function createRoot(options: Partial<RootNode> = {}): RootNode {
     codegenNode: createSimpleExpression(`null`, false),
     loc: locStub,
     ...options
+  }
+}
+
+function createAsset(name: string): AssetData {
+  return {
+    name,
+    warnMissing: true
   }
 }
 
@@ -126,8 +134,13 @@ describe('compiler: codegen', () => {
 
   test('assets + temps', () => {
     const root = createRoot({
-      components: [`Foo`, `bar-baz`, `barbaz`, `Qux__self`],
-      directives: [`my_dir_0`, `my_dir_1`],
+      components: [
+        createAsset(`Foo`),
+        createAsset(`bar-baz`),
+        createAsset(`barbaz`),
+        createAsset(`Qux__self`)
+      ],
+      directives: [createAsset(`my_dir_0`), createAsset(`my_dir_1`)],
       temps: 3
     })
     const { code } = generate(root, { mode: 'function' })

--- a/packages/compiler-core/__tests__/transforms/transformElement.spec.ts
+++ b/packages/compiler-core/__tests__/transforms/transformElement.spec.ts
@@ -69,7 +69,7 @@ describe('compiler: element transform', () => {
   test('import + resolve component', () => {
     const { root } = parseWithElementTransform(`<Foo/>`)
     expect(root.helpers).toContain(RESOLVE_COMPONENT)
-    expect(root.components).toContain(`Foo`)
+    expect(root.components).toEqual([{ name: 'Foo', warnMissing: true }])
   })
 
   test('resolve implcitly self-referencing component', () => {
@@ -77,7 +77,9 @@ describe('compiler: element transform', () => {
       filename: `/foo/bar/Example.vue?vue&type=template`
     })
     expect(root.helpers).toContain(RESOLVE_COMPONENT)
-    expect(root.components).toContain(`Example__self`)
+    expect(root.components).toEqual([
+      { name: 'Example__self', warnMissing: true }
+    ])
   })
 
   test('resolve component from setup bindings', () => {
@@ -86,8 +88,8 @@ describe('compiler: element transform', () => {
         Example: BindingTypes.SETUP_MAYBE_REF
       }
     })
-    expect(root.helpers).not.toContain(RESOLVE_COMPONENT)
-    expect(node.tag).toBe(`$setup["Example"]`)
+    expect(root.helpers).toContain(RESOLVE_COMPONENT)
+    expect(node.tag).toBe(`_component_Example`)
   })
 
   test('do not resolve component from non-script-setup bindings', () => {
@@ -99,7 +101,7 @@ describe('compiler: element transform', () => {
       bindingMetadata
     })
     expect(root.helpers).toContain(RESOLVE_COMPONENT)
-    expect(root.components).toContain(`Example`)
+    expect(root.components).toEqual([{ name: 'Example', warnMissing: true }])
   })
 
   test('static props', () => {
@@ -476,7 +478,7 @@ describe('compiler: element transform', () => {
       }
     )
     expect(root.helpers).toContain(RESOLVE_DIRECTIVE)
-    expect(root.directives).toContain(`foo`)
+    expect(root.directives).toEqual([{ name: 'foo', warnMissing: true }])
     expect(node).toMatchObject({
       tag: `"div"`,
       props: undefined,
@@ -536,9 +538,11 @@ describe('compiler: element transform', () => {
       `<div v-foo v-bar="x" v-baz:[arg].mod.mad="y" />`
     )
     expect(root.helpers).toContain(RESOLVE_DIRECTIVE)
-    expect(root.directives).toContain(`foo`)
-    expect(root.directives).toContain(`bar`)
-    expect(root.directives).toContain(`baz`)
+    expect(root.directives).toEqual([
+      { name: 'foo', warnMissing: true },
+      { name: 'bar', warnMissing: true },
+      { name: 'baz', warnMissing: true }
+    ])
 
     expect(node).toMatchObject({
       directives: {

--- a/packages/compiler-core/src/ast.ts
+++ b/packages/compiler-core/src/ast.ts
@@ -11,7 +11,7 @@ import {
   WITH_DIRECTIVES
 } from './runtimeHelpers'
 import { PropsExpression } from './transforms/transformElement'
-import { ImportItem, TransformContext } from './transform'
+import { ImportItem, TransformContext, AssetData } from './transform'
 
 // Vue template is a platform-agnostic superset of HTML (syntax only).
 // More namespaces like SVG and MathML are declared by platform specific
@@ -101,8 +101,8 @@ export interface RootNode extends Node {
   type: NodeTypes.ROOT
   children: TemplateChildNode[]
   helpers: symbol[]
-  components: string[]
-  directives: string[]
+  components: AssetData[]
+  directives: AssetData[]
   hoists: (JSChildNode | null)[]
   imports: ImportItem[]
   cached: number

--- a/packages/compiler-core/src/ast.ts
+++ b/packages/compiler-core/src/ast.ts
@@ -111,7 +111,7 @@ export interface RootNode extends Node {
   codegenNode?: TemplateChildNode | JSChildNode | BlockStatement
 
   // v2 compat only
-  filters?: string[]
+  filters?: AssetData[]
 }
 
 export type ElementNode =

--- a/packages/compiler-core/src/compat/transformFilter.ts
+++ b/packages/compiler-core/src/compat/transformFilter.ts
@@ -180,12 +180,18 @@ function wrapFilter(
   context.helper(RESOLVE_FILTER)
   const i = filter.indexOf('(')
   if (i < 0) {
-    context.filters!.add(filter)
+    context.filters!.set(filter, {
+      name: filter,
+      warnMissing: true
+    })
     return `${toValidAssetId(filter, 'filter')}(${exp})`
   } else {
     const name = filter.slice(0, i)
     const args = filter.slice(i + 1)
-    context.filters!.add(name)
+    context.filters!.set(name, {
+      name,
+      warnMissing: true
+    })
     return `${toValidAssetId(name, 'filter')}(${exp}${
       args !== ')' ? ',' + args : args
     }`

--- a/packages/compiler-core/src/transform.ts
+++ b/packages/compiler-core/src/transform.ts
@@ -83,6 +83,12 @@ export interface ImportItem {
   path: string
 }
 
+export interface AssetData {
+  name: string
+  warnMissing: boolean
+  fallback?: string
+}
+
 export interface TransformContext
   extends Required<
       Omit<TransformOptions, 'filename' | keyof CompilerCompatOptions>
@@ -91,8 +97,8 @@ export interface TransformContext
   selfName: string | null
   root: RootNode
   helpers: Map<symbol, number>
-  components: Set<string>
-  directives: Set<string>
+  components: Map<string, AssetData>
+  directives: Map<string, AssetData>
   hoists: (JSChildNode | null)[]
   imports: ImportItem[]
   temps: number
@@ -175,8 +181,8 @@ export function createTransformContext(
     // state
     root,
     helpers: new Map(),
-    components: new Set(),
-    directives: new Set(),
+    components: new Map(),
+    directives: new Map(),
     hoists: [],
     imports: [],
     constantCache: new Map(),
@@ -322,8 +328,8 @@ export function transform(root: RootNode, options: TransformOptions) {
   }
   // finalize meta information
   root.helpers = [...context.helpers.keys()]
-  root.components = [...context.components]
-  root.directives = [...context.directives]
+  root.components = [...context.components.values()]
+  root.directives = [...context.directives.values()]
   root.imports = context.imports
   root.hoists = context.hoists
   root.temps = context.temps

--- a/packages/compiler-core/src/transform.ts
+++ b/packages/compiler-core/src/transform.ts
@@ -126,7 +126,7 @@ export interface TransformContext
   constantCache: Map<TemplateChildNode, ConstantTypes>
 
   // 2.x Compat only
-  filters?: Set<string>
+  filters?: Map<string, AssetData>
 }
 
 export function createTransformContext(
@@ -299,7 +299,7 @@ export function createTransformContext(
   }
 
   if (__COMPAT__) {
-    context.filters = new Set()
+    context.filters = new Map()
   }
 
   function addId(id: string) {
@@ -336,7 +336,7 @@ export function transform(root: RootNode, options: TransformOptions) {
   root.cached = context.cached
 
   if (__COMPAT__) {
-    root.filters = [...context.filters!]
+    root.filters = [...context.filters!.values()]
   }
 }
 

--- a/packages/compiler-sfc/__tests__/__snapshots__/compileScript.spec.ts.snap
+++ b/packages/compiler-sfc/__tests__/__snapshots__/compileScript.spec.ts.snap
@@ -214,7 +214,7 @@ return { ref }
 `;
 
 exports[`SFC compile <script setup> inlineTemplate mode avoid unref() when necessary 1`] = `
-"import { unref as _unref, toDisplayString as _toDisplayString, createTextVNode as _createTextVNode, withCtx as _withCtx, createVNode as _createVNode, Fragment as _Fragment, openBlock as _openBlock, createBlock as _createBlock } from \\"vue\\"
+"import { unref as _unref, toDisplayString as _toDisplayString, createTextVNode as _createTextVNode, resolveComponent as _resolveComponent, withCtx as _withCtx, createVNode as _createVNode, Fragment as _Fragment, openBlock as _openBlock, createBlock as _createBlock } from \\"vue\\"
 
 import { ref } from 'vue'
         import Foo, { bar } from './Foo.vue'
@@ -231,8 +231,10 @@ export default {
         function fn() {}
         
 return (_ctx, _cache) => {
+  const _component_Foo = _resolveComponent(\\"Foo\\", false, false, Foo)
+
   return (_openBlock(), _createBlock(_Fragment, null, [
-    _createVNode(Foo, null, {
+    _createVNode(_component_Foo, null, {
       default: _withCtx(() => [
         _createTextVNode(_toDisplayString(_unref(bar)), 1 /* TEXT */)
       ]),
@@ -247,7 +249,7 @@ return (_ctx, _cache) => {
 `;
 
 exports[`SFC compile <script setup> inlineTemplate mode referencing scope components and directives 1`] = `
-"import { unref as _unref, createVNode as _createVNode, withDirectives as _withDirectives, Fragment as _Fragment, openBlock as _openBlock, createBlock as _createBlock } from \\"vue\\"
+"import { resolveDirective as _resolveDirective, unref as _unref, createVNode as _createVNode, withDirectives as _withDirectives, resolveComponent as _resolveComponent, Fragment as _Fragment, openBlock as _openBlock, createBlock as _createBlock } from \\"vue\\"
 
 import ChildComp from './Child.vue'
         import SomeOtherComp from './Other.vue'
@@ -259,12 +261,16 @@ export default {
 
         
 return (_ctx, _cache) => {
+  const _component_ChildComp = _resolveComponent(\\"ChildComp\\", false, false, ChildComp)
+  const _component_some_other_comp = _resolveComponent(\\"some-other-comp\\", false, false, SomeOtherComp)
+  const _directive_my_dir = _resolveDirective(\\"my-dir\\", false, _unref(myDir))
+
   return (_openBlock(), _createBlock(_Fragment, null, [
     _withDirectives(_createVNode(\\"div\\", null, null, 512 /* NEED_PATCH */), [
-      [_unref(myDir)]
+      [_directive_my_dir]
     ]),
-    _createVNode(ChildComp),
-    _createVNode(SomeOtherComp)
+    _createVNode(_component_ChildComp),
+    _createVNode(_component_some_other_comp)
   ], 64 /* STABLE_FRAGMENT */))
 }
 }

--- a/packages/compiler-sfc/__tests__/compileScript.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileScript.spec.ts
@@ -217,10 +217,19 @@ const myEmit = defineEmit(['foo', 'bar'])
         `,
         { inlineTemplate: true }
       )
-      expect(content).toMatch('[_unref(myDir)]')
-      expect(content).toMatch('_createVNode(ChildComp)')
+      expect(content).toMatch(
+        'const _directive_my_dir = _resolveDirective("my-dir", false, _unref(myDir))'
+      )
+      expect(content).toMatch('[_directive_my_dir]')
+      expect(content).toMatch(
+        'const _component_ChildComp = _resolveComponent("ChildComp", false, false, ChildComp)'
+      )
+      expect(content).toMatch('_createVNode(_component_ChildComp)')
       // kebab-case component support
-      expect(content).toMatch('_createVNode(SomeOtherComp)')
+      expect(content).toMatch(
+        'const _component_some_other_comp = _resolveComponent("some-other-comp", false, false, SomeOtherComp)'
+      )
+      expect(content).toMatch('_createVNode(_component_some_other_comp)')
       assertCode(content)
     })
 
@@ -244,8 +253,11 @@ const myEmit = defineEmit(['foo', 'bar'])
         `,
         { inlineTemplate: true }
       )
-      // no need to unref vue component import
-      expect(content).toMatch(`createVNode(Foo,`)
+
+      expect(content).toMatch(
+        `const _component_Foo = _resolveComponent(\"Foo\", false, false, Foo)`
+      )
+      expect(content).toMatch(`createVNode(_component_Foo,`)
       // #2699 should unref named imports from .vue
       expect(content).toMatch(`unref(bar)`)
       // should unref other imports

--- a/packages/compiler-ssr/src/transforms/ssrTransformComponent.ts
+++ b/packages/compiler-ssr/src/transforms/ssrTransformComponent.ts
@@ -307,7 +307,7 @@ function subTransform(
           parentContext.helpers.set(helperKey, value + parentCount)
         }
       } else {
-        ;(parentContext[key] as any).add(value)
+        ;(parentContext[key] as any).set(helperKey, value)
       }
     })
   })

--- a/packages/runtime-core/__tests__/helpers/resolveAssets.spec.ts
+++ b/packages/runtime-core/__tests__/helpers/resolveAssets.spec.ts
@@ -263,13 +263,13 @@ describe('resolveAssets', () => {
         return () => {
           component1 = resolveComponent('FooBar', false, false, FooBarFallBack)!
           component2 = resolveComponent(
-            'NoExist',
+            'notExist',
             false,
             false,
             FooBarFallBack
           )!
           directive1 = resolveDirective('BarBaz', false, BarBazFallBack)!
-          directive2 = resolveDirective('NoExist', false, BarBazFallBack)!
+          directive2 = resolveDirective('notExist', false, BarBazFallBack)!
         }
       }
     }

--- a/packages/runtime-core/__tests__/helpers/resolveAssets.spec.ts
+++ b/packages/runtime-core/__tests__/helpers/resolveAssets.spec.ts
@@ -240,4 +240,47 @@ describe('resolveAssets', () => {
     expect(directive3!).toBe(BarBaz)
     expect(directive4!).toBe(BarBaz)
   })
+
+  test('resolving with fallback', () => {
+    const FooBar = () => null
+    const FooBarFallBack = () => null
+    const BarBaz = { mounted: () => null }
+    const BarBazFallBack = { mounted: () => null }
+
+    let component1: Component | string
+    let component2: Component | string
+    let directive1: Directive
+    let directive2: Directive
+
+    const Root = {
+      components: {
+        FooBar: FooBar
+      },
+      directives: {
+        BarBaz: BarBaz
+      },
+      setup() {
+        return () => {
+          component1 = resolveComponent('FooBar', false, false, FooBarFallBack)!
+          component2 = resolveComponent(
+            'NoExist',
+            false,
+            false,
+            FooBarFallBack
+          )!
+          directive1 = resolveDirective('BarBaz', false, BarBazFallBack)!
+          directive2 = resolveDirective('NoExist', false, BarBazFallBack)!
+        }
+      }
+    }
+
+    const app = createApp(Root)
+    const root = nodeOps.createElement('div')
+    app.mount(root)
+    expect(component1!).toBe(FooBar)
+    expect(component2!).toBe(FooBarFallBack)
+
+    expect(directive1!).toBe(BarBaz)
+    expect(directive2!).toBe(BarBazFallBack)
+  })
 })

--- a/packages/runtime-core/src/helpers/resolveAssets.ts
+++ b/packages/runtime-core/src/helpers/resolveAssets.ts
@@ -21,9 +21,13 @@ export type AssetTypes = typeof COMPONENTS | typeof DIRECTIVES | typeof FILTERS
  */
 export function resolveComponent(
   name: string,
-  maybeSelfReference?: boolean
+  maybeSelfReference?: boolean,
+  warnMissing: boolean = true,
+  fallback: any = name
 ): ConcreteComponent | string {
-  return resolveAsset(COMPONENTS, name, true, maybeSelfReference) || name
+  return (
+    resolveAsset(COMPONENTS, name, warnMissing, maybeSelfReference) || fallback
+  )
 }
 
 export const NULL_DYNAMIC_COMPONENT = Symbol()
@@ -43,8 +47,12 @@ export function resolveDynamicComponent(component: unknown): VNodeTypes {
 /**
  * @private
  */
-export function resolveDirective(name: string): Directive | undefined {
-  return resolveAsset(DIRECTIVES, name)
+export function resolveDirective(
+  name: string,
+  warnMissing: boolean = true,
+  fallback: Directive | undefined = undefined
+): Directive | undefined {
+  return resolveAsset(DIRECTIVES, name, warnMissing) || fallback
 }
 
 /**
@@ -68,7 +76,8 @@ function resolveAsset(
 // overload 2: directives
 function resolveAsset(
   type: typeof DIRECTIVES,
-  name: string
+  name: string,
+  warnMissing?: boolean
 ): Directive | undefined
 // implementation
 // overload 3: filters (compat only)


### PR DESCRIPTION
Close: #3543 

with `<script setup>`, Assets(components/directives) will be tried to resolve from the setup state, this leads to naming conflicts between assets and ordinary variables, e.g.

```html
<template>
  <div v-focus/>
</template>

<script setup>
const focus = ref(0);
</script>
```

The constant `focus` in setup will overwrite the globally registered directive with the same name. This is because the above code will be compiled as:

```js
export function render(_ctx, _cache, $props, $setup) {
  return _withDirectives((_openBlock(), _createBlock('div', null, null, 512 /* NEED_PATCH */)), [
    // Will no longer perform asset resolution
    [$setup["focus"]]
  ])
}
```

with `$setup["focus"]`, it will no longer perform asset resolution. 

My idea is that in order to avoid name conflicts, we should always perform asset resolution, which makes globally registered assets have a higher priority, and at the same time, use setup state as a fallback. E.g.

```js
export function render(_ctx, _cache, $props, $setup) {
  const _directive_focus = _resolveDirective(
    // resolve globally registered assets
    "focus",
    // warnMissing
    false,
    // fallback, when the asset resolution fails, use the fallback instead
    $setup["focus"]
  )

  return _withDirectives((_openBlock(), _createBlock('div', null, null, 512 /* NEED_PATCH */)), [
    [_directive_focus]
  ])
}
```

This behavior also applies to components resolution. And it only takes effect when there is a state with the same name in the setup result, without breaking anything.




