### PR TITLE
fix(runtime-dom): patch `textContent` on svg properly

### DIFF
--- a/packages/runtime-dom/__tests__/patchAttrs.spec.ts
+++ b/packages/runtime-dom/__tests__/patchAttrs.spec.ts
@@ -10,6 +10,13 @@ describe('runtime-dom: attrs patching', () => {
     expect(el.getAttributeNS(xlinkNS, 'href')).toBe(null)
   })
 
+  test('textContent attributes /w svg', () => {
+    const el = document.createElementNS('http://www.w3.org/2000/svg', 'use')
+    patchProp(el, 'textContent', null, 'foo', true)
+    expect(el.attributes.length).toBe(0)
+    expect(el.innerHTML).toBe('foo')
+  })
+
   test('boolean attributes', () => {
     const el = document.createElement('input')
     patchProp(el, 'readonly', null, true)

--- a/packages/runtime-dom/src/patchProp.ts
+++ b/packages/runtime-dom/src/patchProp.ts
@@ -69,7 +69,7 @@ function shouldSetAsProp(
   if (isSVG) {
     // most keys must be set as attribute on svg elements to work
     // ...except innerHTML
-    if (key === 'innerHTML') {
+    if (key === 'innerHTML' || key === 'textContent') {
       return true
     }
     // or native onclick with function values

--- a/packages/runtime-dom/src/patchProp.ts
+++ b/packages/runtime-dom/src/patchProp.ts
@@ -68,7 +68,7 @@ function shouldSetAsProp(
 ) {
   if (isSVG) {
     // most keys must be set as attribute on svg elements to work
-    // ...except innerHTML
+    // ...except innerHTML & textContent
     if (key === 'innerHTML' || key === 'textContent') {
       return true
     }


### PR DESCRIPTION
close #4296 