### PR TITLE
Remove left over debugger line

### DIFF
--- a/packages/compiler-dom/src/transforms/stringifyStatic.ts
+++ b/packages/compiler-dom/src/transforms/stringifyStatic.ts
@@ -183,7 +183,6 @@ function analyzeNode(node: StringifiableNode): [number, number] | false {
   let ec = node.props.length > 0 ? 1 : 0 // element w/ binding count
   let bailed = false
   const bail = (): false => {
-    debugger
     bailed = true
     return false
   }


### PR DESCRIPTION
Looks like this slipped into the 3.2 release @yyx990803