### PR TITLE
feat(sfc): add defineEmits and deprecate defineEmit

### DIFF
--- a/packages/compiler-sfc/__tests__/__snapshots__/compileScript.spec.ts.snap
+++ b/packages/compiler-sfc/__tests__/__snapshots__/compileScript.spec.ts.snap
@@ -54,7 +54,7 @@ return { a }
 }"
 `;
 
-exports[`SFC compile <script setup> defineEmit() 1`] = `
+exports[`SFC compile <script setup> defineEmits() 1`] = `
 "export default {
   expose: [],
   emits: ['foo', 'bar'],
@@ -711,7 +711,7 @@ return { a, b, c, d, x }
 }"
 `;
 
-exports[`SFC compile <script setup> with TypeScript defineEmit w/ type (type literal w/ call signatures) 1`] = `
+exports[`SFC compile <script setup> with TypeScript defineEmits w/ type (type literal w/ call signatures) 1`] = `
 "import { defineComponent as _defineComponent } from 'vue'
 
       
@@ -732,7 +732,7 @@ return { emit }
 })"
 `;
 
-exports[`SFC compile <script setup> with TypeScript defineEmit w/ type 1`] = `
+exports[`SFC compile <script setup> with TypeScript defineEmits w/ type 1`] = `
 "import { defineComponent as _defineComponent } from 'vue'
 
       

--- a/packages/runtime-core/__tests__/apiSetupHelpers.spec.ts
+++ b/packages/runtime-core/__tests__/apiSetupHelpers.spec.ts
@@ -5,15 +5,15 @@ import {
   render,
   SetupContext
 } from '@vue/runtime-test'
-import { defineEmit, defineProps, useContext } from '../src/apiSetupHelpers'
+import { defineEmits, defineProps, useContext } from '../src/apiSetupHelpers'
 
 describe('SFC <script setup> helpers', () => {
   test('should warn runtime usage', () => {
     defineProps()
     expect(`defineProps() is a compiler-hint`).toHaveBeenWarned()
 
-    defineEmit()
-    expect(`defineEmit() is a compiler-hint`).toHaveBeenWarned()
+    defineEmits()
+    expect(`defineEmits() is a compiler-hint`).toHaveBeenWarned()
   })
 
   test('useContext (no args)', () => {

--- a/packages/runtime-core/src/apiSetupHelpers.ts
+++ b/packages/runtime-core/src/apiSetupHelpers.ts
@@ -38,23 +38,28 @@ export function defineProps() {
   return null as any
 }
 
-export function defineEmit<
+export function defineEmits<
   TypeEmit = undefined,
   E extends EmitsOptions = EmitsOptions,
   EE extends string = string,
   InferredEmit = EmitFn<E>
 >(emitOptions?: E | EE[]): TypeEmit extends undefined ? InferredEmit : TypeEmit
 // implementation
-export function defineEmit() {
+export function defineEmits() {
   if (__DEV__) {
     warn(
-      `defineEmit() is a compiler-hint helper that is only usable inside ` +
+      `defineEmits() is a compiler-hint helper that is only usable inside ` +
         `<script setup> of a single file component. Its arguments should be ` +
         `compiled away and passing it at runtime has no effect.`
     )
   }
   return null as any
 }
+
+/**
+ * @deprecated use `defineEmits` instead.
+ */
+export const defineEmit = defineEmits
 
 export function useContext(): SetupContext {
   const i = getCurrentInstance()!

--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -43,7 +43,12 @@ export { provide, inject } from './apiInject'
 export { nextTick } from './scheduler'
 export { defineComponent } from './apiDefineComponent'
 export { defineAsyncComponent } from './apiAsyncComponent'
-export { defineProps, defineEmit, useContext } from './apiSetupHelpers'
+export {
+  defineProps,
+  defineEmits,
+  defineEmit,
+  useContext
+} from './apiSetupHelpers'
 
 // Advanced API ----------------------------------------------------------------
 

--- a/packages/sfc-playground/src/codemirror/CodeMirror.vue
+++ b/packages/sfc-playground/src/codemirror/CodeMirror.vue
@@ -3,7 +3,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, defineProps, defineEmit, watchEffect } from 'vue'
+import { ref, onMounted, defineProps, defineEmits, watchEffect } from 'vue'
 import { debounce } from '../utils'
 import CodeMirror from './codemirror'
 
@@ -24,7 +24,7 @@ const props = defineProps({
   }
 })
 
-const emit = defineEmit<(e: 'change', value: string) => void>()
+const emit = defineEmits<(e: 'change', value: string) => void>()
 
 onMounted(() => {
   const addonOptions = {

--- a/test-dts/setupHelpers.test-d.ts
+++ b/test-dts/setupHelpers.test-d.ts
@@ -2,6 +2,7 @@ import {
   expectType,
   defineProps,
   defineEmit,
+  defineEmits,
   useContext,
   Slots,
   describe
@@ -49,8 +50,8 @@ describe('defineProps w/ runtime declaration', () => {
   props2.baz
 })
 
-describe('defineEmit w/ type declaration', () => {
-  const emit = defineEmit<(e: 'change') => void>()
+describe('defineEmits w/ type declaration', () => {
+  const emit = defineEmits<(e: 'change') => void>()
   emit('change')
   // @ts-expect-error
   emit()
@@ -58,7 +59,7 @@ describe('defineEmit w/ type declaration', () => {
   emit('bar')
 
   type Emits = { (e: 'foo' | 'bar'): void; (e: 'baz', id: number): void }
-  const emit2 = defineEmit<Emits>()
+  const emit2 = defineEmits<Emits>()
 
   emit2('foo')
   emit2('bar')
@@ -67,8 +68,8 @@ describe('defineEmit w/ type declaration', () => {
   emit2('baz')
 })
 
-describe('defineEmit w/ runtime declaration', () => {
-  const emit = defineEmit({
+describe('defineEmits w/ runtime declaration', () => {
+  const emit = defineEmits({
     foo: () => {},
     bar: null
   })
@@ -77,11 +78,22 @@ describe('defineEmit w/ runtime declaration', () => {
   // @ts-expect-error
   emit('baz')
 
-  const emit2 = defineEmit(['foo', 'bar'])
+  const emit2 = defineEmits(['foo', 'bar'])
   emit2('foo')
   emit2('bar', 123)
   // @ts-expect-error
   emit2('baz')
+})
+
+describe('deprecated defineEmit', () => {
+  const emit = defineEmit({
+    foo: () => {},
+    bar: null
+  })
+  emit('foo')
+  emit('bar', 123)
+  // @ts-expect-error
+  emit('baz')
 })
 
 describe('useContext', () => {


### PR DESCRIPTION
Based on https://github.com/vuejs/rfcs/pull/243 and the 3 other repeated PRs. I'm proposing to deprecate `defineEmit` in favour of `defineEmits` as defined in the RFC and to match the `emits` option as well as the plural of `defineProps`

Even though the we are defining the `emit` type of the context option in `setup(props, { emit })`, it seems more idiomatic to make it plural to match `defineProps`