### PR TITLE
chore(sfc-playground): remove compiler macro imports

### DIFF
--- a/packages/sfc-playground/src/Message.vue
+++ b/packages/sfc-playground/src/Message.vue
@@ -8,7 +8,7 @@
 </template>
 
 <script setup lang="ts">
-import { defineProps, ref, watch } from 'vue'
+import { ref, watch } from 'vue'
 import type { CompilerError } from '@vue/compiler-sfc'
 
 const props = defineProps(['err', 'warn'])

--- a/packages/sfc-playground/src/codemirror/CodeMirror.vue
+++ b/packages/sfc-playground/src/codemirror/CodeMirror.vue
@@ -3,7 +3,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, defineProps, defineEmits, watchEffect } from 'vue'
+import { ref, onMounted, watchEffect } from 'vue'
 import { debounce } from '../utils'
 import CodeMirror from './codemirror'
 


### PR DESCRIPTION
Importing `defineEmits` and `defineProps` is no longer needed since v3.1.3