### PR TITLE
test(reactivity): fix unit test case that don't make sense

### DIFF
--- a/packages/reactivity/__tests__/reactive.spec.ts
+++ b/packages/reactivity/__tests__/reactive.spec.ts
@@ -18,18 +18,12 @@ describe('reactivity/reactive', () => {
     expect(Object.keys(observed)).toEqual(['foo'])
   })
 
-  test('proto', () => {
-    const obj = {}
+  test('should not reactive __proto__', () => {
+    const obj = Object.create(null)
     const reactiveObj = reactive(obj)
     expect(isReactive(reactiveObj)).toBe(true)
-    // read prop of reactiveObject will cause reactiveObj[prop] to be reactive
-    // @ts-ignore
     const prototype = reactiveObj['__proto__']
-    const otherObj = { data: ['a'] }
-    expect(isReactive(otherObj)).toBe(false)
-    const reactiveOther = reactive(otherObj)
-    expect(isReactive(reactiveOther)).toBe(true)
-    expect(reactiveOther.data[0]).toBe('a')
+    expect(isReactive(prototype)).toBe(false)
   })
 
   test('nested reactives', () => {

--- a/packages/reactivity/__tests__/reactive.spec.ts
+++ b/packages/reactivity/__tests__/reactive.spec.ts
@@ -19,7 +19,7 @@ describe('reactivity/reactive', () => {
   })
 
   test('should not reactive __proto__', () => {
-    const obj = Object.create(null)
+    const obj = Object.create({})
     const reactiveObj = reactive(obj)
     expect(isReactive(reactiveObj)).toBe(true)
     const prototype = reactiveObj['__proto__']


### PR DESCRIPTION
This `proto` case declares the prototype variable but is never used. And the otherObj variable has nothing to do with this use case.

`__proto__` is one of the non trackable keys, so it should return original.

I use `Object.create({})` instead `{}` that can fix ts error and remove `@ts-ignore`.