### PR TITLE
fix(runtime-core): exit the optimization mode when the user manually renders the compiled slot

### DIFF
--- a/packages/runtime-core/src/componentRenderContext.ts
+++ b/packages/runtime-core/src/componentRenderContext.ts
@@ -74,7 +74,7 @@ export function withCtx(
       closeBlock()
     }
     // #3569
-    if (!isRenderingCompiledSlot) {
+    if (!isRenderingCompiledSlot && res) {
       res.forEach(vnode => {
         // when the user manually renders the compiled slot,
         // it will be able to easily break the optimization update mode,


### PR DESCRIPTION
Fix: #3569 

This is another problem caused by the mixed-use of optimization mode and manual render function, technically, the user can get any VNode in the manually written render function, e.g.

```js
setup(props, { slots }) {
  const index = ref(100)
  return () => {
    // get any vnode
    return slots.foo()[3].children[index.value]
  }
}
```

Suppose the initial value of `index` is 100, and then it becomes `999`, then the old and new subTree may be:

```js
// old
{ type: 'div', dynamicChildren: [vnode1, vnode2] }
// new
{ type: 'div', dynamicChildren: [vnode99], patchFlags: xxx }
```

Obviously, they are not comparable, and they may come from different levels.

The idea is, for slots, if the user manually obtains the contents of the slot, we need to ensure that the vnodes returned by the slot exit the optimization mode