### PR TITLE
fix(runtime): Fix logic check verifying props existence for v-model compat warning.

### DIFF
--- a/packages/runtime-core/src/compat/compatConfig.ts
+++ b/packages/runtime-core/src/compat/compatConfig.ts
@@ -398,9 +398,10 @@ export const deprecationData: Record<DeprecationTypes, DeprecationData> = {
           DeprecationTypes.COMPONENT_V_MODEL
         }: false }\`.`
       if (
-        comp.props && isArray(comp.props)
+        comp.props &&
+        (isArray(comp.props)
           ? comp.props.includes('modelValue')
-          : hasOwn(comp.props, 'modelValue')
+          : hasOwn(comp.props, 'modelValue'))
       ) {
         return (
           `Component delcares "modelValue" prop, which is Vue 3 usage, but ` +


### PR DESCRIPTION
Without this change components that do no define any props can see problems when logging a v-model related `@vue/compat` warning. This can be see in the `AsyncComponentWrapper` below.

![image](https://user-images.githubusercontent.com/1479909/124301944-8453e000-db2e-11eb-9cb4-18d6777132d9.png)

#### This is the actual error that is generated.
![image](https://user-images.githubusercontent.com/1479909/124301746-3939cd00-db2e-11eb-9f1f-1e244105fe88.png)
