### PR TITLE
chore(shared): remove extra NaN logic

### DIFF
--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -143,7 +143,7 @@ export const toHandlerKey = cacheStringFunction(
 
 // compare whether a value has changed, accounting for NaN.
 export const hasChanged = (value: any, oldValue: any): boolean =>
-  Object.is(value, oldValue)
+  !Object.is(value, oldValue)
 
 export const invokeArrayFns = (fns: Function[], arg?: any) => {
   for (let i = 0; i < fns.length; i++) {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -143,7 +143,7 @@ export const toHandlerKey = cacheStringFunction(
 
 // compare whether a value has changed, accounting for NaN.
 export const hasChanged = (value: any, oldValue: any): boolean =>
-  value !== oldValue && value === value
+  Object.is(value, oldValue)
 
 export const invokeArrayFns = (fns: Function[], arg?: any) => {
   for (let i = 0; i < fns.length; i++) {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -143,7 +143,7 @@ export const toHandlerKey = cacheStringFunction(
 
 // compare whether a value has changed, accounting for NaN.
 export const hasChanged = (value: any, oldValue: any): boolean =>
-  value !== oldValue && (value === value || oldValue === oldValue)
+  value !== oldValue && value === value
 
 export const invokeArrayFns = (fns: Function[], arg?: any) => {
   for (let i = 0; i < fns.length; i++) {


### PR DESCRIPTION
since `x !== x`  is the only true when x is `NaN` , so that indicate the `oldValue` and the `value` are both `NaN`
so remain one is fine