### PR TITLE
fix(runtime-core): treat slots manually written by the user as dynamic

### DIFF
--- a/packages/runtime-core/src/vnode.ts
+++ b/packages/runtime-core/src/vnode.ts
@@ -648,10 +648,14 @@ export function normalizeChildren(vnode: VNode, children: unknown) {
         // (compiled / normalized slots already have context)
         ;(children as RawSlots)._ctx = currentRenderingInstance
       } else if (slotFlag === SlotFlags.FORWARDED && currentRenderingInstance) {
+        const parentVNode = currentRenderingInstance.vnode
         // a child component receives forwarded slots from the parent.
         // its slot type is determined by its parent's slot type.
         if (
-          currentRenderingInstance.vnode.patchFlag & PatchFlags.DYNAMIC_SLOTS
+          // non-compiled slot, treat slots manually written by the user as dynamic
+          (parentVNode.children &&
+            !('_' in (parentVNode.children as RawSlots))) ||
+          parentVNode.patchFlag & PatchFlags.DYNAMIC_SLOTS
         ) {
           ;(children as RawSlots)._ = SlotFlags.DYNAMIC
           vnode.patchFlag |= PatchFlags.DYNAMIC_SLOTS

--- a/packages/runtime-core/src/vnode.ts
+++ b/packages/runtime-core/src/vnode.ts
@@ -648,19 +648,15 @@ export function normalizeChildren(vnode: VNode, children: unknown) {
         // (compiled / normalized slots already have context)
         ;(children as RawSlots)._ctx = currentRenderingInstance
       } else if (slotFlag === SlotFlags.FORWARDED && currentRenderingInstance) {
-        const parentVNode = currentRenderingInstance.vnode
         // a child component receives forwarded slots from the parent.
         // its slot type is determined by its parent's slot type.
         if (
-          // non-compiled slot, treat slots manually written by the user as dynamic
-          (parentVNode.children &&
-            !('_' in (parentVNode.children as RawSlots))) ||
-          parentVNode.patchFlag & PatchFlags.DYNAMIC_SLOTS
+          (currentRenderingInstance.slots as RawSlots)._ === SlotFlags.STABLE
         ) {
+          ;(children as RawSlots)._ = SlotFlags.STABLE
+        } else {
           ;(children as RawSlots)._ = SlotFlags.DYNAMIC
           vnode.patchFlag |= PatchFlags.DYNAMIC_SLOTS
-        } else {
-          ;(children as RawSlots)._ = SlotFlags.STABLE
         }
       }
     }


### PR DESCRIPTION
Fix: #3779 