### PR TITLE
feat(runtime-core): support array argument in mergeProps

### DIFF
--- a/packages/compiler-core/__tests__/transforms/transformElement.spec.ts
+++ b/packages/compiler-core/__tests__/transforms/transformElement.spec.ts
@@ -19,9 +19,7 @@ import {
   KEEP_ALIVE,
   BASE_TRANSITION,
   NORMALIZE_CLASS,
-  NORMALIZE_STYLE,
-  NORMALIZE_PROPS,
-  GUARD_REACTIVE_PROPS
+  NORMALIZE_STYLE
 } from '../../src/runtimeHelpers'
 import {
   NodeTypes,
@@ -215,25 +213,17 @@ describe('compiler: element transform', () => {
 
   test('v-bind="obj"', () => {
     const { root, node } = parseWithElementTransform(`<div v-bind="obj" />`)
-    // single v-bind doesn't need mergeProps
-    expect(root.helpers).not.toContain(MERGE_PROPS)
-    expect(root.helpers).toContain(NORMALIZE_PROPS)
-    expect(root.helpers).toContain(GUARD_REACTIVE_PROPS)
+    // obj may be an array here, use mergeProps to spread array
+    expect(root.helpers).toContain(MERGE_PROPS)
 
     // should directly use `obj` in props position
     expect(node.props).toMatchObject({
       type: NodeTypes.JS_CALL_EXPRESSION,
-      callee: NORMALIZE_PROPS,
+      callee: MERGE_PROPS,
       arguments: [
         {
-          type: NodeTypes.JS_CALL_EXPRESSION,
-          callee: GUARD_REACTIVE_PROPS,
-          arguments: [
-            {
-              type: NodeTypes.SIMPLE_EXPRESSION,
-              content: `obj`
-            }
-          ]
+          type: NodeTypes.SIMPLE_EXPRESSION,
+          content: `obj`
         }
       ]
     })

--- a/packages/compiler-core/__tests__/transforms/vIf.spec.ts
+++ b/packages/compiler-core/__tests__/transforms/vIf.spec.ts
@@ -22,7 +22,6 @@ import {
   CREATE_COMMENT,
   FRAGMENT,
   MERGE_PROPS,
-  NORMALIZE_PROPS,
   RENDER_SLOT
 } from '../../src/runtimeHelpers'
 import { createObjectMatcher } from '../testUtils'
@@ -557,13 +556,9 @@ describe('compiler: v-if', () => {
       const branch1 = codegenNode.consequent as VNodeCall
       expect(branch1.props).toMatchObject({
         type: NodeTypes.JS_CALL_EXPRESSION,
-        callee: NORMALIZE_PROPS,
+        callee: MERGE_PROPS,
         arguments: [
-          {
-            type: NodeTypes.JS_CALL_EXPRESSION,
-            callee: MERGE_PROPS,
-            arguments: [createObjectMatcher({ key: `[0]` }), { content: `obj` }]
-          }
+          createObjectMatcher({ key: `[0]` }), { content: `obj` }
         ]
       })
     })

--- a/packages/compiler-core/src/transforms/transformElement.ts
+++ b/packages/compiler-core/src/transforms/transformElement.ts
@@ -44,8 +44,7 @@ import {
   TELEPORT,
   KEEP_ALIVE,
   SUSPENSE,
-  UNREF,
-  GUARD_REACTIVE_PROPS
+  UNREF
 } from '../runtimeHelpers'
 import {
   getInnerRange,
@@ -759,12 +758,8 @@ export function buildProps(
       default:
         // single v-bind
         propsExpression = createCallExpression(
-          context.helper(NORMALIZE_PROPS),
-          [
-            createCallExpression(context.helper(GUARD_REACTIVE_PROPS), [
-              propsExpression
-            ])
-          ]
+          context.helper(MERGE_PROPS),
+          [propsExpression]
         )
         break
     }

--- a/packages/runtime-core/__tests__/vnode.spec.ts
+++ b/packages/runtime-core/__tests__/vnode.spec.ts
@@ -383,6 +383,45 @@ describe('vnode', () => {
       })
     })
 
+    test('object w/ array', () => {
+      let props1: Data = {
+        class: 'a b',
+        style: {
+          color: 'green',
+          fontSize: 10
+        }
+      }
+
+      let props2: Data[] = [
+        {
+          style: [
+            {
+              color: 'blue',
+              width: '300px'
+            }
+          ]
+        },
+        {
+          style: [
+            {
+              color: 'red',
+              height: '300px'
+            }
+          ]
+        }
+      ]
+
+      expect(mergeProps(props1, props2)).toMatchObject({
+        style: {
+          color: 'red',
+          width: '300px',
+          height: '300px',
+          fontSize: 10
+        },
+        class: 'a b'
+      })
+    })
+
     test('style w/ strings', () => {
       let props1: Data = {
         style: 'width:100px;right:10;top:10'

--- a/packages/runtime-core/src/vnode.ts
+++ b/packages/runtime-core/src/vnode.ts
@@ -777,10 +777,9 @@ export function normalizeChildren(vnode: VNode, children: unknown) {
   vnode.shapeFlag |= type
 }
 
-export function mergeProps(...args: (Data & VNodeProps)[]) {
+export function mergeProps(...args: (Data & VNodeProps | Data[])[]) {
   const ret: Data = {}
-  for (let i = 0; i < args.length; i++) {
-    const toMerge = args[i]
+  const merge = (toMerge: Data & VNodeProps) => {
     for (const key in toMerge) {
       if (key === 'class') {
         if (ret.class !== toMerge.class) {
@@ -799,6 +798,15 @@ export function mergeProps(...args: (Data & VNodeProps)[]) {
       } else if (key !== '') {
         ret[key] = toMerge[key]
       }
+    }
+  }
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i]
+    if (isArray(arg)) {
+      // support v-bind="[propsA, propsB]"
+      arg.forEach(prop => merge(prop))
+    } else {
+      merge(arg)
     }
   }
   return ret


### PR DESCRIPTION
https://github.com/vuejs/vue-next/issues/4105
two changes:
1.mergeProps now accept array arguments,
2. `<div v-bind="obj" />` now will compiled to
 `createElementBlock("div", _mergeProps(_ctx.obj))` rather than
`createElementBlock("div", _normalizeProps(_guardReactiveProps({ key: 0 }, _ctx.obj)))`

Btw,this pr solved the unnecessary code output after `injectProp`.
for example, `<div v-if="ok" v-bind="obj"/>` will compiled to:
before:
`createElementBlock("div", _normalizeProps(_mergeProps({ key: 0 }, _ctx.obj))) // unnecessary normalizeProps call`
in this commit:
`createElementBlock("div", _mergeProps({ key: 0 }, _ctx.obj))`