### PR TITLE
test: remove deprecated usage of `waitFor`

### DIFF
--- a/packages/vue/__tests__/Transition.spec.ts
+++ b/packages/vue/__tests__/Transition.spec.ts
@@ -29,7 +29,7 @@ describe('e2e: Transition', () => {
 
   beforeEach(async () => {
     await page().goto(baseUrl)
-    await page().waitFor('#app')
+    await page().waitForSelector('#app')
   })
 
   describe('transition with v-if', () => {

--- a/packages/vue/__tests__/TransitionGroup.spec.ts
+++ b/packages/vue/__tests__/TransitionGroup.spec.ts
@@ -21,7 +21,7 @@ describe('e2e: TransitionGroup', () => {
 
   beforeEach(async () => {
     await page().goto(baseUrl)
-    await page().waitFor('#app')
+    await page().waitForSelector('#app')
   })
 
   test(

--- a/packages/vue/examples/__tests__/commits.spec.ts
+++ b/packages/vue/examples/__tests__/commits.spec.ts
@@ -28,7 +28,7 @@ describe('e2e: commits', () => {
     })
 
     await page().goto(baseUrl)
-    await page().waitFor('li')
+    await page().waitForSelector('li')
     expect(await count('input')).toBe(2)
     expect(await count('label')).toBe(2)
     expect(await text('label[for="master"]')).toBe('master')

--- a/packages/vue/examples/__tests__/grid.spec.ts
+++ b/packages/vue/examples/__tests__/grid.spec.ts
@@ -28,7 +28,7 @@ describe('e2e: grid', () => {
     )}`
 
     await page().goto(baseUrl)
-    await page().waitFor('table')
+    await page().waitForSelector('table')
     expect(await count('th')).toBe(2)
     expect(await count('th.active')).toBe(0)
     expect(await text('th:nth-child(1)')).toContain('Name')

--- a/packages/vue/examples/__tests__/svg.spec.ts
+++ b/packages/vue/examples/__tests__/svg.spec.ts
@@ -77,7 +77,7 @@ describe('e2e: svg', () => {
     )}`
 
     await page().goto(baseUrl)
-    await page().waitFor('svg')
+    await page().waitForSelector('svg')
     expect(await count('g')).toBe(1)
     expect(await count('polygon')).toBe(1)
     expect(await count('circle')).toBe(1)


### PR DESCRIPTION
Hey, according to puppeteer/puppeteer#6214, `waitFor` is being deprecated and should be replaced with `waitForSelector`, `waitForFunction`, or other `waitForX`.

This PR replaces all `waitFor` with corresponding `waitForX`.