### PR TITLE
build: rely on engines to prevent using npm for dependency install

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict = true

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "dev-compiler": "npm-run-all --parallel \"dev template-explorer\" serve",
     "serve": "serve",
     "open": "open http://localhost:5000/packages/template-explorer/local.html",
-    "preinstall": "node ./scripts/checkYarn.js",
     "prebuild-sfc-playground": "node scripts/build.js compiler shared -af cjs && node scripts/build.js runtime reactivity shared -af esm-bundler && node scripts/build.js vue -f esm-bundler-runtime && node scripts/build.js vue -f esm-browser-runtime && node scripts/build.js compiler-sfc -f esm-browser",
     "build-sfc-playground": "cd packages/sfc-playground && vite build"
   },
@@ -40,7 +39,9 @@
     ]
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=10.0.0",
+    "yarn": ">= 1.0.0",
+    "npm": "This repository requires Yarn 1.x for scripts to work properly.\n"
   },
   "devDependencies": {
     "@babel/types": "^7.12.0",

--- a/scripts/checkYarn.js
+++ b/scripts/checkYarn.js
@@ -1,6 +1,0 @@
-if (!/yarn\.js$/.test(process.env.npm_execpath || '')) {
-  console.warn(
-    '\u001b[33mThis repository requires Yarn 1.x for scripts to work properly.\u001b[39m\n'
-  )
-  process.exit(1)
-}


### PR DESCRIPTION
Rather than relying on a preinstall script, set `engine-strict` to `true` in a project `.npmrc` file, relying on the `engines` having `npm` set to note that yarn should be used instead