### PR TITLE
feat(types): support renaming for props

### DIFF
--- a/packages/runtime-core/src/componentProps.ts
+++ b/packages/runtime-core/src/componentProps.ts
@@ -104,7 +104,7 @@ type InferPropType<T> = [T] extends [null]
             : T
 
 export type ExtractPropTypes<O> = O extends object
-  ? { [K in keyof O]?: unknown } &
+  ? { [K in keyof O]?: unknown } & // This is needed to keep the relation between the option prop and the props, allowing to use ctrl+click to navigate to the prop options. see: #3656
       { [K in RequiredKeys<O>]: InferPropType<O[K]> } &
       { [K in OptionalKeys<O>]?: InferPropType<O[K]> }
   : { [K in string]: any }

--- a/packages/runtime-core/src/componentProps.ts
+++ b/packages/runtime-core/src/componentProps.ts
@@ -104,7 +104,8 @@ type InferPropType<T> = [T] extends [null]
             : T
 
 export type ExtractPropTypes<O> = O extends object
-  ? { [K in RequiredKeys<O>]: InferPropType<O[K]> } &
+  ? { [K in keyof O]?: unknown } &
+      { [K in RequiredKeys<O>]: InferPropType<O[K]> } &
       { [K in OptionalKeys<O>]?: InferPropType<O[K]> }
   : { [K in string]: any }
 


### PR DESCRIPTION
IDE features like find references / renaming... not working with `RequiredKeys<O>`, `OptionalKeys<O>` object keys types, this PR add `[K in keyof O]` to patch this problem.

Problems:

- Not sure `unknown` type has consistency behavior with some special tsconfig.json settings.

![Animation2](https://user-images.githubusercontent.com/16279759/115844687-a9ebab80-a452-11eb-88d1-40438f6859d7.gif)
