### PR TITLE
fix(rumtime-core): avoid normalize object slots if it has already been initialized

### DIFF
--- a/packages/runtime-core/src/componentSlots.ts
+++ b/packages/runtime-core/src/componentSlots.ts
@@ -160,7 +160,7 @@ export const updateSlots = (
           delete slots._
         }
       }
-    } else {
+    } else if (!(children as any)[InternalObjectKey]) {
       needDeletionCheck = !(children as RawSlots).$stable
       normalizeObjectSlots(children as RawSlots, slots)
     }


### PR DESCRIPTION
fix #3695