### PR TITLE
fix(runtime-core): trigger warning in the dev environment

### DIFF
--- a/packages/runtime-core/src/helpers/useSsrContext.ts
+++ b/packages/runtime-core/src/helpers/useSsrContext.ts
@@ -7,10 +7,11 @@ export const useSSRContext = <T = Record<string, any>>() => {
   if (!__GLOBAL__) {
     const ctx = inject<T>(ssrContextKey)
     if (!ctx) {
-      warn(
-        `Server rendering context not provided. Make sure to only call ` +
-          `useSSRContext() conditionally in the server build.`
-      )
+      __DEV__ &&
+        warn(
+          `Server rendering context not provided. Make sure to only call ` +
+            `useSSRContext() conditionally in the server build.`
+        )
     }
     return ctx
   } else if (__DEV__) {


### PR DESCRIPTION
Warnings should be triggered only in the dev environment