### PR TITLE
fix(shared): normalize undefined styles to empty object

### DIFF
--- a/packages/shared/src/normalizeProp.ts
+++ b/packages/shared/src/normalizeProp.ts
@@ -1,4 +1,4 @@
-import { isArray, isString, isObject, hyphenate } from './'
+import { EMPTY_OBJ, isArray, isString, isObject, hyphenate } from './'
 import { isNoUnitNumericStyleProp } from './domAttrConfig'
 
 export type NormalizedStyle = Record<string, string | number>
@@ -24,6 +24,8 @@ export function normalizeStyle(
     return value
   } else if (isObject(value)) {
     return value
+  } else if (value == null) {
+    return EMPTY_OBJ
   }
 }
 


### PR DESCRIPTION
Currently, setting `v-bind:style` to a value that can compute to undefined will remove any styles on the element when it does return undefined. I ran into this issue when using `v-show` along with an `undefined` style binding.

This patch makes it so that the `normalizeStyle` function will convert undefined/null bindings to an empty object instead. I feel like this is a good place to add the check, but it is my first patch on this repo. If anyone can think of a better place to do this, I will change it.