### PR TITLE
feat: add exclude option in build script.

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   ],
   "scripts": {
     "dev": "node scripts/dev.js",
-    "build": "node scripts/build.js",
+    "build": "node scripts/build.js --e=playground",
     "size": "node scripts/build.js vue runtime-dom size-check -p -f global",
     "lint": "eslint --ext .ts packages/*/src/**",
     "format": "prettier --write --parser typescript \"packages/**/*.ts?(x)\"",

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -12,6 +12,22 @@ const targets = (exports.targets = fs.readdirSync('packages').filter(f => {
   return true
 }))
 
+exports.fuzzyExcludeTarget = buildExcludeTargets => {
+  buildExcludeTargets = Array.isArray(buildExcludeTargets)
+    ? buildExcludeTargets
+    : [buildExcludeTargets]
+  const filtered = []
+  buildExcludeTargets.forEach(partialTarget => {
+    for (const target of targets) {
+      if (!target.match(partialTarget)) {
+        filtered.push(target)
+      }
+    }
+  })
+
+  return filtered
+}
+
 exports.fuzzyMatchTarget = (partialTargets, includeAllMatching) => {
   const matched = []
   partialTargets.forEach(partialTarget => {


### PR DESCRIPTION
1. add `exclude` or `e` options in build script
2. when exec `yarn build`, we will get an error:
```js
Error: Could not resolve entry module (packages/sfc-playground/src/index.ts)
```
so we should just use `npm run build-sfc-playground` to build playground, and exclude it in` npm run build` script.
is there anything i missed?