### PR TITLE
feat(compiler): Allow 'comments' option to effect comment inclusion in development

### DIFF
--- a/packages/compiler-core/__tests__/parse.spec.ts
+++ b/packages/compiler-core/__tests__/parse.spec.ts
@@ -377,25 +377,42 @@ describe('compiler: parse', () => {
     })
 
     test('comments option', () => {
-      __DEV__ = false
-      const astDefaultComment = baseParse('<!--abc-->')
-      const astNoComment = baseParse('<!--abc-->', { comments: false })
-      const astWithComments = baseParse('<!--abc-->', { comments: true })
-      __DEV__ = true
+      const astOptionNoComment = baseParse('<!--abc-->', { comments: false })
+      const astOptionWithComments = baseParse('<!--abc-->', { comments: true })
 
-      expect(astDefaultComment.children).toHaveLength(0)
-      expect(astNoComment.children).toHaveLength(0)
-      expect(astWithComments.children).toHaveLength(1)
+      expect(astOptionNoComment.children).toHaveLength(0)
+      expect(astOptionWithComments.children).toHaveLength(1)
     })
 
     // #2217
-    test('comments in the <pre> tag should be removed in production mode', () => {
-      __DEV__ = false
+    test('comments in the <pre> tag should be removed when comments option requires it', () => {
       const rawText = `<p/><!-- foo --><p/>`
-      const ast = baseParse(`<pre>${rawText}</pre>`)
-      __DEV__ = true
 
-      expect((ast.children[0] as ElementNode).children).toMatchObject([
+      const astWithComments = baseParse(`<pre>${rawText}</pre>`, {
+        comments: true
+      })
+      expect(
+        (astWithComments.children[0] as ElementNode).children
+      ).toMatchObject([
+        {
+          type: NodeTypes.ELEMENT,
+          tag: 'p'
+        },
+        {
+          type: NodeTypes.COMMENT
+        },
+        {
+          type: NodeTypes.ELEMENT,
+          tag: 'p'
+        }
+      ])
+
+      const astWithoutComments = baseParse(`<pre>${rawText}</pre>`, {
+        comments: false
+      })
+      expect(
+        (astWithoutComments.children[0] as ElementNode).children
+      ).toMatchObject([
         {
           type: NodeTypes.ELEMENT,
           tag: 'p'

--- a/packages/compiler-core/src/options.ts
+++ b/packages/compiler-core/src/options.ts
@@ -61,7 +61,8 @@ export interface ParserOptions
    */
   decodeEntities?: (rawText: string, asAttr: boolean) => string
   /**
-   * Keep comments in the templates AST, even in production
+   * Whether to keep comments in the templates AST.
+   * This defaults to `true` in development and `false` in production builds.
    */
   comments?: boolean
 }

--- a/packages/compiler-core/src/parse.ts
+++ b/packages/compiler-core/src/parse.ts
@@ -77,7 +77,7 @@ export const defaultParserOptions: MergedParserOptions = {
     rawText.replace(decodeRE, (_, p1) => decodeMap[p1]),
   onError: defaultOnError,
   onWarn: defaultOnWarn,
-  comments: false
+  comments: __DEV__
 }
 
 export const enum TextModes {
@@ -118,9 +118,14 @@ function createParserContext(
   rawOptions: ParserOptions
 ): ParserContext {
   const options = extend({}, defaultParserOptions)
-  for (const key in rawOptions) {
+
+  let key: keyof ParserOptions
+  for (key in rawOptions) {
     // @ts-ignore
-    options[key] = rawOptions[key] || defaultParserOptions[key]
+    options[key] =
+      rawOptions[key] === undefined
+        ? defaultParserOptions[key]
+        : rawOptions[key]
   }
   return {
     options,
@@ -282,12 +287,8 @@ function parseChildren(
           node.content = node.content.replace(/[\t\r\n\f ]+/g, ' ')
         }
       }
-      // also remove comment nodes in prod by default
-      if (
-        !__DEV__ &&
-        node.type === NodeTypes.COMMENT &&
-        !context.options.comments
-      ) {
+      // Remove comment nodes if desired by configuration.
+      else if (node.type === NodeTypes.COMMENT && !context.options.comments) {
         removedWhitespace = true
         nodes[i] = null as any
       }


### PR DESCRIPTION
Close: #3392
Replace: #3395

This PR does not change any default behavior, but allows the `comments` option to fully control comment nodes.