### PR TITLE
fix(shared): toDisplayString()  skip unwrap raw refs  markRaw()

### DIFF
--- a/packages/shared/__tests__/toDisplayString.spec.ts
+++ b/packages/shared/__tests__/toDisplayString.spec.ts
@@ -1,4 +1,4 @@
-import { computed, ref } from '@vue/reactivity'
+import { computed, ref, markRaw } from '@vue/reactivity'
 import { toDisplayString } from '../src'
 
 describe('toDisplayString', () => {
@@ -21,6 +21,22 @@ describe('toDisplayString', () => {
     expect(toDisplayString(arr)).toBe(JSON.stringify(arr, null, 2))
   })
 
+  test('markRaw ref', () => {
+    let rawValue = 5
+
+    let refRaw = markRaw(ref(rawValue))
+
+    // spy on value getter
+    let spyRefRawValue = jest.spyOn(refRaw, 'value', 'get')
+
+    let refRawDisplayString = toDisplayString(refRaw)
+    expect(refRawDisplayString).toBe(JSON.stringify(refRaw, null, 2))
+    expect(refRawDisplayString).not.toBe('5')
+
+    // .value should not be accessed as to not trigger reactivity
+    expect(spyRefRawValue).not.toHaveBeenCalled()
+  })
+
   test('refs', () => {
     const n = ref(1)
     const np = computed(() => n.value + 1)
@@ -31,7 +47,7 @@ describe('toDisplayString', () => {
       })
     ).toBe(JSON.stringify({ n: 1, np: 2 }, null, 2))
   })
-  
+
   test('objects with custom toString', () => {
     class TestClass {
       toString() {

--- a/packages/shared/src/toDisplayString.ts
+++ b/packages/shared/src/toDisplayString.ts
@@ -21,7 +21,7 @@ export const toDisplayString = (val: unknown): string => {
 
 const replacer = (_key: string, val: any): any => {
   // can't use isRef here since @vue/shared has no deps
-  if (val && val.__v_isRef) {
+  if (val && val.__v_isRef && !val.__v_skip) {
     return replacer(_key, val.value)
   } else if (isMap(val)) {
     return {


### PR DESCRIPTION
`toDisplayString()` should not unwrap or track refs that were marked as raw

`__v_skip === true`