### PR TITLE
refactor(runtime-core): improve the type of defineAsyncComponent

### DIFF
--- a/packages/runtime-core/src/apiAsyncComponent.ts
+++ b/packages/runtime-core/src/apiAsyncComponent.ts
@@ -206,7 +206,7 @@ export function defineAsyncComponent<
         }
       }
     }
-  }) as any
+  }) as T
 }
 
 function createInnerComp(


### PR DESCRIPTION
At the definition of this function, we wanna the type of the return value of this function is `T`. So I change the type assertion from `any` to `T`.