### PR TITLE
feat(ref): all refs are now an async iterable

### DIFF
--- a/packages/reactivity/__tests__/ref.spec.ts
+++ b/packages/reactivity/__tests__/ref.spec.ts
@@ -336,4 +336,37 @@ describe('reactivity/ref', () => {
     _trigger!()
     expect(dummy).toBe(2)
   })
+
+  test('ref as an async iterable', async () => {
+    let myRef = ref(0)
+
+    const results: any[] = []
+
+    const testFunc = async () => {
+      for await (const value of myRef) {
+        console.log
+        results.push(value)
+        if (value === 3) {
+          break
+        }
+      }
+      results.push('done')
+    }
+
+    const done = testFunc()
+
+    myRef.value++
+    await Promise.resolve()
+    myRef.value++
+    await Promise.resolve()
+    myRef.value++
+    await Promise.resolve()
+    myRef.value++
+    await Promise.resolve()
+    myRef.value++
+    await Promise.resolve()
+
+    await done
+    expect(results).toEqual([0, 1, 2, 3, 'done'])
+  })
 })


### PR DESCRIPTION
Refs can now be consumed with a `for-await` loop, or with other APIs, such as `rxjs@7` that accept `AsyncIterable`.

After some discussion with @yyx990803, here is a small PR to add async iterable support to instance of `RefImpl`.

If this lands, then any API that accepts an async iterator will "just work" with a `ref` instance. For example, in RxJS, anything that accepts an Observable could now just accept a `RefImpl` from Vue. Similarly, updates to a ref can be consumed with `for await` loops, or perhaps even `yield`-ed within an `AsyncGenerator` (`async function*`). So there's a lot of interesting potential here.

It might also help create opportunities to right interesting code, or maybe even coroutines at some point, within the library itself.

## Open Questions

One open question/concern I have, is this relies on `watch`. Since I don't understand the mechanics of `watch` yet, I assume it relies on some underlying global state that may or may not switch between given async contexts. So... if someone were to wait and create the iterable out-of-band with a `setup` or some other part of Vue's lifecycle, I'm not sure how they will behave.

Another concern I would have isn't necessarily about the feature, but more about `for-await` in general, and what we can add to this feature to keep people from shooting themselves in the foot. Since, in theory, a `ref` lasts for as long as someone has a handle to it, if someone uses `for await` to endlessly consume the ref, it's possible to end up with a single hung promise when a component unmounts. It may be prudent to add an `onUnmount` in the `RefAsyncIterable` initialization that flushes all pending promises when it's unmounted.


## Example usage:

```ts
const myRef = ref(0);

async function someHandler() {
   for await (const value of myRef) {
      // triggered each time `myRef.value` is updated.
      console.log(value);
   }
}


// Later this would trigger the for await loop.
myRef.value++;
```


Example of it "just working" with another library:

```ts
import { from } from 'rxjs';
import { ref } from 'vue';

const myRef = ref(0);

from(myRef).subscribe(console.log); // will log on each change to `myRef.value`;

// later
myRef.value++;
```