### PR TITLE
fix(warn): skip ShadowRoot check on unsupported platforms

### DIFF
--- a/packages/runtime-dom/src/index.ts
+++ b/packages/runtime-dom/src/index.ts
@@ -184,6 +184,7 @@ function normalizeContainer(
   }
   if (
     __DEV__ &&
+    window.ShadowRoot &&
     container instanceof window.ShadowRoot &&
     container.mode === 'closed'
   ) {


### PR DESCRIPTION
When using browsers not support the **shadowRoot** interface, this would throw `invalid 'instanceof' operand type` error because the window.shadowRoot got undefined.

So i add a defensive code here.