### PR TITLE
refactor: use isString for type assertion

### DIFF
--- a/packages/compiler-core/__tests__/compile.spec.ts
+++ b/packages/compiler-core/__tests__/compile.spec.ts
@@ -1,5 +1,6 @@
 import { baseCompile as compile } from '../src'
 import { SourceMapConsumer, RawSourceMap } from 'source-map'
+import { isString } from '@vue/shared'
 
 describe('compiler: integration tests', () => {
   const source = `
@@ -39,7 +40,7 @@ describe('compiler: integration tests', () => {
           : generatedOffset - lastNewLinePos - 1
     }
     if (expectName) {
-      res.name = typeof expectName === 'string' ? expectName : token
+      res.name = isString(expectName) ? expectName : token
     }
     return res
   }

--- a/packages/compiler-sfc/__tests__/compileScript.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileScript.spec.ts
@@ -1,4 +1,5 @@
 import { BindingTypes } from '@vue/compiler-core'
+import { isString } from '@vue/shared'
 import { compileSFCScript as compile, assertCode } from './utils'
 
 describe('SFC compile <script setup>', () => {
@@ -930,7 +931,7 @@ const emit = defineEmits(['a', 'b'])
         expect(content).toMatch(`let __temp, __restore`)
       }
       expect(content).toMatch(`${shouldAsync ? `async ` : ``}setup(`)
-      if (typeof expected === 'string') {
+      if (isString(expected)) {
         expect(content).toMatch(expected)
       } else {
         expect(expected(content)).toBe(true)

--- a/packages/compiler-sfc/src/compileScript.ts
+++ b/packages/compiler-sfc/src/compileScript.ts
@@ -22,6 +22,7 @@ import {
   camelize,
   capitalize,
   generateCodeFrame,
+  isString,
   makeMap
 } from '@vue/shared'
 import {
@@ -1301,7 +1302,7 @@ export function compileScript(
         tips.forEach(warnOnce)
       }
       const err = errors[0]
-      if (typeof err === 'string') {
+      if (isString(err)) {
         throw new Error(err)
       } else if (err) {
         if (err.loc) {
@@ -1962,9 +1963,7 @@ function isCallOf(
     node &&
     node.type === 'CallExpression' &&
     node.callee.type === 'Identifier' &&
-    (typeof test === 'string'
-      ? node.callee.name === test
-      : test(node.callee.name))
+    (isString(test) ? node.callee.name === test : test(node.callee.name))
   )
 }
 

--- a/packages/compiler-sfc/src/cssVars.ts
+++ b/packages/compiler-sfc/src/cssVars.ts
@@ -10,9 +10,11 @@ import {
 import { SFCDescriptor } from './parse'
 import { PluginCreator } from 'postcss'
 import hash from 'hash-sum'
+import { isString } from '@vue/shared'
 
 export const CSS_VARS_HELPER = `useCssVars`
-export const cssVarRE = /\bv-bind\(\s*(?:'([^']+)'|"([^"]+)"|([^'"][^)]*))\s*\)/g
+export const cssVarRE =
+  /\bv-bind\(\s*(?:'([^']+)'|"([^"]+)"|([^'"][^)]*))\s*\)/g
 
 export function genCssVarsFromList(
   vars: string[],
@@ -89,9 +91,7 @@ export function genCssVarsCode(
       ? transformed.content
       : transformed.children
           .map(c => {
-            return typeof c === 'string'
-              ? c
-              : (c as SimpleExpressionNode).content
+            return isString(c) ? c : (c as SimpleExpressionNode).content
           })
           .join('')
 

--- a/packages/compiler-ssr/src/transforms/ssrTransformComponent.ts
+++ b/packages/compiler-ssr/src/transforms/ssrTransformComponent.ts
@@ -47,7 +47,7 @@ import {
   ssrTransformSuspense
 } from './ssrTransformSuspense'
 import { ssrProcessTransitionGroup } from './ssrTransformTransitionGroup'
-import { isSymbol, isObject, isArray } from '@vue/shared'
+import { isSymbol, isObject, isArray, isString } from '@vue/shared'
 
 // We need to construct the slot functions in the 1st pass to ensure proper
 // scope tracking, but the children of each slot cannot be processed until
@@ -210,7 +210,7 @@ export function ssrProcessComponent(
       node.ssrCodegenNode.arguments.push(`_scopeId`)
     }
 
-    if (typeof component === 'string') {
+    if (isString(component)) {
       // static component
       context.pushStatement(
         createCallExpression(`_push`, [node.ssrCodegenNode])

--- a/packages/compiler-ssr/src/transforms/ssrTransformElement.ts
+++ b/packages/compiler-ssr/src/transforms/ssrTransformElement.ts
@@ -32,6 +32,7 @@ import {
   escapeHtml,
   isBooleanAttr,
   isSSRSafeAttrName,
+  isString,
   NO,
   propsToAttrMap
 } from '@vue/shared'
@@ -354,7 +355,7 @@ function removeStaticBinding(
 ) {
   const regExp = new RegExp(`^ ${binding}=".+"$`)
 
-  const i = tag.findIndex(e => typeof e === 'string' && regExp.test(e))
+  const i = tag.findIndex(e => isString(e) && regExp.test(e))
 
   if (i > -1) {
     tag.splice(i, 1)

--- a/packages/runtime-core/__tests__/rendererChildren.spec.ts
+++ b/packages/runtime-core/__tests__/rendererChildren.spec.ts
@@ -8,9 +8,11 @@ import {
   serialize,
   serializeInner
 } from '@vue/runtime-test'
+import { isString } from '@vue/shared'
+
 function toSpan(content: any) {
-  if (typeof content === 'string') {
-    return h('span', content.toString())
+  if (isString(content)) {
+    return h('span', content)
   } else {
     return h('span', { key: content }, content.toString())
   }

--- a/packages/runtime-core/src/compat/global.ts
+++ b/packages/runtime-core/src/compat/global.ts
@@ -486,7 +486,7 @@ function installCompatMount(
       }
 
       let container: Element
-      if (typeof selectorOrEl === 'string') {
+      if (isString(selectorOrEl)) {
         // eslint-disable-next-line
         const result = document.querySelector(selectorOrEl)
         if (!result) {

--- a/packages/runtime-core/src/compat/renderFn.ts
+++ b/packages/runtime-core/src/compat/renderFn.ts
@@ -127,7 +127,7 @@ export function compatH(
   }
 
   // to support v2 string component name look!up
-  if (typeof type === 'string') {
+  if (isString(type)) {
     const t = hyphenate(type)
     if (t === 'transition' || t === 'transition-group' || t === 'keep-alive') {
       // since transition and transition-group are runtime-dom-specific,

--- a/packages/runtime-core/src/compat/renderHelpers.ts
+++ b/packages/runtime-core/src/compat/renderHelpers.ts
@@ -5,6 +5,7 @@ import {
   isArray,
   isObject,
   isReservedProp,
+  isString,
   normalizeClass
 } from '@vue/shared'
 import { ComponentInternalInstance } from '../component'
@@ -170,7 +171,7 @@ export function legacyMarkOnce(tree: VNode) {
 export function legacyBindDynamicKeys(props: any, values: any[]) {
   for (let i = 0; i < values.length; i += 2) {
     const key = values[i]
-    if (typeof key === 'string' && key) {
+    if (isString(key) && key) {
       props[values[i]] = values[i + 1]
     }
   }
@@ -178,5 +179,5 @@ export function legacyBindDynamicKeys(props: any, values: any[]) {
 }
 
 export function legacyPrependModifier(value: any, symbol: string) {
-  return typeof value === 'string' ? symbol + value : value
+  return isString(value) ? symbol + value : value
 }

--- a/packages/runtime-core/src/customFormatter.ts
+++ b/packages/runtime-core/src/customFormatter.ts
@@ -1,5 +1,12 @@
 import { isReactive, isReadonly, isRef, Ref, toRaw } from '@vue/reactivity'
-import { EMPTY_OBJ, extend, isArray, isFunction, isObject } from '@vue/shared'
+import {
+  EMPTY_OBJ,
+  extend,
+  isArray,
+  isFunction,
+  isObject,
+  isString
+} from '@vue/shared'
 import { ComponentInternalInstance, ComponentOptions } from './component'
 import { ComponentPublicInstance } from './componentPublicInstance'
 
@@ -139,7 +146,7 @@ export function initCustomFormatter() {
   function formatValue(v: unknown, asRaw = true) {
     if (typeof v === 'number') {
       return ['span', numberStyle, v]
-    } else if (typeof v === 'string') {
+    } else if (isString(v)) {
       return ['span', stringStyle, JSON.stringify(v)]
     } else if (typeof v === 'boolean') {
       return ['span', keywordStyle, v]

--- a/packages/runtime-dom/src/apiCustomElement.ts
+++ b/packages/runtime-dom/src/apiCustomElement.ts
@@ -21,7 +21,14 @@ import {
   ConcreteComponent,
   ComponentOptions
 } from '@vue/runtime-core'
-import { camelize, extend, hyphenate, isArray, toNumber } from '@vue/shared'
+import {
+  camelize,
+  extend,
+  hyphenate,
+  isArray,
+  isString,
+  toNumber
+} from '@vue/shared'
 import { hydrate, render } from '.'
 
 export type VueElementConstructor<P = {}> = {
@@ -269,7 +276,7 @@ export class VueElement extends BaseClass {
       if (shouldReflect) {
         if (val === true) {
           this.setAttribute(hyphenate(key), '')
-        } else if (typeof val === 'string' || typeof val === 'number') {
+        } else if (isString(val) || typeof val === 'number') {
           this.setAttribute(hyphenate(key), val + '')
         } else if (!val) {
           this.removeAttribute(hyphenate(key))

--- a/packages/server-renderer/src/helpers/ssrRenderSlot.ts
+++ b/packages/server-renderer/src/helpers/ssrRenderSlot.ts
@@ -1,6 +1,6 @@
 import { ComponentInternalInstance, Slots } from 'vue'
 import { Props, PushFn, renderVNodeChildren, SSRBufferItem } from '../render'
-import { isArray } from '@vue/shared'
+import { isArray, isString } from '@vue/shared'
 
 export type SSRSlots = Record<string, SSRSlot>
 export type SSRSlot = (
@@ -64,5 +64,5 @@ export function ssrRenderSlot(
 
 const commentRE = /^<!--.*-->$/
 function isComment(item: SSRBufferItem) {
-  return typeof item === 'string' && commentRE.test(item)
+  return isString(item) && commentRE.test(item)
 }


### PR DESCRIPTION
We have a `isString` function in _@vue/shared_, but at some places we still do type assertion by writing `typeof value === 'string'` repeatedly, so I refactor all code that looks like this.