### PR TITLE
perf(core) improve queueJob by remove unnecessary statement

### DIFF
--- a/packages/runtime-core/src/scheduler.ts
+++ b/packages/runtime-core/src/scheduler.ts
@@ -68,9 +68,9 @@ function findInsertionIndex(job: SchedulerJob) {
   // the start index should be `flushIndex + 1`
   let start = flushIndex + 1
   let end = queue.length
-  const jobId = getId(job)
-
+  
   while (start < end) {
+    const jobId = getId(job)
     const middle = (start + end) >>> 1
     const middleJobId = getId(queue[middle])
     middleJobId < jobId ? (start = middle + 1) : (end = middle)
@@ -94,12 +94,7 @@ export function queueJob(job: SchedulerJob) {
       )) &&
     job !== currentPreFlushParentJob
   ) {
-    const pos = findInsertionIndex(job)
-    if (pos > -1) {
-      queue.splice(pos, 0, job)
-    } else {
-      queue.push(job)
-    }
+    queue.splice(findInsertionIndex(job), 0, job)
     queueFlush()
   }
 }


### PR DESCRIPTION
the findInsertionIndex function always return a number >= 1, so we don't need compare it to -1.and in the findInsertionIndex function we don't need get the job's id when the loop's condition is not satisfied.