### PR TITLE
fix(compiler-sfc): script setup - allow for import identifers with $

### DIFF
--- a/packages/compiler-sfc/src/compileScript.ts
+++ b/packages/compiler-sfc/src/compileScript.ts
@@ -332,7 +332,9 @@ export function compileScript(
 
     let isUsedInTemplate = true
     if (isTS && sfc.template && !sfc.template.src) {
-      isUsedInTemplate = new RegExp(`\\b${local}\\b`).test(
+      // escape ( local$ => local\\$ )
+      let localEscaped = local.replace(/[$]/g,'\\$&')
+      isUsedInTemplate = new RegExp(`\\b${localEscaped}\\b`).test(
         resolveTemplateUsageCheckString(sfc)
       )
     }


### PR DESCRIPTION

```
import { local$ } from "module"
```

Fixes: identifiers with $ in the name were not included in the returned values of the setup script.

closes: https://github.com/vuejs/vue-next/issues/4274