### PR TITLE
fix(compat): return merged data from `mergedDataFn`

### DIFF
--- a/packages/runtime-core/src/compat/data.ts
+++ b/packages/runtime-core/src/compat/data.ts
@@ -29,10 +29,13 @@ export function mergeDataOption(to: any, from: any) {
     return from
   }
   return function mergedDataFn(this: ComponentPublicInstance) {
-    return deepMergeData(
-      isFunction(to) ? to.call(this, this) : to,
-      isFunction(from) ? from.call(this, this) : from,
-      this.$
-    )
+    if (isFunction(to)) {
+      to = to.call(this, this)
+    }
+    if (isFunction(from)) {
+      from = from.call(this, this)
+    }
+    deepMergeData(to, from, this.$)
+    return to
   }
 }


### PR DESCRIPTION
You forgot to return `to`. Data was always undefined if using mixins.