### PR TITLE
perf(core): improve vdom diffing by removing unnecessary conditional statement in getSequence function

### DIFF
--- a/packages/runtime-core/src/renderer.ts
+++ b/packages/runtime-core/src/renderer.ts
@@ -2462,7 +2462,7 @@ export function traverseStaticChildren(n1: VNode, n2: VNode, shallow = false) {
 // https://en.wikipedia.org/wiki/Longest_increasing_subsequence
 function getSequence(arr: number[]): number[] {
   const p = arr.slice()
-  const result = [0]
+  const result = []
   let i, j, u, v, c
   const len = arr.length
   for (i = 0; i < len; i++) {
@@ -2484,12 +2484,10 @@ function getSequence(arr: number[]): number[] {
           v = c
         }
       }
-      if (arrI < arr[result[u]]) {
-        if (u > 0) {
-          p[i] = result[u - 1]
-        }
-        result[u] = i
+      if (u > 0) {
+        p[i] = result[u - 1]
       }
+      result[u] = i
     }
   }
   u = result.length


### PR DESCRIPTION
Here is some simple explanation for this pr.
For the removal of conditional statement if (arrI < arr[result[u]]):
Before the while loop at line 2479, the arrI variable always less than the last item of the result array,
so after this loop, arrI always less than the result[v],
and after this loop, the v always equals to u,
so we don't need the arrI < arr[result[u]] statement.

For the result array init const result = []:
Actually, this change make the result variable different from original,but it don't effect the children patch result.
Original getSequence([0, 1, 8, 7, 9, 5]) will be[0, 1, 3, 4], now it's [1, 3, 4].