### PR TITLE
fix(runtime-core): allow calling hasOwnProperty on proxy

### DIFF
--- a/packages/runtime-core/__tests__/componentPublicInstance.spec.ts
+++ b/packages/runtime-core/__tests__/componentPublicInstance.spec.ts
@@ -209,6 +209,22 @@ describe('component: proxy', () => {
     ])
   })
 
+  test('allow calling hasOwnProperty', () => {
+    let instanceProxy: any
+    const Comp = {
+      render() {},
+      mounted() {
+        instanceProxy = this
+      }
+    }
+
+    const app = createApp(Comp)
+
+    app.mount(nodeOps.createElement('div'))
+
+    expect(instanceProxy.hasOwnProperty).not.toBeNull()
+  })
+
   // #864
   test('should not warn declared but absent props', () => {
     const Comp = {

--- a/packages/runtime-core/src/componentPublicInstance.ts
+++ b/packages/runtime-core/src/componentPublicInstance.ts
@@ -387,6 +387,8 @@ export const PublicInstanceProxyHandlers: ProxyHandler<any> = {
             `but is not defined on instance.`
         )
       }
+    } else if (key === 'hasOwnProperty') {
+      return ctx.hasOwnProperty
     }
   },
 


### PR DESCRIPTION
It is currently not possible to call `hasOwnProperty` on the proxy instance,
which makes it impossible to spy with Jest, as Jest needs to call this method (see https://github.com/facebook/jest/blob/30e802036291f4c9c9fd4feef6faba485df54dd2/packages/jest-mock/src/index.ts#L986)

This commit fixes this by properly returning the `hasOwnProperty` method in the `get` section of the proxy.

There is currently a workaround in vue-test-utils-next that monkey patches the proxy to add the method (see https://github.com/vuejs/vue-test-utils-next/blob/23d3d3e1f4178a87de5023f5255e0623653affdc/src/mount.ts#L493-L495).
This is temporarily fine, but developers trying to create spies without using @vue/test-utils will run into the same issue.

The proposed fix is obviously very naive: the point was just to get the ball rolling 🙂 