### PR TITLE
feat(reactivity): bitwise dep markers to optimize re-tracking

### DIFF
--- a/packages/reactivity/__tests__/effect.spec.ts
+++ b/packages/reactivity/__tests__/effect.spec.ts
@@ -8,7 +8,8 @@ import {
   DebuggerEvent,
   markRaw,
   shallowReactive,
-  readonly
+  readonly,
+  ReactiveEffectRunner
 } from '../src/index'
 import { ITERATE_KEY } from '../src/effect'
 
@@ -488,6 +489,96 @@ describe('reactivity/effect', () => {
     obj.prop = 'value2'
     expect(dummy).toBe('other')
     expect(conditionalSpy).toHaveBeenCalledTimes(2)
+  })
+
+  it('should handle deep effect recursion using cleanup fallback', () => {
+    const results = reactive([0])
+    const effects: { fx: ReactiveEffectRunner; index: number }[] = []
+    for (let i = 1; i < 40; i++) {
+      ;(index => {
+        const fx = effect(() => {
+          results[index] = results[index - 1] * 2
+        })
+        effects.push({ fx, index })
+      })(i)
+    }
+
+    expect(results[39]).toBe(0)
+    results[0] = 1
+    expect(results[39]).toBe(Math.pow(2, 39))
+  })
+
+  it('should register deps independently during effect recursion', () => {
+    const input = reactive({ a: 1, b: 2, c: 0 })
+    const output = reactive({ fx1: 0, fx2: 0 })
+
+    const fx1Spy = jest.fn(() => {
+      let result = 0
+      if (input.c < 2) result += input.a
+      if (input.c > 1) result += input.b
+      output.fx1 = result
+    })
+
+    const fx1 = effect(fx1Spy)
+
+    const fx2Spy = jest.fn(() => {
+      let result = 0
+      if (input.c > 1) result += input.a
+      if (input.c < 3) result += input.b
+      output.fx2 = result + output.fx1
+    })
+
+    const fx2 = effect(fx2Spy)
+
+    expect(fx1).not.toBeNull()
+    expect(fx2).not.toBeNull()
+
+    expect(output.fx1).toBe(1)
+    expect(output.fx2).toBe(2 + 1)
+    expect(fx1Spy).toHaveBeenCalledTimes(1)
+    expect(fx2Spy).toHaveBeenCalledTimes(1)
+
+    fx1Spy.mockClear()
+    fx2Spy.mockClear()
+    input.b = 3
+    expect(output.fx1).toBe(1)
+    expect(output.fx2).toBe(3 + 1)
+    expect(fx1Spy).toHaveBeenCalledTimes(0)
+    expect(fx2Spy).toHaveBeenCalledTimes(1)
+
+    fx1Spy.mockClear()
+    fx2Spy.mockClear()
+    input.c = 1
+    expect(output.fx1).toBe(1)
+    expect(output.fx2).toBe(3 + 1)
+    expect(fx1Spy).toHaveBeenCalledTimes(1)
+    expect(fx2Spy).toHaveBeenCalledTimes(1)
+
+    fx1Spy.mockClear()
+    fx2Spy.mockClear()
+    input.c = 2
+    expect(output.fx1).toBe(3)
+    expect(output.fx2).toBe(1 + 3 + 3)
+    expect(fx1Spy).toHaveBeenCalledTimes(1)
+
+    // Invoked twice due to change of fx1.
+    expect(fx2Spy).toHaveBeenCalledTimes(2)
+
+    fx1Spy.mockClear()
+    fx2Spy.mockClear()
+    input.c = 3
+    expect(output.fx1).toBe(3)
+    expect(output.fx2).toBe(1 + 3)
+    expect(fx1Spy).toHaveBeenCalledTimes(1)
+    expect(fx2Spy).toHaveBeenCalledTimes(1)
+
+    fx1Spy.mockClear()
+    fx2Spy.mockClear()
+    input.a = 10
+    expect(output.fx1).toBe(3)
+    expect(output.fx2).toBe(10 + 3)
+    expect(fx1Spy).toHaveBeenCalledTimes(0)
+    expect(fx2Spy).toHaveBeenCalledTimes(1)
   })
 
   it('should not double wrap if the passed function is a effect', () => {

--- a/packages/reactivity/src/Dep.ts
+++ b/packages/reactivity/src/Dep.ts
@@ -1,0 +1,51 @@
+import { ReactiveEffect, getTrackOpBit } from './effect'
+
+export type Dep = Set<ReactiveEffect> & TrackedMarkers
+
+/**
+ * wasTracked and newTracked maintain the status for several levels of effect
+ * tracking recursion. One bit per level is used to define wheter the dependency
+ * was/is tracked.
+ */
+type TrackedMarkers = { wasTracked: number; newTracked: number }
+
+export function createDep(effects?: ReactiveEffect[]): Dep {
+  const dep = new Set<ReactiveEffect>(effects) as Dep
+  dep.wasTracked = 0
+  dep.newTracked = 0
+  return dep
+}
+
+export function wasTracked(dep: Dep): boolean {
+  return hasBit(dep.wasTracked, getTrackOpBit())
+}
+
+export function newTracked(dep: Dep): boolean {
+  return hasBit(dep.newTracked, getTrackOpBit())
+}
+
+export function setWasTracked(dep: Dep) {
+  dep.wasTracked = setBit(dep.wasTracked, getTrackOpBit())
+}
+
+export function setNewTracked(dep: Dep) {
+  dep.newTracked = setBit(dep.newTracked, getTrackOpBit())
+}
+
+export function resetTracked(dep: Dep) {
+  const trackOpBit = getTrackOpBit()
+  dep.wasTracked = clearBit(dep.wasTracked, trackOpBit)
+  dep.newTracked = clearBit(dep.newTracked, trackOpBit)
+}
+
+function hasBit(value: number, bit: number): boolean {
+  return (value & bit) > 0
+}
+
+function setBit(value: number, bit: number): number {
+  return value | bit
+}
+
+function clearBit(value: number, bit: number): number {
+  return value & ~bit
+}

--- a/packages/reactivity/src/computed.ts
+++ b/packages/reactivity/src/computed.ts
@@ -2,6 +2,7 @@ import { ReactiveEffect } from './effect'
 import { Ref, trackRefValue, triggerRefValue } from './ref'
 import { isFunction, NOOP } from '@vue/shared'
 import { ReactiveFlags, toRaw } from './reactive'
+import { Dep } from './Dep'
 
 export interface ComputedRef<T = any> extends WritableComputedRef<T> {
   readonly value: T
@@ -31,7 +32,7 @@ export const setComputedScheduler = (s: ComputedScheduler | undefined) => {
 }
 
 class ComputedRefImpl<T> {
-  public dep?: Set<ReactiveEffect> = undefined
+  public dep?: Dep = undefined
 
   private _value!: T
   private _dirty = true

--- a/packages/reactivity/src/ref.ts
+++ b/packages/reactivity/src/ref.ts
@@ -1,13 +1,9 @@
-import {
-  isTracking,
-  ReactiveEffect,
-  trackEffects,
-  triggerEffects
-} from './effect'
+import { isTracking, trackEffects, triggerEffects } from './effect'
 import { TrackOpTypes, TriggerOpTypes } from './operations'
 import { isArray, isObject, hasChanged } from '@vue/shared'
 import { reactive, isProxy, toRaw, isReactive } from './reactive'
 import { CollectionTypes } from './collectionHandlers'
+import { createDep, Dep } from './Dep'
 
 export declare const RefSymbol: unique symbol
 
@@ -27,11 +23,11 @@ export interface Ref<T = any> {
   /**
    * Deps are maintained locally rather than in depsMap for performance reasons.
    */
-  dep?: Set<ReactiveEffect>
+  dep?: Dep
 }
 
 type RefBase<T> = {
-  dep?: Set<ReactiveEffect>
+  dep?: Dep
   value: T
 }
 
@@ -39,7 +35,7 @@ export function trackRefValue(ref: RefBase<any>) {
   if (isTracking()) {
     ref = toRaw(ref)
     if (!ref.dep) {
-      ref.dep = new Set<ReactiveEffect>()
+      ref.dep = createDep()
     }
     if (__DEV__) {
       trackEffects(ref.dep, {
@@ -101,7 +97,7 @@ export function shallowRef(value?: unknown) {
 }
 
 class RefImpl<T> {
-  public dep?: Set<ReactiveEffect> = undefined
+  public dep?: Dep = undefined
 
   private _value: T
 
@@ -170,7 +166,7 @@ export type CustomRefFactory<T> = (
 }
 
 class CustomRefImpl<T> {
-  public dep?: Set<ReactiveEffect> = undefined
+  public dep?: Dep = undefined
 
   private readonly _get: ReturnType<CustomRefFactory<T>>['get']
   private readonly _set: ReturnType<CustomRefFactory<T>>['set']

--- a/packages/runtime-core/src/renderer.ts
+++ b/packages/runtime-core/src/renderer.ts
@@ -1406,25 +1406,32 @@ function baseCreateRenderer(
     isSVG,
     optimized
   ) => {
-    const componentUpdateFn = () => {
+    const componentUpdateFn = function(this: ReactiveEffect) {
       if (!instance.isMounted) {
         let vnodeHook: VNodeHook | null | undefined
         const { el, props } = initialVNode
         const { bm, m, parent } = instance
 
-        // beforeMount hook
-        if (bm) {
-          invokeArrayFns(bm)
-        }
-        // onVnodeBeforeMount
-        if ((vnodeHook = props && props.onVnodeBeforeMount)) {
-          invokeVNodeHook(vnodeHook, parent, initialVNode)
-        }
-        if (
-          __COMPAT__ &&
-          isCompatEnabled(DeprecationTypes.INSTANCE_EVENT_HOOKS, instance)
-        ) {
-          instance.emit('hook:beforeMount')
+        try {
+          // Disallow component effect recursion during pre-lifecycle hooks.
+          this.allowRecurse = false
+
+          // beforeMount hook
+          if (bm) {
+            invokeArrayFns(bm)
+          }
+          // onVnodeBeforeMount
+          if ((vnodeHook = props && props.onVnodeBeforeMount)) {
+            invokeVNodeHook(vnodeHook, parent, initialVNode)
+          }
+          if (
+            __COMPAT__ &&
+            isCompatEnabled(DeprecationTypes.INSTANCE_EVENT_HOOKS, instance)
+          ) {
+            instance.emit('hook:beforeMount')
+          }
+        } finally {
+          this.allowRecurse = true
         }
 
         if (el && hydrateNode) {
@@ -1551,19 +1558,26 @@ function baseCreateRenderer(
           next = vnode
         }
 
-        // beforeUpdate hook
-        if (bu) {
-          invokeArrayFns(bu)
-        }
-        // onVnodeBeforeUpdate
-        if ((vnodeHook = next.props && next.props.onVnodeBeforeUpdate)) {
-          invokeVNodeHook(vnodeHook, parent, next, vnode)
-        }
-        if (
-          __COMPAT__ &&
-          isCompatEnabled(DeprecationTypes.INSTANCE_EVENT_HOOKS, instance)
-        ) {
-          instance.emit('hook:beforeUpdate')
+        try {
+          // Disallow component effect recursion during pre-lifecycle hooks.
+          this.allowRecurse = false
+
+          // beforeUpdate hook
+          if (bu) {
+            invokeArrayFns(bu)
+          }
+          // onVnodeBeforeUpdate
+          if ((vnodeHook = next.props && next.props.onVnodeBeforeUpdate)) {
+            invokeVNodeHook(vnodeHook, parent, next, vnode)
+          }
+          if (
+            __COMPAT__ &&
+            isCompatEnabled(DeprecationTypes.INSTANCE_EVENT_HOOKS, instance)
+          ) {
+            instance.emit('hook:beforeUpdate')
+          }
+        } finally {
+          this.allowRecurse = true
         }
 
         // render


### PR DESCRIPTION
Currently for every effect run, all existing dependencies are first cleaned up and then retracked. This involves Set additions and removals. In many cases, dependencies rarely change so we already discussed that there was room for optmization here (https://github.com/vuejs/vue-next/pull/2345#issuecomment-727200679).

This PR optimizes re-tracking of effect dependencies.

It uses markers which identify whether a dependency is new, stable or old. Because effect execution/tracking may be recursive, the markers are actually bitwise and support up to 30 levels deep (the amount of bits we can safely use for a SMI small integer). When the depth is more than 30 levels (notice that this is unlikely to occur), the 'old' full cleanup method is used instead. 

## Component render/update recursion
Notice that this optimization, unlike the old cleanup/retrack method, postpones deleting the old dependencies until the end of the effect execution. Ideally, this *should* not make a difference, but I found one situation in which it did: the component update.

The `onBeforeUpdate` test in apiLifecycle.spec.ts failed. It turned out that the component update 'effect' has the `allowRecursive` flag turned on, because child components must be able to re-trigger the parent. However, when one of the (beforeMount/beforeUpdate) life cycle hooks is invoked, it is possible that this triggers any of the dependencies of the render method. This causes the render/update effect to be queued again unnecessarily.

Currently, the 'cleanup' cleared all dependencies just in time, making sure that this recursive trigger doesn't occur (I don't think this is intentional, it rather feels like a lucky side effect to me). To make this PR work, I had to explicitly disable allowRecursive while executing these pre-render hooks.

## Performance effect
Ideally, this algorithm only needs to iterate the Dep array twice without having to touch any of the sets. It is a robust performance enhancement, and performs stable even when the order or tracked dependencies changes! 

This has a huge boost on all effects, and especially those with a lot of dependencies. The *mix* benchmark, which represents a real-world scenario, was boosted by almost **40%**!

![performance-comparison](https://user-images.githubusercontent.com/120531/123807420-1e7a1500-d8f0-11eb-9452-76642f44be5c.png)

