### PR TITLE
fix(runtime-core): should not track dynamic children when the user calls a compiled slot inside template expression

### DIFF
--- a/packages/runtime-core/src/compat/instance.ts
+++ b/packages/runtime-core/src/compat/instance.ts
@@ -37,6 +37,7 @@ import {
 import { resolveFilter } from '../helpers/resolveAssets'
 import { resolveMergedOptions } from '../componentOptions'
 import { InternalSlots, Slots } from '../componentSlots'
+import { ContextualRenderFn } from '../componentRenderContext'
 
 export type LegacyPublicInstance = ComponentPublicInstance &
   LegacyPublicProperties
@@ -106,7 +107,7 @@ export function installCompatInstanceProperties(map: PublicPropertiesMap) {
       const res: InternalSlots = {}
       for (const key in i.slots) {
         const fn = i.slots[key]!
-        if (!(fn as any)._nonScoped) {
+        if (!(fn as ContextualRenderFn)._ns /* non-scoped slot */) {
           res[key] = fn
         }
       }

--- a/packages/runtime-core/src/compat/renderFn.ts
+++ b/packages/runtime-core/src/compat/renderFn.ts
@@ -281,7 +281,7 @@ function convertLegacySlots(vnode: VNode): VNode {
       for (const key in slots) {
         const slotChildren = slots[key]
         slots[key] = () => slotChildren
-        slots[key]._nonScoped = true
+        slots[key]._ns = true /* non-scoped slot */
       }
     }
   }

--- a/packages/runtime-core/src/componentRenderContext.ts
+++ b/packages/runtime-core/src/componentRenderContext.ts
@@ -1,6 +1,6 @@
 import { ComponentInternalInstance } from './component'
 import { devtoolsComponentUpdated } from './devtools'
-import { closeBlock, openBlock } from './vnode'
+import { setBlockTracking } from './vnode'
 
 /**
  * mark the current rendering instance for asset resolution (e.g.
@@ -57,21 +57,10 @@ export const withScopeId = (_id: string) => withCtx
 
 export type ContextualRenderFn = {
   (...args: any[]): any
+  _n: boolean /* already normalized */
   _c: boolean /* compiled */
   _d: boolean /* disableTracking */
-  _nonScoped: boolean
-}
-
-/**
- * used to force bailout when creating a VNode,
- * when the user manually calls the slot function,
- * it will potentially break the optimization mode
- */
-export let shouldForceBailout = false
-function setShouldForceBailout(bailout: boolean) {
-  const prev = shouldForceBailout
-  shouldForceBailout = bailout
-  return prev
+  _ns: boolean /* nonScoped */
 }
 
 /**
@@ -84,22 +73,26 @@ export function withCtx(
   isNonScopedSlot?: boolean // __COMPAT__ only
 ) {
   if (!ctx) return fn
+
+  // already normalized
+  if ((fn as ContextualRenderFn)._n) {
+    return fn
+  }
+
   const renderFnWithContext: ContextualRenderFn = (...args: any[]) => {
-    // in the case of recursively calling, save the prev value
-    const prev = setShouldForceBailout(false)
     // If a user calls a compiled slot inside a template expression (#1745), it
-    // can mess up block tracking, so by default we need to push a null block to
-    // avoid that. This isn't necessary if rendering a compiled `<slot>`.
+    // can mess up block tracking, so by default we disable block tracking and
+    // force bail out when invoking a compiled slot (indicated by the ._d flag).
+    // This isn't necessary if rendering a compiled `<slot>`, so we flip the
+    // ._d flag off when invoking the wrapped fn inside `renderSlot`.
     if (renderFnWithContext._d) {
-      openBlock(true /* null block that disables tracking */)
-      setShouldForceBailout(true)
+      setBlockTracking(-1)
     }
     const prevInstance = setCurrentRenderingInstance(ctx)
     const res = fn(...args)
     setCurrentRenderingInstance(prevInstance)
     if (renderFnWithContext._d) {
-      closeBlock()
-      setShouldForceBailout(prev)
+      setBlockTracking(1)
     }
 
     if (__DEV__ || __FEATURE_PROD_DEVTOOLS__) {
@@ -108,14 +101,18 @@ export function withCtx(
 
     return res
   }
-  // mark this as a compiled slot function.
+
+  // mark normalized to avoid duplicated wrapping
+  renderFnWithContext._n = true
+  // mark this as compiled by default
   // this is used in vnode.ts -> normalizeChildren() to set the slot
   // rendering flag.
-  // also used to cache the normalized results to avoid repeated normalization
   renderFnWithContext._c = true
+  // disable block tracking by default
   renderFnWithContext._d = true
+  // compat build only flag to distinguish scoped slots from non-scoped ones
   if (__COMPAT__ && isNonScopedSlot) {
-    renderFnWithContext._nonScoped = true
+    renderFnWithContext._ns = true
   }
   return renderFnWithContext
 }

--- a/packages/runtime-core/src/componentSlots.ts
+++ b/packages/runtime-core/src/componentSlots.ts
@@ -17,7 +17,7 @@ import {
 } from '@vue/shared'
 import { warn } from './warning'
 import { isKeepAlive } from './components/KeepAlive'
-import { withCtx } from './componentRenderContext'
+import { ContextualRenderFn, withCtx } from './componentRenderContext'
 import { isHmrUpdating } from './hmr'
 import { DeprecationTypes, isCompatEnabled } from './compat/compatConfig'
 import { toRaw } from '@vue/reactivity'
@@ -62,9 +62,8 @@ const normalizeSlot = (
   key: string,
   rawSlot: Function,
   ctx: ComponentInternalInstance | null | undefined
-): Slot =>
-  (rawSlot as any)._c ||
-  (withCtx((props: any) => {
+): Slot => {
+  const normalized = withCtx((props: any) => {
     if (__DEV__ && currentInstance) {
       warn(
         `Slot "${key}" invoked outside of the render function: ` +
@@ -73,7 +72,11 @@ const normalizeSlot = (
       )
     }
     return normalizeSlotValue(rawSlot(props))
-  }, ctx) as Slot)
+  }, ctx) as Slot
+  // NOT a compiled slot
+  ;(normalized as ContextualRenderFn)._c = false
+  return normalized
+}
 
 const normalizeObjectSlots = (
   rawSlots: RawSlots,

--- a/packages/runtime-core/src/helpers/renderSlot.ts
+++ b/packages/runtime-core/src/helpers/renderSlot.ts
@@ -1,5 +1,6 @@
 import { Data } from '../component'
 import { Slots, RawSlots } from '../componentSlots'
+import { ContextualRenderFn } from '../componentRenderContext'
 import { Comment, isVNode } from '../vnode'
 import {
   VNodeArrayChildren,
@@ -10,10 +11,6 @@ import {
 } from '../vnode'
 import { PatchFlags, SlotFlags } from '@vue/shared'
 import { warn } from '../warning'
-
-export let isRenderingCompiledSlot = 0
-export const setCompiledSlotRendering = (n: number) =>
-  (isRenderingCompiledSlot += n)
 
 /**
  * Compiler runtime helper for rendering `<slot/>`
@@ -43,7 +40,9 @@ export function renderSlot(
   // invocation interfering with template-based block tracking, but in
   // `renderSlot` we can be sure that it's template-based so we can force
   // enable it.
-  isRenderingCompiledSlot++
+  if (slot && (slot as ContextualRenderFn)._c) {
+    ;(slot as ContextualRenderFn)._d = false
+  }
   openBlock()
   const validSlotContent = slot && ensureValidVNode(slot(props))
   const rendered = createBlock(
@@ -57,7 +56,9 @@ export function renderSlot(
   if (!noSlotted && rendered.scopeId) {
     rendered.slotScopeIds = [rendered.scopeId + '-s']
   }
-  isRenderingCompiledSlot--
+  if (slot && (slot as ContextualRenderFn)._c) {
+    ;(slot as ContextualRenderFn)._d = true
+  }
   return rendered
 }
 

--- a/packages/runtime-core/src/vnode.ts
+++ b/packages/runtime-core/src/vnode.ts
@@ -35,7 +35,8 @@ import { warn } from './warning'
 import { TeleportImpl, isTeleport } from './components/Teleport'
 import {
   currentRenderingInstance,
-  currentScopeId
+  currentScopeId,
+  shouldForceBailout
 } from './componentRenderContext'
 import { RendererNode, RendererElement } from './renderer'
 import { NULL_DYNAMIC_COMPONENT } from './helpers/resolveAssets'
@@ -263,7 +264,9 @@ export function createBlock(
     true /* isBlock: prevent a block from tracking itself */
   )
   // save current block children on the block vnode
-  vnode.dynamicChildren = currentBlock || (EMPTY_ARR as any)
+  vnode.dynamicChildren = shouldForceBailout
+    ? null
+    : currentBlock || (EMPTY_ARR as any)
   // close block
   closeBlock()
   // a block is always going to be patched, so track it as a child of its
@@ -347,6 +350,11 @@ function _createVNode(
       warn(`Invalid vnode type when creating vnode: ${type}.`)
     }
     type = Comment
+  }
+
+  if (shouldForceBailout) {
+    patchFlag = 0
+    dynamicProps = null
   }
 
   if (isVNode(type)) {

--- a/packages/runtime-core/src/vnode.ts
+++ b/packages/runtime-core/src/vnode.ts
@@ -35,8 +35,7 @@ import { warn } from './warning'
 import { TeleportImpl, isTeleport } from './components/Teleport'
 import {
   currentRenderingInstance,
-  currentScopeId,
-  shouldForceBailout
+  currentScopeId
 } from './componentRenderContext'
 import { RendererNode, RendererElement } from './renderer'
 import { NULL_DYNAMIC_COMPONENT } from './helpers/resolveAssets'
@@ -218,7 +217,7 @@ export function closeBlock() {
 // Only tracks when this value is > 0
 // We are not using a simple boolean because this value may need to be
 // incremented/decremented by nested usage of v-once (see below)
-let shouldTrack = 1
+let isBlockTreeEnabled = 1
 
 /**
  * Block tracking sometimes needs to be disabled, for example during the
@@ -237,7 +236,7 @@ let shouldTrack = 1
  * @private
  */
 export function setBlockTracking(value: number) {
-  shouldTrack += value
+  isBlockTreeEnabled += value
 }
 
 /**
@@ -263,14 +262,13 @@ export function createBlock(
     true /* isBlock: prevent a block from tracking itself */
   )
   // save current block children on the block vnode
-  vnode.dynamicChildren = shouldForceBailout
-    ? null
-    : currentBlock || (EMPTY_ARR as any)
+  vnode.dynamicChildren =
+    isBlockTreeEnabled > 0 ? currentBlock || (EMPTY_ARR as any) : null
   // close block
   closeBlock()
   // a block is always going to be patched, so track it as a child of its
   // parent block
-  if (shouldTrack > 0 && currentBlock) {
+  if (isBlockTreeEnabled > 0 && currentBlock) {
     currentBlock.push(vnode)
   }
   return vnode
@@ -349,11 +347,6 @@ function _createVNode(
       warn(`Invalid vnode type when creating vnode: ${type}.`)
     }
     type = Comment
-  }
-
-  if (shouldForceBailout) {
-    patchFlag = 0
-    dynamicProps = null
   }
 
   if (isVNode(type)) {
@@ -465,7 +458,7 @@ function _createVNode(
   }
 
   if (
-    shouldTrack > 0 &&
+    isBlockTreeEnabled > 0 &&
     // avoid a block node from tracking itself
     !isBlockNode &&
     // has current parent block
@@ -644,7 +637,7 @@ export function normalizeChildren(vnode: VNode, children: unknown) {
         // _c marker is added by withCtx() indicating this is a compiled slot
         slot._c && (slot._d = false)
         normalizeChildren(vnode, slot())
-        slot._c && (slot._d = false)
+        slot._c && (slot._d = true)
       }
       return
     } else {

--- a/packages/runtime-core/src/vnode.ts
+++ b/packages/runtime-core/src/vnode.ts
@@ -41,7 +41,6 @@ import {
 import { RendererNode, RendererElement } from './renderer'
 import { NULL_DYNAMIC_COMPONENT } from './helpers/resolveAssets'
 import { hmrDirtyComponents } from './hmr'
-import { setCompiledSlotRendering } from './helpers/renderSlot'
 import { convertLegacyComponent } from './compat/component'
 import { convertLegacyVModelProps } from './compat/componentVModel'
 import { defineLegacyVNodeProperties } from './compat/renderFn'
@@ -643,9 +642,9 @@ export function normalizeChildren(vnode: VNode, children: unknown) {
       const slot = (children as any).default
       if (slot) {
         // _c marker is added by withCtx() indicating this is a compiled slot
-        slot._c && setCompiledSlotRendering(1)
+        slot._c && (slot._d = false)
         normalizeChildren(vnode, slot())
-        slot._c && setCompiledSlotRendering(-1)
+        slot._c && (slot._d = false)
       }
       return
     } else {


### PR DESCRIPTION
Fix: #3548 

**Edit:**

Also fix #3569, at first I tried to fix issue #3569 in another independent PR(https://github.com/vuejs/vue-next/pull/3573), and then I realized the strong coupling between issue #3548 and issue #3569, so I merged them into this one PR.

Issue #3569 is another problem caused by the mixed-use of optimization mode and manual render function, technically, the user can get any VNode in the manually written render function, e.g.

```js
setup(props, { slots }) {
  const index = ref(100)
  return () => {
    // get any vnode
    return slots.foo()[3].children[index.value]
  }
}
```

Suppose the initial value of `index` is 100, and then it becomes `999`, then the old and new subTree may be:

```js
// old
{ type: 'div', dynamicChildren: [vnode1, vnode2] }
// new
{ type: 'div', dynamicChildren: [vnode99], patchFlags: xxx }
```

Obviously, they are not comparable, and they may come from different levels.

The idea is, for slots, if the user manually obtains the contents of the slot by calling the slots function, we should be forced to bail out the optimization mode