### PR TITLE
feat(effectScope): dereference child from parent after stop to prevent memleaks

### DIFF
--- a/packages/reactivity/__tests__/effectScope.spec.ts
+++ b/packages/reactivity/__tests__/effectScope.spec.ts
@@ -77,8 +77,9 @@ describe('reactivity/effect/scope', () => {
       })
     })
 
-    expect(scope.effects.length).toBe(2)
-    expect(scope.effects[1]).toBeInstanceOf(EffectScope)
+    expect(scope.effects.length).toBe(1)
+    expect(scope.scopes.length).toBe(1)
+    expect(scope.scopes[0]).toBeInstanceOf(EffectScope)
 
     expect(dummy).toBe(0)
     counter.num = 7

--- a/packages/reactivity/__tests__/effectScope.spec.ts
+++ b/packages/reactivity/__tests__/effectScope.spec.ts
@@ -194,9 +194,9 @@ describe('reactivity/effect/scope', () => {
   it('should derefence child scope from parent scope after stopping child scope (no memleaks)', async () => {
     const parent = new EffectScope()
     const child = parent.run(() => new EffectScope())!
-    expect(parent.effects.includes(child)).toBe(true)
+    expect(parent.scopes.includes(child)).toBe(true)
     child.stop()
-    expect(parent.effects.includes(child)).toBe(false)
+    expect(parent.scopes.includes(child)).toBe(false)
   })
 
   it('test with higher level APIs', async () => {


### PR DESCRIPTION
When you create a nested effectScope, and then stop it, it will still be referenced by the parent. Causing memory leaks.

One of the mean features (for me at least) of effectScopes is the ability to prevent memory leaks when using it outside of the normal component context. After testing 3.2-beta I realized that my scope/effects were still leaking due to the parent scope still holding a reference after stopping it.

This PR solves this issue without (significant) memory or performance impact on normal (not nested) scopes. It simply reuses the slot in the effects array to dereference efficiently in O(1).