### PR TITLE
chore: rename `onDispose` to `onScopeDispose` in warnings and tests

### DIFF
--- a/packages/reactivity/__tests__/effectScope.spec.ts
+++ b/packages/reactivity/__tests__/effectScope.spec.ts
@@ -173,7 +173,7 @@ describe('reactivity/effect/scope', () => {
     expect(doubled).toBe(undefined)
   })
 
-  it('should fire onDispose hook', () => {
+  it('should fire onScopeDispose hook', () => {
     let dummy = 0
 
     const scope = new EffectScope()
@@ -192,7 +192,7 @@ describe('reactivity/effect/scope', () => {
     expect(dummy).toBe(7)
   })
 
-  it('should warn onDispose() is called when there is no active effect scope', () => {
+  it('should warn onScopeDispose() is called when there is no active effect scope', () => {
     const spy = jest.fn()
     const scope = new EffectScope()
     scope.run(() => {
@@ -204,7 +204,7 @@ describe('reactivity/effect/scope', () => {
     onScopeDispose(spy)
 
     expect(
-      '[Vue warn] onDispose() is called when there is no active effect scope to be associated with.'
+      '[Vue warn] onScopeDispose() is called when there is no active effect scope to be associated with.'
     ).toHaveBeenWarned()
 
     scope.stop()

--- a/packages/reactivity/src/effectScope.ts
+++ b/packages/reactivity/src/effectScope.ts
@@ -98,7 +98,7 @@ export function onScopeDispose(fn: () => void) {
     activeEffectScope.cleanups.push(fn)
   } else if (__DEV__) {
     warn(
-      `onDispose() is called when there is no active effect scope` +
+      `onScopeDispose() is called when there is no active effect scope` +
         ` to be associated with.`
     )
   }


### PR DESCRIPTION
`onDispose` looks like a typo to me, as there's no other reference to this name in the codebase