### PR TITLE
feat(types): support find definition for jsx tags, events

### DIFF
--- a/packages/runtime-dom/types/jsx.d.ts
+++ b/packages/runtime-dom/types/jsx.d.ts
@@ -1311,10 +1311,8 @@ export interface Events {
   onTransitionstart: TransitionEvent
 }
 
-type StringKeyOf<T> = Extract<keyof T, string>
-
 type EventHandlers<E> = {
-  [K in StringKeyOf<E>]?: E[K] extends Function ? E[K] : (payload: E[K]) => void
+  [K in keyof E]?: E[K] extends Function ? E[K] : (payload: E[K]) => void
 }
 
 // use namespace import to avoid collision with generated types which use
@@ -1332,7 +1330,7 @@ type ReservedProps = {
 type ElementAttrs<T> = T & ReservedProps
 
 type NativeElements = {
-  [K in StringKeyOf<IntrinsicElementAttributes>]: ElementAttrs<
+  [K in keyof IntrinsicElementAttributes]: ElementAttrs<
     IntrinsicElementAttributes[K]
   >
 }


### PR DESCRIPTION
`StringKeyOf` seem has no practical effect, unused it to support find definition for jsx tags and events in IDE.

![Animation](https://user-images.githubusercontent.com/16279759/115841940-e5d14180-a44f-11eb-94dc-6787aaafca4a.gif)
