### PR TITLE
fix(compiler-core): adding identifier on validAssetId if variable `name` has specific character

### DIFF
--- a/packages/compiler-core/__tests__/utils.spec.ts
+++ b/packages/compiler-core/__tests__/utils.spec.ts
@@ -2,7 +2,8 @@ import { Position } from '../src/ast'
 import {
   getInnerRange,
   advancePositionWithClone,
-  isMemberExpression
+  isMemberExpression,
+  toValidAssetId
 } from '../src/utils'
 
 function p(line: number, column: number, offset: number): Position {
@@ -106,4 +107,14 @@ test('isMemberExpression', () => {
   expect(isMemberExpression('foo()')).toBe(false)
   expect(isMemberExpression('a?b:c')).toBe(false)
   expect(isMemberExpression(`state['text'] = $event`)).toBe(false)
+})
+
+test('toValidAssetId', () => {
+  expect(toValidAssetId('foo', 'component')).toBe('_component_foo')
+  expect(toValidAssetId('p', 'directive')).toBe('_directive_p')
+  expect(toValidAssetId('div', 'filter')).toBe('_filter_div')
+  expect(toValidAssetId('foo-bar', 'component')).toBe('_component_foo_bar')
+  expect(toValidAssetId('test-测试-1', 'component')).toBe(
+    '_component_test_2797935797_1'
+  )
 })

--- a/packages/compiler-core/src/utils.ts
+++ b/packages/compiler-core/src/utils.ts
@@ -430,7 +430,10 @@ export function toValidAssetId(
   name: string,
   type: 'component' | 'directive' | 'filter'
 ): string {
-  return `_${type}_${name.replace(/[^\w]/g, '_')}`
+  // see issue#4422, we need adding identifier on validAssetId if variable `name` has specific character
+  return `_${type}_${name.replace(/[^\w]/g, (searchValue, replaceValue) => {
+    return searchValue === '-' ? '_' : name.charCodeAt(replaceValue).toString()
+  })}`
 }
 
 // Check if a node contains expressions that reference current context scope ids


### PR DESCRIPTION
see issue #4422  

If component name is not strict, the generated render function will not run. 
We can solve this edge case by adding an unique identifier on specific `validAssetId`.

Close #4422 