### PR TITLE
fix(compat): correctly merge lifecycle hooks when using Vue.extend (fix #3761)

### DIFF
--- a/packages/runtime-core/src/compat/globalConfig.ts
+++ b/packages/runtime-core/src/compat/globalConfig.ts
@@ -1,4 +1,4 @@
-import { extend, isArray } from '@vue/shared'
+import { extend, toArray } from '@vue/shared'
 import { AppConfig } from '../apiCreateApp'
 import { mergeDataOption } from './data'
 import {
@@ -117,7 +117,7 @@ function mergeHook(
   to: Function[] | Function | undefined,
   from: Function | Function[]
 ) {
-  return Array.from(new Set([...(isArray(to) ? to : to ? [to] : []), from]))
+  return Array.from(new Set([...toArray(to), ...toArray(from)]))
 }
 
 function mergeObjectOptions(to: Object | undefined, from: Object | undefined) {

--- a/packages/runtime-core/src/compat/globalConfig.ts
+++ b/packages/runtime-core/src/compat/globalConfig.ts
@@ -1,4 +1,4 @@
-import { extend, toArray } from '@vue/shared'
+import { extend, isArray } from '@vue/shared'
 import { AppConfig } from '../apiCreateApp'
 import { mergeDataOption } from './data'
 import {
@@ -111,6 +111,10 @@ export const legacyOptionMergeStrats = {
   // since we are only exposing these for compat and nobody should be relying
   // on the watch-specific behavior, just expose the object merge strat.
   watch: mergeObjectOptions
+}
+
+function toArray(target: any) {
+  return isArray(target) ? target : target ? [target] : []
 }
 
 function mergeHook(

--- a/packages/runtime-core/src/componentOptions.ts
+++ b/packages/runtime-core/src/componentOptions.ts
@@ -767,55 +767,44 @@ export function applyOptions(
       globalMixins
     )
   }
-  if (beforeMount) {
-    runLifecycleHook(onBeforeMount, beforeMount, publicThis)
+
+  function registerLifecycleHook(
+    register: Function,
+    hook?: Function | Function[]
+  ) {
+    // Array lifecycle hooks are only present in the compat build
+    if (__COMPAT__ && isArray(hook)) {
+      hook.forEach(_hook => register(_hook.bind(publicThis)))
+    } else if (hook) {
+      register((hook as Function).bind(publicThis))
+    }
   }
-  if (mounted) {
-    runLifecycleHook(onMounted, mounted, publicThis)
-  }
-  if (beforeUpdate) {
-    runLifecycleHook(onBeforeUpdate, beforeUpdate, publicThis)
-  }
-  if (updated) {
-    runLifecycleHook(onUpdated, updated, publicThis)
-  }
-  if (activated) {
-    runLifecycleHook(onActivated, activated, publicThis)
-  }
-  if (deactivated) {
-    runLifecycleHook(onDeactivated, deactivated, publicThis)
-  }
-  if (errorCaptured) {
-    runLifecycleHook(onErrorCaptured, errorCaptured, publicThis)
-  }
-  if (renderTracked) {
-    runLifecycleHook(onRenderTracked, renderTracked, publicThis)
-  }
-  if (renderTriggered) {
-    runLifecycleHook(onRenderTriggered, renderTriggered, publicThis)
-  }
-  if (beforeUnmount) {
-    runLifecycleHook(onBeforeUnmount, beforeUnmount, publicThis)
-  }
-  if (unmounted) {
-    runLifecycleHook(onUnmounted, unmounted, publicThis)
-  }
-  if (serverPrefetch) {
-    runLifecycleHook(onServerPrefetch, serverPrefetch, publicThis)
-  }
+
+  registerLifecycleHook(onBeforeMount, beforeMount)
+  registerLifecycleHook(onMounted, mounted)
+  registerLifecycleHook(onBeforeUpdate, beforeUpdate)
+  registerLifecycleHook(onUpdated, updated)
+  registerLifecycleHook(onActivated, activated)
+  registerLifecycleHook(onDeactivated, deactivated)
+  registerLifecycleHook(onErrorCaptured, errorCaptured)
+  registerLifecycleHook(onRenderTracked, renderTracked)
+  registerLifecycleHook(onRenderTriggered, renderTriggered)
+  registerLifecycleHook(onBeforeUnmount, beforeUnmount)
+  registerLifecycleHook(onUnmounted, unmounted)
+  registerLifecycleHook(onServerPrefetch, serverPrefetch)
 
   if (__COMPAT__) {
     if (
       beforeDestroy &&
       softAssertCompatEnabled(DeprecationTypes.OPTIONS_BEFORE_DESTROY, instance)
     ) {
-      runLifecycleHook(onBeforeUnmount, beforeDestroy, publicThis)
+      registerLifecycleHook(onBeforeUnmount, beforeDestroy)
     }
     if (
       destroyed &&
       softAssertCompatEnabled(DeprecationTypes.OPTIONS_DESTROYED, instance)
     ) {
-      runLifecycleHook(onUnmounted, destroyed, publicThis)
+      registerLifecycleHook(onUnmounted, destroyed)
     }
   }
 
@@ -833,12 +822,6 @@ export function applyOptions(
       warn(`The \`expose\` option is ignored when used in mixins.`)
     }
   }
-}
-
-function runLifecycleHook(handler: Function, hook: Function | Function[], context: ComponentPublicInstance) {
-  // Array lifecycle hooks are only present in the compat build
-  if (__COMPAT__ && isArray(hook)) hook.forEach(_hook => handler(_hook.bind(context)))
-  else handler((hook as Function).bind(context))
 }
 
 function resolveInstanceAssets(

--- a/packages/runtime-core/src/componentOptions.ts
+++ b/packages/runtime-core/src/componentOptions.ts
@@ -768,40 +768,40 @@ export function applyOptions(
     )
   }
   if (beforeMount) {
-    onBeforeMount(beforeMount.bind(publicThis))
+    runLifecycleHook(onBeforeMount, beforeMount, publicThis)
   }
   if (mounted) {
-    onMounted(mounted.bind(publicThis))
+    runLifecycleHook(onMounted, mounted, publicThis)
   }
   if (beforeUpdate) {
-    onBeforeUpdate(beforeUpdate.bind(publicThis))
+    runLifecycleHook(onBeforeUpdate, beforeUpdate, publicThis)
   }
   if (updated) {
-    onUpdated(updated.bind(publicThis))
+    runLifecycleHook(onUpdated, updated, publicThis)
   }
   if (activated) {
-    onActivated(activated.bind(publicThis))
+    runLifecycleHook(onActivated, activated, publicThis)
   }
   if (deactivated) {
-    onDeactivated(deactivated.bind(publicThis))
+    runLifecycleHook(onDeactivated, deactivated, publicThis)
   }
   if (errorCaptured) {
-    onErrorCaptured(errorCaptured.bind(publicThis))
+    runLifecycleHook(onErrorCaptured, errorCaptured, publicThis)
   }
   if (renderTracked) {
-    onRenderTracked(renderTracked.bind(publicThis))
+    runLifecycleHook(onRenderTracked, renderTracked, publicThis)
   }
   if (renderTriggered) {
-    onRenderTriggered(renderTriggered.bind(publicThis))
+    runLifecycleHook(onRenderTriggered, renderTriggered, publicThis)
   }
   if (beforeUnmount) {
-    onBeforeUnmount(beforeUnmount.bind(publicThis))
+    runLifecycleHook(onBeforeUnmount, beforeUnmount, publicThis)
   }
   if (unmounted) {
-    onUnmounted(unmounted.bind(publicThis))
+    runLifecycleHook(onUnmounted, unmounted, publicThis)
   }
   if (serverPrefetch) {
-    onServerPrefetch(serverPrefetch.bind(publicThis))
+    runLifecycleHook(onServerPrefetch, serverPrefetch, publicThis)
   }
 
   if (__COMPAT__) {
@@ -809,13 +809,13 @@ export function applyOptions(
       beforeDestroy &&
       softAssertCompatEnabled(DeprecationTypes.OPTIONS_BEFORE_DESTROY, instance)
     ) {
-      onBeforeUnmount(beforeDestroy.bind(publicThis))
+      runLifecycleHook(onBeforeUnmount, beforeDestroy, publicThis)
     }
     if (
       destroyed &&
       softAssertCompatEnabled(DeprecationTypes.OPTIONS_DESTROYED, instance)
     ) {
-      onUnmounted(destroyed.bind(publicThis))
+      runLifecycleHook(onUnmounted, destroyed, publicThis)
     }
   }
 
@@ -833,6 +833,12 @@ export function applyOptions(
       warn(`The \`expose\` option is ignored when used in mixins.`)
     }
   }
+}
+
+function runLifecycleHook(handler: Function, hook: Function | Function[], context: ComponentPublicInstance) {
+  // Array lifecycle hooks are only present in the compat build
+  if (__COMPAT__ && isArray(hook)) hook.forEach(_hook => handler(_hook.bind(context)))
+  else handler((hook as Function).bind(context))
 }
 
 function resolveInstanceAssets(

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -180,3 +180,7 @@ export const getGlobalThis = (): any => {
               : {})
   )
 }
+
+export const toArray = (target: any) => {
+  return isArray(target) ? target : target ? [target] : []
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -180,7 +180,3 @@ export const getGlobalThis = (): any => {
               : {})
   )
 }
-
-export const toArray = (target: any) => {
-  return isArray(target) ? target : target ? [target] : []
-}

--- a/packages/vue-compat/__tests__/global.spec.ts
+++ b/packages/vue-compat/__tests__/global.spec.ts
@@ -145,22 +145,31 @@ describe('GLOBAL_EXTEND', () => {
   })
 
   it('should not merge nested mixins created with Vue.extend', () => {
+    const a = jest.fn();
+    const b = jest.fn();
+    const c = jest.fn();
+    const d = jest.fn();
     const A = Vue.extend({
-      created: () => {}
+      created: a
     })
     const B = Vue.extend({
       mixins: [A],
-      created: () => {}
+      created: b
     })
     const C = Vue.extend({
       extends: B,
-      created: () => {}
+      created: c
     })
     const D = Vue.extend({
       mixins: [C],
-      created: () => {}
+      created: d,
+      render() { return null },
     })
-    expect(D.options.created!.length).toBe(4)
+    new D().$mount()
+    expect(a.mock.calls.length).toStrictEqual(1)
+    expect(b.mock.calls.length).toStrictEqual(1)
+    expect(c.mock.calls.length).toStrictEqual(1)
+    expect(d.mock.calls.length).toStrictEqual(1)
   })
 
   it('should merge methods', () => {

--- a/packages/vue-compat/__tests__/options.spec.ts
+++ b/packages/vue-compat/__tests__/options.spec.ts
@@ -10,7 +10,8 @@ beforeEach(() => {
   toggleDeprecationWarning(true)
   Vue.configureCompat({
     MODE: 2,
-    GLOBAL_MOUNT: 'suppress-warning'
+    GLOBAL_MOUNT: 'suppress-warning',
+    GLOBAL_EXTEND: 'suppress-warning'
   })
 })
 
@@ -68,6 +69,38 @@ test('beforeDestroy/destroyed', async () => {
     beforeDestroy,
     destroyed
   }
+
+  const vm = new Vue({
+    template: `<child v-if="ok"/>`,
+    data() {
+      return { ok: true }
+    },
+    components: { child }
+  }).$mount() as any
+
+  vm.ok = false
+  await nextTick()
+  expect(beforeDestroy).toHaveBeenCalled()
+  expect(destroyed).toHaveBeenCalled()
+
+  expect(
+    deprecationData[DeprecationTypes.OPTIONS_BEFORE_DESTROY].message
+  ).toHaveBeenWarned()
+
+  expect(
+    deprecationData[DeprecationTypes.OPTIONS_DESTROYED].message
+  ).toHaveBeenWarned()
+})
+
+test('beforeDestroy/destroyed in Vue.extend components', async () => {
+  const beforeDestroy = jest.fn()
+  const destroyed = jest.fn()
+
+  const child = Vue.extend({
+    template: `foo`,
+    beforeDestroy,
+    destroyed
+  })
 
   const vm = new Vue({
     template: `<child v-if="ok"/>`,


### PR DESCRIPTION
Note: this fix does introduce some performance overhead to the hot-path, I've tried to negate it with a `__VUE_COMPAT__` check in `runLifecycleHook`.

Closes #3761 