### PR TITLE
fix(types): h support for resolveComponent and slot

### DIFF
--- a/packages/runtime-core/src/h.ts
+++ b/packages/runtime-core/src/h.ts
@@ -132,12 +132,12 @@ export function h(type: Component, children?: RawChildren): VNode
 // concrete component
 export function h<P>(
   type: ConcreteComponent | string,
-  children?: RawChildren
+  children?: RawChildren | RawSlots
 ): VNode
 export function h<P>(
   type: ConcreteComponent<P> | string,
   props?: (RawProps & P) | ({} extends P ? null : never),
-  children?: RawChildren
+  children?: RawChildren | RawSlots
 ): VNode
 
 // component without props

--- a/test-dts/h.test-d.ts
+++ b/test-dts/h.test-d.ts
@@ -223,7 +223,9 @@ describe('Boolean prop implicit false', () => {
 
 // #2357
 describe('resolveComponent should work', () => {
-  h(resolveComponent('test'), {})
+  h(resolveComponent('test'))
+  h(resolveComponent('test'))
+  h(resolveComponent('test'), null, {})
   h(resolveComponent('test'), null, { default: () => {} })
   h(resolveComponent('test'), {
     message: '1'

--- a/test-dts/h.test-d.ts
+++ b/test-dts/h.test-d.ts
@@ -16,19 +16,14 @@ describe('h inference w/ element', () => {
   // key
   h('div', { key: 1 })
   h('div', { key: 'foo' })
-  //  @ts-expect-error
   expectError(h('div', { key: [] }))
-  //  @ts-expect-error
   expectError(h('div', { key: {} }))
   // ref
   h('div', { ref: 'foo' })
   h('div', { ref: ref(null) })
   h('div', { ref: _el => {} })
-  //  @ts-expect-error
   expectError(h('div', { ref: [] }))
-  //  @ts-expect-error
   expectError(h('div', { ref: {} }))
-  //  @ts-expect-error
   expectError(h('div', { ref: 123 }))
   // slots
   const slots = { default: () => {} } // RawSlots
@@ -229,7 +224,7 @@ describe('Boolean prop implicit false', () => {
 // #2357
 describe('resolveComponent should work', () => {
   h(resolveComponent('test'), {})
-  h(resolveComponent('test'), null, {})
+  h(resolveComponent('test'), null, { default: () => {} })
   h(resolveComponent('test'), {
     message: '1'
   })

--- a/test-dts/h.test-d.ts
+++ b/test-dts/h.test-d.ts
@@ -228,7 +228,8 @@ describe('Boolean prop implicit false', () => {
 
 // #2357
 describe('resolveComponent should work', () => {
-  h(resolveComponent('test'))
+  h(resolveComponent('test'), {})
+  h(resolveComponent('test'), null, {})
   h(resolveComponent('test'), {
     message: '1'
   })


### PR DESCRIPTION
https://v3.vuejs.org/guide/render-function.html#slots

this code in the document got no overload matches.

```javascript
render() {
  // `<div><child v-slot="props"><span>{{ props.text }}</span></child></div>`
  return h('div', [
    h(
      resolveComponent('child'),
      null,
      // pass `slots` as the children object
      // in the form of { name: props => VNode | Array<VNode> }
      {
        default: (props) => h('span', props.text)
      }
    )
  ])
}
```