### PR TITLE
fix(runtime): Addressed issue with $parent chain when using expose()

### DIFF
--- a/packages/runtime-core/__tests__/apiExpose.spec.ts
+++ b/packages/runtime-core/__tests__/apiExpose.spec.ts
@@ -171,13 +171,20 @@ describe('api: expose', () => {
   })
 
   test('expose should allow access to built-in instance properties', () => {
+    const GrandChild = defineComponent({
+      render() {
+        return h('div')
+      }
+    })
+
+    const grandChildRef = ref()
     const Child = defineComponent({
       render() {
         return h('div')
       },
       setup(_, { expose }) {
         expose()
-        return {}
+        return () => h(GrandChild, { ref: grandChildRef })
       }
     })
 
@@ -190,5 +197,7 @@ describe('api: expose', () => {
     const root = nodeOps.createElement('div')
     render(h(Parent), root)
     expect(childRef.value.$el.tag).toBe('div')
+    expect(grandChildRef.value.$parent).toBe(childRef.value)
+    expect(grandChildRef.value.$parent.$parent).toBe(grandChildRef.value.$root)
   })
 })

--- a/packages/runtime-core/src/componentPublicInstance.ts
+++ b/packages/runtime-core/src/componentPublicInstance.ts
@@ -1,6 +1,7 @@
 import {
   ComponentInternalInstance,
   Data,
+  getExposeProxy,
   isStatefulComponent
 } from './component'
 import { nextTick, queueJob } from './scheduler'
@@ -217,7 +218,7 @@ const getPublicInstance = (
   i: ComponentInternalInstance | null
 ): ComponentPublicInstance | ComponentInternalInstance['exposed'] | null => {
   if (!i) return null
-  if (isStatefulComponent(i)) return i.exposed ? i.exposed : i.proxy
+  if (isStatefulComponent(i)) return getExposeProxy(i) || i.proxy
   return getPublicInstance(i.parent)
 }
 


### PR DESCRIPTION
The instances provided by `$parent` and `$root` when dealing with a `$parent` or `$root` that used the 'expose(...)' function do not not return the `ExposeProxy`, thus no Vue public `$` getters are accessible on these objects.

This PR returns that functionality.