### PR TITLE
types(props): Support `undefined` as default

### DIFF
--- a/packages/runtime-core/src/componentProps.ts
+++ b/packages/runtime-core/src/componentProps.ts
@@ -76,7 +76,7 @@ type RequiredKeys<T> = {
     // don't mark Boolean props as undefined
     | BooleanConstructor
     | { type: BooleanConstructor }
-    ? K
+    ? T[K] extends { default: undefined | (() => undefined) } ? never : K
     : never
 }[keyof T]
 

--- a/test-dts/defineComponent.test-d.tsx
+++ b/test-dts/defineComponent.test-d.tsx
@@ -23,6 +23,8 @@ describe('with object props', () => {
     h: boolean
     bb: string
     bbb: string
+    bbbb: string | undefined
+    bbbbb: string | undefined
     cc?: string[] | undefined
     dd: { n: 1 }
     ee?: () => string
@@ -61,6 +63,14 @@ describe('with object props', () => {
         // Note: default function value requires arrow syntax + explicit
         // annotation
         default: (props: any) => (props.bb as string) || 'foo'
+      },
+      bbbb: {
+        type: String,
+        default: undefined
+      },
+      bbbbb: {
+        type: String,
+        default: () => undefined
       },
       // explicit type casting
       cc: Array as PropType<string[]>,
@@ -129,6 +139,8 @@ describe('with object props', () => {
       expectType<ExpectedProps['h']>(props.h)
       expectType<ExpectedProps['bb']>(props.bb)
       expectType<ExpectedProps['bbb']>(props.bbb)
+      expectType<ExpectedProps['bbbb']>(props.bbbb)
+      expectType<ExpectedProps['bbbbb']>(props.bbbbb)
       expectType<ExpectedProps['cc']>(props.cc)
       expectType<ExpectedProps['dd']>(props.dd)
       expectType<ExpectedProps['ee']>(props.ee)


### PR DESCRIPTION
fix #3782

Allows `default:undefined` on prop types