### PR TITLE
fix: misuse Dom's Comment element constructor as a vnode type

### DIFF
--- a/packages/runtime-core/src/components/Suspense.ts
+++ b/packages/runtime-core/src/components/Suspense.ts
@@ -88,9 +88,7 @@ export const SuspenseImpl = {
 }
 
 // Force-casted public typing for h and TSX props inference
-export const Suspense = ((__FEATURE_SUSPENSE__
-  ? SuspenseImpl
-  : null) as any) as {
+export const Suspense = (__FEATURE_SUSPENSE__ ? SuspenseImpl : null) as any as {
   __isSuspense: true
   new (): { $props: VNodeProps & SuspenseProps }
 }
@@ -521,13 +519,8 @@ function createSuspenseBoundary(
         return
       }
 
-      const {
-        vnode,
-        activeBranch,
-        parentComponent,
-        container,
-        isSVG
-      } = suspense
+      const { vnode, activeBranch, parentComponent, container, isSVG } =
+        suspense
 
       // invoke @fallback event
       triggerEvent(vnode, 'onFallback')

--- a/packages/runtime-core/src/components/Suspense.ts
+++ b/packages/runtime-core/src/components/Suspense.ts
@@ -6,6 +6,7 @@ import {
   openBlock,
   closeBlock,
   currentBlock,
+  Comment,
   createVNode
 } from '../vnode'
 import { isFunction, isArray, ShapeFlags, toNumber } from '@vue/shared'
@@ -87,7 +88,9 @@ export const SuspenseImpl = {
 }
 
 // Force-casted public typing for h and TSX props inference
-export const Suspense = (__FEATURE_SUSPENSE__ ? SuspenseImpl : null) as any as {
+export const Suspense = ((__FEATURE_SUSPENSE__
+  ? SuspenseImpl
+  : null) as any) as {
   __isSuspense: true
   new (): { $props: VNodeProps & SuspenseProps }
 }
@@ -518,8 +521,13 @@ function createSuspenseBoundary(
         return
       }
 
-      const { vnode, activeBranch, parentComponent, container, isSVG } =
-        suspense
+      const {
+        vnode,
+        activeBranch,
+        parentComponent,
+        container,
+        isSVG
+      } = suspense
 
       // invoke @fallback event
       triggerEvent(vnode, 'onFallback')


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9816225/130937499-b51ceb4f-0038-4a5b-8ca7-834bbd5be4f1.png)


We want to create a commet node  at [here](https://github.com/vuejs/vue-next/pull/4451/files#diff-069bd39ee093a8545c4e26aa7264c6ba4561a28f07f3d7d7080f4c0f71710281L723) but forget to import the `Comment` symbol. The Comment constructor from dom has been used, then we get the error:

![image](https://user-images.githubusercontent.com/9816225/130938806-e2368fd7-d5a0-4467-8bd5-1bceb294a0aa.png)
