### PR TITLE
perf(reactivity): improve reactive effect memory usage

### DIFF
--- a/packages/reactivity/__tests__/computed.spec.ts
+++ b/packages/reactivity/__tests__/computed.spec.ts
@@ -2,7 +2,6 @@ import {
   computed,
   reactive,
   effect,
-  stop,
   ref,
   WritableComputedRef,
   isReadonly
@@ -125,7 +124,7 @@ describe('reactivity/computed', () => {
     expect(dummy).toBe(undefined)
     value.foo = 1
     expect(dummy).toBe(1)
-    stop(cValue.effect)
+    cValue.effect.stop()
     value.foo = 2
     expect(dummy).toBe(1)
   })
@@ -196,7 +195,7 @@ describe('reactivity/computed', () => {
 
   it('should expose value when stopped', () => {
     const x = computed(() => 1)
-    stop(x.effect)
+    x.effect.stop()
     expect(x.value).toBe(1)
   })
 })

--- a/packages/reactivity/__tests__/effect.spec.ts
+++ b/packages/reactivity/__tests__/effect.spec.ts
@@ -590,12 +590,13 @@ describe('reactivity/effect', () => {
   })
 
   it('scheduler', () => {
-    let runner: any, dummy
-    const scheduler = jest.fn(_runner => {
-      runner = _runner
+    let dummy
+    let run: any
+    const scheduler = jest.fn(() => {
+      run = runner
     })
     const obj = reactive({ foo: 1 })
-    effect(
+    const runner = effect(
       () => {
         dummy = obj.foo
       },
@@ -609,7 +610,7 @@ describe('reactivity/effect', () => {
     // should not run yet
     expect(dummy).toBe(1)
     // manually run
-    runner()
+    run()
     // should have run
     expect(dummy).toBe(2)
   })

--- a/packages/reactivity/__tests__/effect.spec.ts
+++ b/packages/reactivity/__tests__/effect.spec.ts
@@ -490,12 +490,12 @@ describe('reactivity/effect', () => {
     expect(conditionalSpy).toHaveBeenCalledTimes(2)
   })
 
-  it('should not double wrap if the passed function is a effect', () => {
-    const runner = effect(() => {})
-    const otherRunner = effect(runner)
-    expect(runner).not.toBe(otherRunner)
-    expect(runner.raw).toBe(otherRunner.raw)
-  })
+  // it('should not double wrap if the passed function is a effect', () => {
+  //   const runner = effect(() => {})
+  //   const otherRunner = effect(runner)
+  //   expect(runner).not.toBe(otherRunner)
+  //   expect(runner.raw).toBe(otherRunner.raw)
+  // })
 
   it('should not run multiple times for a single mutation', () => {
     let dummy
@@ -633,19 +633,19 @@ describe('reactivity/effect', () => {
     expect(onTrack).toHaveBeenCalledTimes(3)
     expect(events).toEqual([
       {
-        effect: runner,
+        effect: runner.effect,
         target: toRaw(obj),
         type: TrackOpTypes.GET,
         key: 'foo'
       },
       {
-        effect: runner,
+        effect: runner.effect,
         target: toRaw(obj),
         type: TrackOpTypes.HAS,
         key: 'bar'
       },
       {
-        effect: runner,
+        effect: runner.effect,
         target: toRaw(obj),
         type: TrackOpTypes.ITERATE,
         key: ITERATE_KEY
@@ -671,7 +671,7 @@ describe('reactivity/effect', () => {
     expect(dummy).toBe(2)
     expect(onTrigger).toHaveBeenCalledTimes(1)
     expect(events[0]).toEqual({
-      effect: runner,
+      effect: runner.effect,
       target: toRaw(obj),
       type: TriggerOpTypes.SET,
       key: 'foo',
@@ -684,7 +684,7 @@ describe('reactivity/effect', () => {
     expect(dummy).toBeUndefined()
     expect(onTrigger).toHaveBeenCalledTimes(2)
     expect(events[1]).toEqual({
-      effect: runner,
+      effect: runner.effect,
       target: toRaw(obj),
       type: TriggerOpTypes.DELETE,
       key: 'foo',

--- a/packages/reactivity/__tests__/effect.spec.ts
+++ b/packages/reactivity/__tests__/effect.spec.ts
@@ -490,12 +490,12 @@ describe('reactivity/effect', () => {
     expect(conditionalSpy).toHaveBeenCalledTimes(2)
   })
 
-  // it('should not double wrap if the passed function is a effect', () => {
-  //   const runner = effect(() => {})
-  //   const otherRunner = effect(runner)
-  //   expect(runner).not.toBe(otherRunner)
-  //   expect(runner.raw).toBe(otherRunner.raw)
-  // })
+  it('should not double wrap if the passed function is a effect', () => {
+    const runner = effect(() => {})
+    const otherRunner = effect(runner)
+    expect(runner).not.toBe(otherRunner)
+    expect(runner.effect.fn).toBe(otherRunner.effect.fn)
+  })
 
   it('should not run multiple times for a single mutation', () => {
     let dummy

--- a/packages/reactivity/__tests__/readonly.spec.ts
+++ b/packages/reactivity/__tests__/readonly.spec.ts
@@ -382,7 +382,7 @@ describe('reactivity/readonly', () => {
     const eff = effect(() => {
       roArr.includes(2)
     })
-    expect(eff.deps.length).toBe(0)
+    expect(eff.effect.deps.length).toBe(0)
   })
 
   test('readonly should track and trigger if wrapping reactive original (collection)', () => {

--- a/packages/reactivity/src/effect.ts
+++ b/packages/reactivity/src/effect.ts
@@ -43,21 +43,7 @@ export class ReactiveEffect<T = any> {
   constructor(
     public fn: () => T,
     public scheduler: EffectScheduler | null = null,
-    /**
-     * Indicates whether the effect is allowed to recursively trigger itself
-     * when managed by the scheduler.
-     *
-     * By default, a job cannot trigger itself because some built-in method calls,
-     * e.g. Array.prototype.push actually performs reads as well (#1740) which
-     * can lead to confusing infinite loops.
-     * The allowed cases are component update functions and watch callbacks.
-     * Component update functions may update child component props, which in turn
-     * trigger flush: "pre" watch callbacks that mutates state that the parent
-     * relies on (#1801). Watch callbacks doesn't track its dependencies so if it
-     * triggers itself again, it's likely intentional and it is the user's
-     * responsibility to perform recursive state mutation that eventually
-     * stabilizes (#1727).
-     */
+    // allow recursive self-invocation
     public allowRecurse = false
   ) {}
 

--- a/packages/reactivity/src/effect.ts
+++ b/packages/reactivity/src/effect.ts
@@ -105,6 +105,10 @@ export function effect<T = any>(
   fn: () => T,
   options?: ReactiveEffectOptions
 ): ReactiveEffectRunner {
+  if ((fn as ReactiveEffectRunner).effect) {
+    fn = (fn as ReactiveEffectRunner).effect.fn
+  }
+
   const _effect = new ReactiveEffect(fn)
   if (options) {
     extend(_effect, options)

--- a/packages/reactivity/src/index.ts
+++ b/packages/reactivity/src/index.ts
@@ -46,7 +46,9 @@ export {
   resetTracking,
   ITERATE_KEY,
   ReactiveEffect,
+  ReactiveEffectRunner,
   ReactiveEffectOptions,
+  EffectScheduler,
   DebuggerEvent
 } from './effect'
 export { TrackOpTypes, TriggerOpTypes } from './operations'

--- a/packages/runtime-core/__tests__/scheduler.spec.ts
+++ b/packages/runtime-core/__tests__/scheduler.spec.ts
@@ -1,4 +1,3 @@
-import { effect, stop } from '@vue/reactivity'
 import {
   queueJob,
   nextTick,
@@ -576,20 +575,19 @@ describe('scheduler', () => {
 
     // simulate parent component that toggles child
     const job1 = () => {
-      stop(job2)
+      // @ts-ignore
+      job2.active = false
     }
-    job1.id = 0 // need the id to ensure job1 is sorted before job2
-
     // simulate child that's triggered by the same reactive change that
     // triggers its toggle
-    const job2 = effect(() => spy())
-    expect(spy).toHaveBeenCalledTimes(1)
+    const job2 = () => spy()
+    expect(spy).toHaveBeenCalledTimes(0)
 
     queueJob(job1)
     queueJob(job2)
     await nextTick()
 
-    // should not be called again
-    expect(spy).toHaveBeenCalledTimes(1)
+    // should not be called
+    expect(spy).toHaveBeenCalledTimes(0)
   })
 })

--- a/packages/runtime-core/src/compat/global.ts
+++ b/packages/runtime-core/src/compat/global.ts
@@ -1,7 +1,6 @@
 import {
   isReactive,
   reactive,
-  stop,
   track,
   TrackOpTypes,
   trigger,
@@ -575,7 +574,7 @@ function installCompatMount(
         // stop effects
         if (effects) {
           for (let i = 0; i < effects.length; i++) {
-            stop(effects[i])
+            effects[i].stop()
           }
         }
         // unmounted hook

--- a/packages/runtime-core/src/component.ts
+++ b/packages/runtime-core/src/component.ts
@@ -4,8 +4,7 @@ import {
   pauseTracking,
   resetTracking,
   shallowReadonly,
-  proxyRefs,
-  ReactiveEffectRunner
+  proxyRefs
 } from '@vue/reactivity'
 import {
   ComponentPublicInstance,
@@ -58,6 +57,7 @@ import { currentRenderingInstance } from './componentRenderContext'
 import { startMeasure, endMeasure } from './profiling'
 import { convertLegacyRenderFn } from './compat/renderFn'
 import { globalCompatConfig, validateCompatConfig } from './compat/compatConfig'
+import { SchedulerJob } from './scheduler'
 
 export type Data = Record<string, unknown>
 
@@ -216,9 +216,14 @@ export interface ComponentInternalInstance {
    */
   subTree: VNode
   /**
-   * Bound effect runner
+   * Main update effect
+   * @internal
    */
-  update: ReactiveEffectRunner
+  effect: ReactiveEffect
+  /**
+   * Bound effect runner to be passed to schedulers
+   */
+  update: SchedulerJob
   /**
    * The render function that returns vdom tree.
    * @internal
@@ -443,6 +448,7 @@ export function createComponentInstance(
     root: null!, // to be immediately set
     next: null,
     subTree: null!, // will be set synchronously right after creation
+    effect: null!, // will be set synchronously right after creation
     update: null!, // will be set synchronously right after creation
     render: null,
     proxy: null,

--- a/packages/runtime-core/src/component.ts
+++ b/packages/runtime-core/src/component.ts
@@ -4,7 +4,8 @@ import {
   pauseTracking,
   resetTracking,
   shallowReadonly,
-  proxyRefs
+  proxyRefs,
+  ReactiveEffectRunner
 } from '@vue/reactivity'
 import {
   ComponentPublicInstance,
@@ -215,9 +216,9 @@ export interface ComponentInternalInstance {
    */
   subTree: VNode
   /**
-   * The reactive effect for rendering and patching the component. Callable.
+   * Bound effect runner
    */
-  update: ReactiveEffect
+  update: ReactiveEffectRunner
   /**
    * The render function that returns vdom tree.
    * @internal

--- a/packages/runtime-core/src/scheduler.ts
+++ b/packages/runtime-core/src/scheduler.ts
@@ -3,10 +3,10 @@ import { isArray } from '@vue/shared'
 import { ComponentPublicInstance } from './componentPublicInstance'
 import { ComponentInternalInstance, getComponentName } from './component'
 import { warn } from './warning'
-import { ReactiveEffectRunner } from '@vue/reactivity'
 
-export interface SchedulerJob extends Function, Partial<ReactiveEffectRunner> {
+export interface SchedulerJob extends Function {
   id?: number
+  active?: boolean
   allowRecurse?: boolean
   /**
    * Attached by renderer.ts when setting up a component's render effect

--- a/packages/runtime-core/src/scheduler.ts
+++ b/packages/runtime-core/src/scheduler.ts
@@ -7,6 +7,21 @@ import { warn } from './warning'
 export interface SchedulerJob extends Function {
   id?: number
   active?: boolean
+  /**
+   * Indicates whether the effect is allowed to recursively trigger itself
+   * when managed by the scheduler.
+   *
+   * By default, a job cannot trigger itself because some built-in method calls,
+   * e.g. Array.prototype.push actually performs reads as well (#1740) which
+   * can lead to confusing infinite loops.
+   * The allowed cases are component update functions and watch callbacks.
+   * Component update functions may update child component props, which in turn
+   * trigger flush: "pre" watch callbacks that mutates state that the parent
+   * relies on (#1801). Watch callbacks doesn't track its dependencies so if it
+   * triggers itself again, it's likely intentional and it is the user's
+   * responsibility to perform recursive state mutation that eventually
+   * stabilizes (#1727).
+   */
   allowRecurse?: boolean
   /**
    * Attached by renderer.ts when setting up a component's render effect


### PR DESCRIPTION
Based on #2345 , but with smaller API change

- Use class implementation for `ReactiveEffect`
- Switch internal creation of effects to use the class constructor
- Avoid options object allocation
- Avoid creating bound effect runner function (used in schedulers) when not necessary. Only component update effects will need to create a bound copy of the runner.

<img width="201" alt="Screen Shot 2021-06-24 at 5 29 31 PM" src="https://user-images.githubusercontent.com/499550/123334916-c15a1a00-d511-11eb-901f-87e6d2e8ace7.png">

Consumes ~17% less memory compared to last commit (which already improved the memory usage a bit) when creating computed/watch/watchEffect (image showing benchmark of creating 10k each).

Introduces a very minor breaking change: the `scheduler` option passed to `effect` no longer receives the runner function. Instead, simply call the reference of the returned runner:

```js
const run = effect(() => {}, {
  scheduler: () => {
    run()
  }
})
```