### PR TITLE
fix(shared): toDisplayString toString override support

### DIFF
--- a/packages/shared/__tests__/toDisplayString.spec.ts
+++ b/packages/shared/__tests__/toDisplayString.spec.ts
@@ -19,6 +19,46 @@ describe('toDisplayString', () => {
     expect(toDisplayString(obj)).toBe(JSON.stringify(obj, null, 2))
     const arr = [obj]
     expect(toDisplayString(arr)).toBe(JSON.stringify(arr, null, 2))
+
+    const obj_with_toString_override = {
+      foo: 555,
+      toString() {
+        return 'override'
+      }
+    }
+    expect(toDisplayString(obj_with_toString_override)).toBe('override')
+
+    const obj_with_non_invokeable_toString_override = {
+      foo: 555,
+      toString: null
+    }
+    expect(toDisplayString(obj_with_non_invokeable_toString_override)).toBe(
+      `{
+  "foo": 555,
+  "toString": null
+}`
+    )
+
+    // object created from null does not have .toString in its prototype
+    const nullObjectWithoutToString = Object.create(null)
+    nullObjectWithoutToString.bar = 1
+    expect(toDisplayString(nullObjectWithoutToString)).toBe(
+      `{
+  "bar": 1
+}`
+    )
+
+    // array toString override is ignored
+    const arrWithToStringOverride = [1, 2, 3]
+    arrWithToStringOverride.toString = () =>
+      'override for array is not supported'
+    expect(toDisplayString(arrWithToStringOverride)).toBe(
+      `[
+  1,
+  2,
+  3
+]`
+    )
   })
 
   test('refs', () => {
@@ -31,7 +71,7 @@ describe('toDisplayString', () => {
       })
     ).toBe(JSON.stringify({ n: 1, np: 2 }, null, 2))
   })
-  
+
   test('objects with custom toString', () => {
     class TestClass {
       toString() {

--- a/packages/shared/src/toDisplayString.ts
+++ b/packages/shared/src/toDisplayString.ts
@@ -4,6 +4,7 @@ import {
   isObject,
   isPlainObject,
   isSet,
+  isFunction,
   objectToString
 } from './index'
 
@@ -12,11 +13,22 @@ import {
  * @private
  */
 export const toDisplayString = (val: unknown): string => {
-  return val == null
-    ? ''
-    : isArray(val) || (isObject(val) && val.toString === objectToString)
-    ? JSON.stringify(val, replacer, 2)
-    : String(val)
+  if (val == null) return ''
+
+  let hasToString = false
+  if (!isObject(val)) {
+    hasToString = true
+  } else if (isArray(val)) {
+    // skip toString override check for Array
+    hasToString = false
+  } else {
+    // Object - check if toString is an invokable override
+    hasToString =
+      val.toString &&
+      val.toString !== objectToString &&
+      isFunction(val.toString)
+  }
+  return hasToString ? String(val) : JSON.stringify(val, replacer, 2)
 }
 
 const replacer = (_key: string, val: any): any => {

--- a/packages/shared/src/toDisplayString.ts
+++ b/packages/shared/src/toDisplayString.ts
@@ -5,7 +5,6 @@ import {
   isFunction,
   isPlainObject,
   isSet,
-  isFunction,
   objectToString
 } from './index'
 

--- a/packages/shared/src/toDisplayString.ts
+++ b/packages/shared/src/toDisplayString.ts
@@ -15,20 +15,19 @@ import {
 export const toDisplayString = (val: unknown): string => {
   if (val == null) return ''
 
-  let hasToString = false
-  if (!isObject(val)) {
-    hasToString = true
-  } else if (isArray(val)) {
-    // skip toString override check for Array
-    hasToString = false
-  } else {
-    // Object - check if toString is an invokable override
-    hasToString =
+  let useToString = true
+
+  if (isArray(val)) {
+    useToString = false
+  } else if (isObject(val)) {
+    // object with invokeable toString override
+    useToString =
       val.toString &&
       val.toString !== objectToString &&
       isFunction(val.toString)
   }
-  return hasToString ? String(val) : JSON.stringify(val, replacer, 2)
+
+  return useToString ? String(val) : JSON.stringify(val, replacer, 2)
 }
 
 const replacer = (_key: string, val: any): any => {


### PR DESCRIPTION

fix: https://github.com/vuejs/vue-next/issues/4334 

fix for the case object without `toString`  for example: 
```js
let obj = Object.create(null)  // typeof  is Object, however it will not have toString in prototype chain
``` 


handle the case that `toString` is non invokable, and use the JSON formatter for that case
```js
let obj = {a:1, toString: 'bar')
```



improving on: https://github.com/vuejs/vue-next/pull/4335

