### PR TITLE
fix(compiler-sfc): ref sugar work with destructuring + arrow function

### DIFF
--- a/packages/compiler-sfc/__tests__/__snapshots__/compileScript.spec.ts.snap
+++ b/packages/compiler-sfc/__tests__/__snapshots__/compileScript.spec.ts.snap
@@ -693,6 +693,21 @@ return { a, b, test }
 }"
 `;
 
+exports[`SFC compile <script setup> ref: syntax sugar work with destructuring + arrow function expression 1`] = `
+"export default {
+  expose: [],
+  setup(__props) {
+
+      const {} = () => 1;
+      const {} = useSomthing(() => 1);
+      const {} = useSomthing(computed(() => 1));
+      
+return {  }
+}
+
+}"
+`;
+
 exports[`SFC compile <script setup> should expose top level declarations 1`] = `
 "import { x } from './x'
       

--- a/packages/compiler-sfc/__tests__/compileScript.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileScript.spec.ts
@@ -656,6 +656,17 @@ const emit = defineEmit(['a', 'b'])
       })
     })
 
+    test('work with destructuring + arrow function expression', () => {
+      const { content } = compile(`
+      <script setup>
+      ref: ({} = () => 1);
+      ref: ({} = useSomthing(() => 1));
+      ref: ({} = useSomthing(computed(() => 1)));
+      </script>
+      `)
+      assertCode(content)
+    })
+
     test('multi ref declarations', () => {
       const { content, bindings } = compile(`<script setup>
       ref: a = 1, b = 2, c = {

--- a/packages/compiler-sfc/src/compileScript.ts
+++ b/packages/compiler-sfc/src/compileScript.ts
@@ -348,10 +348,11 @@ export function compileScript(
             break
           }
         }
-        for (let i = left.end!; i > 0; i++) {
-          const char = source[i + startOffset]
+
+        for (let i = right.end! + startOffset; i > right.start!; i--) {
+          const char = source[i]
           if (char === ')') {
-            s.remove(i + startOffset, i + startOffset + 1)
+            s.remove(i, i + 1)
             break
           }
         }


### PR DESCRIPTION
fix #3581