### PR TITLE
docs(server-renderer) fix typo in `renderToWebStream` error, and remove Cloudflare Worker reference

### DIFF
--- a/packages/server-renderer/README.md
+++ b/packages/server-renderer/README.md
@@ -88,7 +88,7 @@ function renderToWebStream(
 **Usage**
 
 ```js
-// e.g. inside a Cloudflare Worker
+// e.g. inside an environment with ReadableStream support
 return new Response(renderToWebStream(app))
 ```
 

--- a/packages/server-renderer/src/renderToStream.ts
+++ b/packages/server-renderer/src/renderToStream.ts
@@ -129,7 +129,7 @@ export function renderToWebStream(
 ): ReadableStream {
   if (!Ctor && !hasGlobalWebStream) {
     throw new Error(
-      `ReadableStream constructor is not avaialbe in the global scope and ` +
+      `ReadableStream constructor is not available in the global scope and ` +
         `must be explicitly passed in as the 3rd argument:\n\n` +
         `  import { ReadableStream } from 'stream/web'\n` +
         `  const stream = renderToWebStream(app, {}, ReadableStream)`


### PR DESCRIPTION
Fixing the typo is pretty self explanatory, but the Cloudflare Workers doc change needs a little more explanation:

Unfortunately, Cloudflare Workers does not expose the `ReadableStream` constructor, which means it's not as simple as `return new Response(renderToWebStream(app))` here.

There are ways to get this to work in Cloudflare Workers via ponyfill-ing `ReadableStream`, and then manually writing back to a `TransformStream` which is available in their environment, and ends up looking something like this:
```js
...
import {ReadableStream as polyReadableStream} from 'web-streams-polyfill/dist/ponyfill.es2018.mjs';

async function pipeReaderToWriter(reader, writer){
	const encoder = new TextEncoder();
	for(;;){
		const {value, done} = await reader.read();
		const encoded = encoder.encode(value);
		await writer.write(encoded);
		if(done){
			break;
		}
	}
	writer.close();
}
...
```
```js
...
const {readable, writable} = new TransformStream();
const render = renderToWebStream(app, {}, polyReadableStream);
pipeReaderToWriter(render.getReader(), writable.getWriter());
return new Response(readable);
...
```
More discussion can be found in https://github.com/vuejs/vue-next/issues/4243.

I figured that this complexity is very Cloudflare Workers specific, so perhaps wouldn't make sense to include in the README here. However I think it's a good idea to remove the CF Workers reference here, so others aren't confused about this not working in future. If it makes sense, I'd be happy to contribute some docs somewhere (where?) about this, or extend this README if you feel it makes the most sense here. Let me know.