### PR TITLE
chore(ts): added description to CreateAppFunction

### DIFF
--- a/packages/runtime-core/src/apiCreateApp.ts
+++ b/packages/runtime-core/src/apiCreateApp.ts
@@ -166,6 +166,12 @@ export function createAppContext(): AppContext {
   }
 }
 
+/**
+ * It's possible to pass listeners for emited events to `rootProps`.
+ * Event name must be transformed to `on` + PascalCaseEventName no dashes.
+ * 
+ * > Event `header-click` must be transformed to `onHeaderClick`
+ */
 export type CreateAppFunction<HostElement> = (
   rootComponent: Component,
   rootProps?: Data | null


### PR DESCRIPTION
Added explanation how to pass to `rootProps` listeners for event emitters inside rendering component.

I used it inside Angular with Webpack 5 Module Federation: [link](https://github.com/ApplY3D/module-federation-examples/blob/master/angular-react-vue/angular-app/src/app/app.component.ts#L55)