### PR TITLE
fix(Teleport): avoid changing the reference of vnode.dynamicChildren

### DIFF
--- a/packages/runtime-core/src/components/Teleport.ts
+++ b/packages/runtime-core/src/components/Teleport.ts
@@ -84,13 +84,13 @@ export const TeleportImpl = {
     } = internals
 
     const disabled = isTeleportDisabled(n2.props)
-    const { shapeFlag, children } = n2
+    let { shapeFlag, children, dynamicChildren } = n2
 
     // #3302
     // HMR updated, force full diff
     if (__DEV__ && isHmrUpdating) {
       optimized = false
-      n2.dynamicChildren = null
+      dynamicChildren = null
     }
 
     if (n1 == null) {
@@ -146,11 +146,11 @@ export const TeleportImpl = {
       const currentAnchor = wasDisabled ? mainAnchor : targetAnchor
       isSVG = isSVG || isTargetSVG(target)
 
-      if (n2.dynamicChildren) {
+      if (dynamicChildren) {
         // fast path when the teleport happens to be a block root
         patchBlockChildren(
           n1.dynamicChildren!,
-          n2.dynamicChildren,
+          dynamicChildren,
           currentContainer,
           parentComponent,
           parentSuspense,


### PR DESCRIPTION
Fix: #3641 