### PR TITLE
fix(sfc-playground): Transform named default exports without altering scope

### DIFF
--- a/packages/sfc-playground/src/output/moduleCompiler.ts
+++ b/packages/sfc-playground/src/output/moduleCompiler.ts
@@ -140,7 +140,17 @@ function processFile(file: File, seen = new Set<File>()) {
 
     // default export
     if (node.type === 'ExportDefaultDeclaration') {
-      s.overwrite(node.start!, node.start! + 14, `${moduleKey}.default =`)
+      if ('id' in node.declaration && node.declaration.id) {
+        // named hoistable/class exports
+        // export default function foo() {}
+        // export default class A {}
+        const { name } = node.declaration.id
+        s.remove(node.start!, node.start! + 15)
+        s.append(`\n${exportKey}(${moduleKey}, "default", () => ${name})`)
+      } else {
+        // anonymous default exports
+        s.overwrite(node.start!, node.start! + 14, `${moduleKey}.default =`)
+      }
     }
 
     // export * from './foo'


### PR DESCRIPTION
[fix issue: vite #4049](https://github.com/vitejs/vite/issues/4049)

[align behavior with vite #4053](https://github.com/vitejs/vite/pull/4053)

[Reproduction link](https://sfc.vuejs.org/#eyJBcHAudnVlIjoiPHRlbXBsYXRlPlxuICA8aDE+e3sgbXNnIH19PC9oMT5cbjwvdGVtcGxhdGU+XG5cbjxzY3JpcHQgc2V0dXA+XG5pbXBvcnQgaGVsbG8gZnJvbSAnLi9oZWxsby5qcydcbmNvbnNvbGUubG9nKGhlbGxvKVxuY29uc3QgbXNnID0gJ0hlbGxvIFdvcmxkISdcbjwvc2NyaXB0PiIsImhlbGxvLmpzIjoiZXhwb3J0IGRlZmF1bHQgZnVuY3Rpb24gaGVsbG8oKSB7XG4gIHJldHVybiAxMjM0O1xufVxuXG5jb25zb2xlLmxvZyh0eXBlb2YgaGVsbG8pO1xuXG5oZWxsby50ZXN0ID0gMTIzNDsifQ==)