### PR TITLE
updated typing of key in VNodeProps (fix #4240)

### DIFF
--- a/packages/runtime-core/src/components/KeepAlive.ts
+++ b/packages/runtime-core/src/components/KeepAlive.ts
@@ -46,7 +46,7 @@ export interface KeepAliveProps {
   max?: number | string
 }
 
-type CacheKey = string | number | ConcreteComponent
+type CacheKey = string | number | symbol | ConcreteComponent
 type Cache = Map<CacheKey, VNode>
 type Keys = Set<CacheKey>
 

--- a/packages/runtime-core/src/renderer.ts
+++ b/packages/runtime-core/src/renderer.ts
@@ -1873,7 +1873,7 @@ function baseCreateRenderer(
       const s2 = i // next starting index
 
       // 5.1 build key:index map for newChildren
-      const keyToNewIndexMap: Map<string | number, number> = new Map()
+      const keyToNewIndexMap: Map<string | number | symbol, number> = new Map()
       for (i = s2; i <= e2; i++) {
         const nextChild = (c2[i] = optimized
           ? cloneIfMounted(c2[i] as VNode)

--- a/packages/runtime-core/src/vnode.ts
+++ b/packages/runtime-core/src/vnode.ts
@@ -90,7 +90,7 @@ export type VNodeHook =
 
 // https://github.com/microsoft/TypeScript/issues/33099
 export type VNodeProps = {
-  key?: string | number
+  key?: string | number | symbol
   ref?: VNodeRef
 
   // vnode hooks
@@ -138,7 +138,7 @@ export interface VNode<
 
   type: VNodeTypes
   props: (VNodeProps & ExtraProps) | null
-  key: string | number | null
+  key: string | number | symbol | null
   ref: VNodeNormalizedRef | null
   /**
    * SFC only. This is assigned on vnode creation using currentScopeId


### PR DESCRIPTION
### Issue
[#4240](https://github.com/vuejs/vue-next/issues/4240)

### Version
3.2.0-beta.7

### Reproduction link
[Reproduction link](https://sfc.vuejs.org/#eyJBcHAudnVlIjoiPHRlbXBsYXRlPlxuICA8dWw+XG4gICAgPGxpIHYtZm9yPVwiKGl0ZW0sIGkpIGluIGxpc3RcIiA6a2V5PVwiaXRlbS5zeW1ib2xcIiB2LWh0bWw9XCJpdGVtLnRpdGxlXCI+PC9saT5cbiAgPC91bD5cblxuICA8dWw+XG4gICAgPGxpIHYtZm9yPVwiKGl0ZW0sIGkpIGluIGxpc3RcIiA6a2V5PVwiaVwiIHYtaHRtbD1cIml0ZW0udGl0bGVcIj48L2xpPlxuICA8L3VsPlxuXG48L3RlbXBsYXRlPlxuXG48c2NyaXB0IHNldHVwIGxhbmc9XCJ0c1wiPlxuY29uc3QgbGlzdCA9IFtcbiAgeyBzeW1ib2w6IFN5bWJvbCgpLCB0aXRsZTogJ0EnIH0sXG4gIHsgc3ltYm9sOiBTeW1ib2woKSwgdGl0bGU6ICdCJyB9LFxuICB7IHN5bWJvbDogU3ltYm9sKCksIHRpdGxlOiAnQycgfSxcbl07XG5cbi8vIFdoZW4gd2UgYXJlIHVzaW5nIDprZXk9XCJpXCIgaW4gdGhlIHRlbXBsYXRlLCB0aGUgZm9sbG93aW5nIGFjdGlvbnMgd2lsbCByZXVzZSBET00gZWxlbWVudHMgaW5jb3JyZWN0bHk6XG5cbi8vIFRoaXMgd291bGQgY2hhbmdlIGkgZm9yIGV2ZXJ5IGl0ZW0gaW4gdGhlIGxpc3QsIGJ1dCBub3QgdGhlaXIgc3ltYm9sOlxubGlzdC5zaGlmdCgpO1xuXG4vLyBBZGRpbmcgYSBuZXcgaXRlbSBzaW11bHRhbmVvdXNseSBhcyByZW1vdmluZyBhbm90aGVyIHdvdWxkIHByb2R1Y2UgYSBuZXcgZW50cnkgaW4gdGhlIGxpc3Qgd2l0aCB0aGUgc2FtZSBpIGFzIGFub3RoZXIgaXRlbSBwcmV2aW91c2x5IGhhZC4gVGVsbGluZyBWdWUgdGhhdCB0aGlzIGVudHJ5IGlzIHRoZSBzYW1lIGFzIHdoYXQgdGhlIFwiQ1wiIGVudHJ5IGlzIGluY29ycmVjdCBhbmQgY2FuIHByb2R1Y2UgaW5jb3JyZWN0IGJlaGF2aW9yIGluIGVkZ2UgY2FzZXMuIEEgc3ltYm9sIGlzIGEgbW9yZSByb2J1c3QsIHlldCBpbmV4cGVuc2l2ZSBjaG9pY2UuXG5saXN0LnB1c2goeyBzeW1ib2w6IFN5bWJvbCgpLCB0aXRsZTogJ0EnfSk7XG5cbjwvc2NyaXB0PiJ9)


### Steps to reproduce
1. Use symbols as :key in a v-for.
2. Compile component incl. template with TypeScript (vue-tsc --noEmit)

### What was expected?
Vue allows using a symbol as a v-for :key. This is very useful in some situations, since symbols are an automatically unique primitive. I would expect the typing of v-for :key to include symbol.

### What was actually happening?
The code works at runtime, but the type checking step complains that the provided v-for :key is not string | number | undefined.

### What is the fix doing?
Added type support for symbol for a v-for :key.

---
Symbols have been officially supported as a v-for :key since Vue 2.5. For some reason, the typing (but not the functionality) regressed with Vue 3.0.

We noticed this bug after switching from Vue-cli to Vite, since Vite supports TypeScript in templates out-of-the-box.