### PR TITLE
perf(runtime-core): use new Array.fill to populate array

### DIFF
--- a/packages/runtime-core/src/renderer.ts
+++ b/packages/runtime-core/src/renderer.ts
@@ -1991,8 +1991,7 @@ function baseCreateRenderer(
       // and oldIndex = 0 is a special value indicating the new node has
       // no corresponding old node.
       // used for determining longest stable subsequence
-      const newIndexToOldIndexMap = new Array(toBePatched)
-      for (i = 0; i < toBePatched; i++) newIndexToOldIndexMap[i] = 0
+      const newIndexToOldIndexMap = new Array(toBePatched).fill(0)
 
       for (i = s1; i <= e1; i++) {
         const prevChild = c1[i]


### PR DESCRIPTION
Same as [#319](https://github.com/vuejs/vue-next/pull/319).
1. According to [0038-vue3-ie11-support](https://github.com/vuejs/rfcs/blob/master/active-rfcs/0038-vue3-ie11-support.md), there is no need to support IE.
2. I have tested in several browsers as followed showing that `fill` is faster.

firefox 89.0.1
<img width="586" alt="firefox 89 0 1" src="https://user-images.githubusercontent.com/37934144/124922923-d1acd300-dfae-11eb-8d1e-d84232c23b59.png">
chrome 91
<img width="586" alt="chrome 91" src="https://user-images.githubusercontent.com/37934144/124922948-d7a2b400-dfae-11eb-9c65-91ed2d35efe9.png">
safari 14.1.1
<img width="586" alt="safari 14 1 1" src="https://user-images.githubusercontent.com/37934144/124922960-d96c7780-dfae-11eb-8971-5526a20883bc.png">

