### PR TITLE
types(defineComponent): fix unwrap when returning `Ref<T>|undefined` from `setup`

### DIFF
--- a/packages/reactivity/src/ref.ts
+++ b/packages/reactivity/src/ref.ts
@@ -205,7 +205,11 @@ type BaseTypes = string | number | boolean
 export interface RefUnwrapBailTypes {}
 
 export type ShallowUnwrapRef<T> = {
-  [K in keyof T]: T[K] extends Ref<infer V> ? V : T[K]
+  [K in keyof T]: T[K] extends Ref<infer V>
+    ? V
+    : T[K] extends Ref<infer V> | undefined // if `V` is `unknown` that means it does not extend `Ref` and is undefined
+      ? unknown extends V ? undefined : V | undefined
+      : T[K]
 }
 
 export type UnwrapRef<T> = T extends Ref<infer V>

--- a/test-dts/component.test-d.ts
+++ b/test-dts/component.test-d.ts
@@ -159,6 +159,7 @@ describe('object props', () => {
           setupC: {
             a: ref(2)
           },
+          setupD: undefined as Ref<number> | undefined,
           setupProps: props
         }
       }
@@ -190,7 +191,7 @@ describe('object props', () => {
     expectType<Number>(rawBindings.setupA)
     expectType<Ref<Number>>(rawBindings.setupB)
     expectType<Ref<Number>>(rawBindings.setupC.a)
-    expectType<Number>(rawBindings.setupA)
+    expectType<Ref<Number> | undefined>(rawBindings.setupD)
 
     // raw bindings props
     expectType<ExpectedProps['a']>(rawBindings.setupProps.a)
@@ -215,7 +216,7 @@ describe('object props', () => {
     expectType<Number>(setup.setupA)
     expectType<Number>(setup.setupB)
     expectType<Ref<Number>>(setup.setupC.a)
-    expectType<Number>(setup.setupA)
+    expectType<number | undefined>(setup.setupD)
 
     // raw bindings props
     expectType<ExpectedProps['a']>(setup.setupProps.a)
@@ -239,6 +240,7 @@ describe('object props', () => {
     // instance
     const instance = new MyComponent()
     expectType<number>(instance.setupA)
+    expectType<number | undefined>(instance.setupD)
     // @ts-expect-error
     instance.notExist
   })


### PR DESCRIPTION
fix #3990


`ShallowUnwrapRef` was not handling the `Ref<T>|undefined` type

Minimal repro
```ts
defineComponent({
  setup() {
    return {
      a: undefined as Ref<number> | undefined
    }
  },
  methods: {
    test() {
      // @ts-expect-error `a` should not be a ref
      this.a?.value
    }
  }
})
```