### PR TITLE
build(server-renderer): Add ESM as a build target

### DIFF
--- a/packages/server-renderer/package.json
+++ b/packages/server-renderer/package.json
@@ -3,13 +3,16 @@
   "version": "3.2.0-beta.6",
   "description": "@vue/server-renderer",
   "main": "index.js",
+  "module": "dist/server-renderer.esm-bundler.js",
   "types": "dist/server-renderer.d.ts",
   "files": [
     "index.js",
     "dist"
   ],
   "buildOptions": {
+    "name": "VueServerRenderer",
     "formats": [
+      "esm-bundler",
       "cjs"
     ]
   },


### PR DESCRIPTION
Scope of changes:
Add ESM as a build target for `@vue/server-renderer`

Reasoning:
I'm trying to fix [Vue compatibility with Astro](https://github.com/snowpackjs/astro/issues/182), which is build on top of Snowpack, so build tool that doesn't like non-ESM sources, and that causes issues with code duplication and breaking solutions based on being singletons, like [`currentRenderingInstance`](https://github.com/vuejs/vue-next/blob/1867591e7c54406e92575753dd77fffba17606a2/packages/runtime-core/src/componentRenderContext.ts#L9), that leads to errors while trying to render nested components.

Exposing this package as ESM is probably the simplest way to solve that problem, and from what I see some changes in this area was already made, for example https://github.com/vuejs/vue-next/commit/ee4cbaeec917362c571ce95352adccd6ec2d1f47, so hope it's inline with the vision.