### PR TITLE
types(reactivity): simplify the UnwrapNestedRefs

### DIFF
--- a/packages/reactivity/src/reactive.ts
+++ b/packages/reactivity/src/reactive.ts
@@ -11,7 +11,7 @@ import {
   shallowCollectionHandlers,
   shallowReadonlyCollectionHandlers
 } from './collectionHandlers'
-import { UnwrapRef, Ref } from './ref'
+import { UnwrapRefSimple, Ref } from './ref'
 
 export const enum ReactiveFlags {
   SKIP = '__v_skip',
@@ -60,7 +60,7 @@ function getTargetType(value: Target) {
 }
 
 // only unwrap nested ref
-export type UnwrapNestedRefs<T> = T extends Ref ? T : UnwrapRef<T>
+export type UnwrapNestedRefs<T> = T extends Ref ? T : UnwrapRefSimple<T>
 
 /**
  * Creates a reactive copy of the original object.

--- a/packages/reactivity/src/ref.ts
+++ b/packages/reactivity/src/ref.ts
@@ -264,7 +264,7 @@ export type UnwrapRef<T> = T extends Ref<infer V>
   ? UnwrapRefSimple<V>
   : UnwrapRefSimple<T>
 
-type UnwrapRefSimple<T> = T extends
+export type UnwrapRefSimple<T> = T extends
   | Function
   | CollectionTypes
   | BaseTypes


### PR DESCRIPTION
Using `UnwrapRef` in `UnwrapNestedRefs` is actually redundant, direct use of `UnwrapRefSimple` can reduce the level.