### PR TITLE
fix(runtime-core): update initial old value to deep watch callback in ssr …

### DIFF
--- a/packages/runtime-core/src/apiWatch.ts
+++ b/packages/runtime-core/src/apiWatch.ts
@@ -259,7 +259,7 @@ function doWatch(
     } else if (immediate) {
       callWithAsyncErrorHandling(cb, instance, ErrorCodes.WATCH_CALLBACK, [
         getter(),
-        undefined,
+        isMultiSource ? [] : undefined,
         onInvalidate
       ])
     }


### PR DESCRIPTION
Currently `watch` usage below **in SSR context**  will cause iterate error.
```js
setup(){
  const a = ref(1)
  const b = ref(2)
  watch([a, b], ([newA, newB], [oldA, oldB]) => {
    // ...
  }, { deep: true, immediate: true })
}
```
because second parameter for the first time calling of watch callback is `undefined`.
In this PR, we change it to `[]` for multi-source, make code work.