### PR TITLE
fix(runtime-core): add useAttrs and useSlots export

### DIFF
--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -58,7 +58,9 @@ export {
   withAsyncContext,
   // deprecated
   defineEmit,
-  useContext
+  useContext,
+  useAttrs,
+  useSlots
 } from './apiSetupHelpers'
 
 // Advanced API ----------------------------------------------------------------

--- a/test-dts/setupHelpers.test-d.ts
+++ b/test-dts/setupHelpers.test-d.ts
@@ -4,6 +4,8 @@ import {
   defineEmit,
   defineEmits,
   useContext,
+  useAttrs,
+  useSlots,
   withDefaults,
   Slots,
   describe
@@ -133,4 +135,14 @@ describe('useContext', () => {
   // should be able to emit anything
   emit('foo')
   emit('bar')
+})
+
+describe('useAttrs', () => {
+  const attrs = useAttrs()
+  expectType<Record<string, unknown>>(attrs)
+})
+
+describe('useSlots', () => {
+  const slots = useSlots()
+  expectType<Slots>(slots)
 })


### PR DESCRIPTION
Cant import useAttrs and useSlots from ”vue“ in my program，because there is no export of useAttrs and useSlots.