### PR TITLE
test(runtime-core): modify unit test case that do not describe correctly

### DIFF
--- a/packages/runtime-core/__tests__/rendererComponent.spec.ts
+++ b/packages/runtime-core/__tests__/rendererComponent.spec.ts
@@ -68,7 +68,7 @@ describe('renderer: component', () => {
     expect(serializeInner(root)).toBe(`<div id="foo" class="bar">test</div>`)
   })
 
-  it('should update an Component tag which is already mounted', () => {
+  it('should mount again an Component tag which is already mounted', () => {
     const Comp1 = {
       render: () => {
         return h('div', 'foo')


### PR DESCRIPTION
This case will mount again when Comp1 becomes Comp2, because n1 and n2 are not the same VNode when patch function compares these tow VNode.

I think that unit test case description is misleading.