### PR TITLE
fix(compiler-sfc): fix import usage check in template strings case sensitive

### DIFF
--- a/packages/compiler-sfc/__tests__/__snapshots__/compileScript.spec.ts.snap
+++ b/packages/compiler-sfc/__tests__/__snapshots__/compileScript.spec.ts.snap
@@ -206,7 +206,7 @@ return { x }
 
 exports[`SFC compile <script setup> imports imports not used in <template> should not be exposed 1`] = `
 "import { defineComponent as _defineComponent } from 'vue'
-import { FooBar, FooBaz, FooQux, vMyDir, x, y, z, x$y, VAR, VAR2, VAR3, Last } from './x'
+import { FooBar, FooBaz, fooQux, vMyDir, x, y, z, x$y, VAR, VAR2, VAR3, Last } from './x'
         
 export default _defineComponent({
   setup(__props, { expose }) {
@@ -214,7 +214,7 @@ export default _defineComponent({
 
         const fooBar: FooBar = 1
         
-return { fooBar, FooBaz, FooQux, vMyDir, x, z, x$y, VAR, VAR3, Last }
+return { fooBar, FooBaz, fooQux, vMyDir, x, z, x$y, VAR, VAR3, Last }
 }
 
 })"

--- a/packages/compiler-sfc/__tests__/compileScript.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileScript.spec.ts
@@ -213,7 +213,7 @@ defineExpose({ foo: 123 })
     test('imports not used in <template> should not be exposed', () => {
       const { content } = compile(`
         <script setup lang="ts">
-        import { FooBar, FooBaz, FooQux, vMyDir, x, y, z, x$y, VAR, VAR2, VAR3, Last } from './x'
+        import { FooBar, FooBaz, fooQux, vMyDir, x, y, z, x$y, VAR, VAR2, VAR3, Last } from './x'
         const fooBar: FooBar = 1
         </script>
         <template>
@@ -233,7 +233,7 @@ defineExpose({ foo: 123 })
       // x$y: #4274 should escape special chars when creating Regex
       // VAR & VAR3: #4340 interpolations in tempalte strings
       expect(content).toMatch(
-        `return { fooBar, FooBaz, FooQux, vMyDir, x, z, x$y, VAR, VAR3, Last }`
+        `return { fooBar, FooBaz, fooQux, vMyDir, x, z, x$y, VAR, VAR3, Last }`
       )
       assertCode(content)
     })

--- a/packages/compiler-sfc/src/compileScript.ts
+++ b/packages/compiler-sfc/src/compileScript.ts
@@ -2212,7 +2212,7 @@ function resolveTemplateUsageCheckString(sfc: SFCDescriptor) {
             !parserOptions.isNativeTag!(node.tag) &&
             !parserOptions.isBuiltInComponent!(node.tag)
           ) {
-            code += `,${capitalize(camelize(node.tag))}`
+            code += `,${camelize(node.tag)}`
           }
           for (let i = 0; i < node.props.length; i++) {
             const prop = node.props[i]


### PR DESCRIPTION
fix: #4358 

Solve the following scene problems:
```vue
<script setup lang="ts">
import Test1 from './Test1.vue'
import test2 from './test2.vue'
</script>

<template>
  <h1 style="color: green">App.vue</h1>
  <Test1 />
  <test2 />
</template>
```
Here will change `test2` to `Test2`, caused the mismatch.
https://github.com/vuejs/vue-next/blob/03abc2573c9f6f98fffd357ce983a667c28a62d4/packages/compiler-sfc/src/compileScript.ts#L339-L340
