### PR TITLE
fix(types): fix `this` type broken in computed options

### DIFF
--- a/packages/reactivity/src/computed.ts
+++ b/packages/reactivity/src/computed.ts
@@ -12,7 +12,7 @@ export interface WritableComputedRef<T> extends Ref<T> {
   readonly effect: ReactiveEffect<T>
 }
 
-export type ComputedGetter<T> = (...ctx: any) => T
+export type ComputedGetter<T> = (...args: any[]) => T
 export type ComputedSetter<T> = (v: T) => void
 
 export interface WritableComputedOptions<T> {

--- a/packages/reactivity/src/computed.ts
+++ b/packages/reactivity/src/computed.ts
@@ -12,7 +12,7 @@ export interface WritableComputedRef<T> extends Ref<T> {
   readonly effect: ReactiveEffect<T>
 }
 
-export type ComputedGetter<T> = (ctx?: any) => T
+export type ComputedGetter<T> = (...ctx: any) => T
 export type ComputedSetter<T> = (v: T) => void
 
 export interface WritableComputedOptions<T> {

--- a/test-dts/defineComponent.test-d.tsx
+++ b/test-dts/defineComponent.test-d.tsx
@@ -396,12 +396,12 @@ describe('type inference w/ options API', () => {
       }
     },
     computed: {
-      d(): number {
+      d() {
         expectType<number>(this.b)
         return this.b + 1
       },
       e: {
-        get(): number {
+        get() {
           expectType<number>(this.b)
           expectType<number>(this.d)
 
@@ -514,10 +514,10 @@ describe('with mixins', () => {
       expectType<string>(props.aP1)
     },
     computed: {
-      dC1(): number {
+      dC1() {
         return this.d + this.a
       },
-      dC2(): string {
+      dC2() {
         return this.aP1 + 'dC2'
       }
     }
@@ -926,7 +926,7 @@ describe('emits', () => {
     },
     mounted() {
       // #3599
-      this.$nextTick(function() {
+      this.$nextTick(function () {
         // this should be bound to this instance
 
         this.$emit('click', 1)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/31695475/127758427-93a9d3fa-6b9f-4058-bc71-bd55423a06a1.png)
  related issue #3010