### PR TITLE
refactor(compiler-sfc): remove duplicate judgment conditions

### DIFF
--- a/packages/compiler-sfc/src/compileScript.ts
+++ b/packages/compiler-sfc/src/compileScript.ts
@@ -201,14 +201,12 @@ export function compileScript(
       let content = script.content
       if (cssVars.length) {
         content = rewriteDefault(content, `__default__`, plugins)
-        if (cssVars.length) {
-          content += genNormalScriptCssVarsCode(
-            cssVars,
-            bindings,
-            scopeId,
-            !!options.isProd
-          )
-        }
+        content += genNormalScriptCssVarsCode(
+          cssVars,
+          bindings,
+          scopeId,
+          !!options.isProd
+        )
         content += `\nexport default __default__`
       }
       return {


### PR DESCRIPTION
https://github.com/vuejs/vue-next/blob/57f10812cc7f1e9f6c92736c36aba577943996fd/packages/compiler-sfc/src/compileScript.ts#L202-L213
The judgment conditions on lines 202 and 204 are duplicated, remove duplicate  `cssVars.length`