### PR TITLE
fix(type): avoid ThisType incompatibility of the nextTick function

### DIFF
--- a/packages/runtime-core/src/scheduler.ts
+++ b/packages/runtime-core/src/scheduler.ts
@@ -1,6 +1,5 @@
 import { ErrorCodes, callWithErrorHandling } from './errorHandling'
 import { isArray } from '@vue/shared'
-import { ComponentPublicInstance } from './componentPublicInstance'
 
 export interface SchedulerJob {
   (): void
@@ -49,10 +48,7 @@ let currentPreFlushParentJob: SchedulerJob | null = null
 const RECURSION_LIMIT = 100
 type CountMap = Map<SchedulerJob | SchedulerCb, number>
 
-export function nextTick(
-  this: ComponentPublicInstance | void,
-  fn?: () => void
-): Promise<void> {
+export function nextTick(this: object | void, fn?: () => void): Promise<void> {
   const p = currentFlushPromise || resolvedPromise
   return fn ? p.then(this ? fn.bind(this) : fn) : p
 }

--- a/test-dts/defineComponent.test-d.tsx
+++ b/test-dts/defineComponent.test-d.tsx
@@ -893,6 +893,10 @@ describe('emits', () => {
       expectError(this.$emit('input'))
       //  @ts-expect-error
       expectError(this.$emit('input', 1))
+    },
+    mounted() {
+      // #3599
+      this.$nextTick()
     }
   })
 


### PR DESCRIPTION
Fix: #3599 

When the component has the `emits` options, the `ThisType` of the `nextTick` function may be incompatible with the component instance, e.g.

```js
  defineComponent({
    emits: ['click']
  })
```

The `$emit`'s type of the component instance is:

```js
(event: "click", n: number) => void
```

But the `$emit`'s type of `ThisType` of `$nextTick` is:

```js
(event: string, n: number) => void
```

So there is a type incompatibility `'Type 'string' is not assignable to type '"click"''`. At first, I tried to unify their types, but I failed, maybe @pikax can give it another try.
