### PR TITLE
fix(runtime-core): fix the bug 'Mixins watchers not triggered when watching same property', see issue#3966

### DIFF
--- a/packages/runtime-core/__tests__/apiOptions.spec.ts
+++ b/packages/runtime-core/__tests__/apiOptions.spec.ts
@@ -9,7 +9,8 @@ import {
   renderToString,
   ref,
   defineComponent,
-  createApp
+  createApp,
+  TestText
 } from '@vue/runtime-test'
 
 describe('api: options', () => {
@@ -631,6 +632,57 @@ describe('api: options', () => {
       'mixinC mounted',
       'comp mounted'
     ])
+  })
+
+  test('trigger watch in mixins', async () => {
+    let ctx: any
+    const mixinA = defineComponent({
+      data() {
+        return {
+          fromMixinA: ''
+        }
+      },
+      watch: {
+        obj(to) {
+          this.fromMixinA = to
+        }
+      }
+    })
+    const mixinB = defineComponent({
+      data() {
+        return {
+          fromMixinB: ''
+        }
+      },
+      watch: {
+        obj(to) {
+          this.fromMixinB = to
+        }
+      }
+    })
+    const Comp = defineComponent({
+      mixins: [mixinA, mixinB],
+      data() {
+        return {
+          obj: '',
+          fromComp: ''
+        }
+      },
+      watch: {
+        obj(to) {
+          this.fromComp = to
+        }
+      },
+      render() {
+        ctx = this
+        return `${this.fromComp}${this.fromMixinA}${this.fromMixinB}`
+      }
+    })
+    const root = nodeOps.createElement('div')
+    render(h(Comp), root)
+    ctx.obj = '1'
+    await nextTick()
+    expect((root.children[0] as TestText).text).toBe('111')
   })
 
   test('render from mixin', () => {


### PR DESCRIPTION
In issue #3966, mixins watchers not triggered when watching same property. That's because mixins watchers are being overridden instead of merged together.

Though I see this comment in the source code:
```
// watch has special merge behavior in v2, but isn't actually needed in v3.
// since we are only exposing these for compat and nobody should be relying
// on the watch-specific behavior, just expose the object merge strat.
```
I still think maybe we need triggered all watch in mixins. So I open this PR.

Maybe we can discuss this behavior, and if we really don't need this feature, I will close this PR.

Close #3966