### PR TITLE
fix: remove beforeDestory, destroyes warnings when using beforeUnmount, unmounted

### DIFF
--- a/packages/runtime-core/__tests__/componentOptions.spec.ts
+++ b/packages/runtime-core/__tests__/componentOptions.spec.ts
@@ -1,0 +1,57 @@
+import { render, h, nodeOps, defineComponent } from '@vue/runtime-test'
+
+describe('component options', () => {
+  test('with beforeDestroy, destoryed, no beforeUnmount, no unmounted', () => {
+    const Comp = defineComponent({
+      render() {
+        return h('div')
+      },
+      beforeDestroy() {},
+      destroyed() {}
+    })
+
+    const root = nodeOps.createElement('div')
+    render(h(Comp, {}), root)
+
+    expect(
+      '`beforeDestroy` has been renamed to `beforeUnmount`'
+    ).toHaveBeenWarned()
+    expect('`destroyed` has been renamed to `unmounted`').toHaveBeenWarned()
+  })
+  test('with beforeUnmount, unmounted, no beforeDestroy, no destroyed', () => {
+    const Comp = defineComponent({
+      render() {
+        return h('div')
+      },
+      beforeUnmount() {},
+      unmounted() {}
+    })
+
+    const root = nodeOps.createElement('div')
+    render(h(Comp, {}), root)
+
+    expect(
+      '`beforeDestroy` has been renamed to `beforeUnmount`'
+    ).not.toHaveBeenWarned()
+    expect('`destroyed` has been renamed to `unmounted`').not.toHaveBeenWarned()
+  })
+  test('with beforeDestroy, destoryed, beforeUnmount, unmounted', () => {
+    const Comp = defineComponent({
+      render() {
+        return h('div')
+      },
+      beforeDestroy() {},
+      destroyed() {},
+      beforeUnmount() {},
+      unmounted() {}
+    })
+
+    const root = nodeOps.createElement('div')
+    render(h(Comp, {}), root)
+
+    expect(
+      '`beforeDestroy` has been renamed to `beforeUnmount`'
+    ).not.toHaveBeenWarned()
+    expect('`destroyed` has been renamed to `unmounted`').not.toHaveBeenWarned()
+  })
+})

--- a/packages/runtime-core/src/componentOptions.ts
+++ b/packages/runtime-core/src/componentOptions.ts
@@ -795,13 +795,13 @@ export function applyOptions(
   if (renderTriggered) {
     onRenderTriggered(renderTriggered.bind(publicThis))
   }
-  if (__DEV__ && beforeDestroy) {
+  if (__DEV__ && !beforeUnmount && beforeDestroy) {
     warn(`\`beforeDestroy\` has been renamed to \`beforeUnmount\`.`)
   }
   if (beforeUnmount) {
     onBeforeUnmount(beforeUnmount.bind(publicThis))
   }
-  if (__DEV__ && destroyed) {
+  if (__DEV__ && !unmounted && destroyed) {
     warn(`\`destroyed\` has been renamed to \`unmounted\`.`)
   }
   if (unmounted) {


### PR DESCRIPTION
fix #3684 

Hi. I'm Daybrush. I am making a component that supports Vue2 and Vue3 at the same time.
I hope there are no warnings when using both beforeDestroy and beforeUnmount.