### PR TITLE
#4013: Add missing [LifecycleHooks.SERVER_PREFETCH] to ErrorTypeStrings

### DIFF
--- a/packages/runtime-core/src/errorHandling.ts
+++ b/packages/runtime-core/src/errorHandling.ts
@@ -24,6 +24,7 @@ export const enum ErrorCodes {
 }
 
 export const ErrorTypeStrings: Record<number | string, string> = {
+  [LifecycleHooks.SERVER_PREFETCH]: 'serverPrefetch hook',
   [LifecycleHooks.BEFORE_CREATE]: 'beforeCreate hook',
   [LifecycleHooks.CREATED]: 'created hook',
   [LifecycleHooks.BEFORE_MOUNT]: 'beforeMount hook',


### PR DESCRIPTION
Just a small change that fixes a broken apollo extension setup.