### PR TITLE
fix(build): build vue-compat in default exports mode

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -81,7 +81,8 @@ function createConfig(format, output, plugins = []) {
     process.exit(1)
   }
 
-  output.exports = 'named'
+  const isCompatBuild = !!packageOptions.compat
+  output.exports = isCompatBuild ? 'default' : 'named'
   output.sourcemap = !!process.env.SOURCE_MAP
   output.externalLiveBindings = false
 
@@ -91,7 +92,6 @@ function createConfig(format, output, plugins = []) {
   const isBrowserESMBuild = /esm-browser/.test(format)
   const isNodeBuild = format === 'cjs'
   const isGlobalBuild = /global/.test(format)
-  const isCompatBuild = !!packageOptions.compat
   const isCompatPackage = pkg.name === '@vue/compat'
 
   if (isGlobalBuild) {


### PR DESCRIPTION
https://github.com/vuejs/vue-next/commit/f2fb8a51a95ec28f34267c6e0ea85b30810409ea introduced change in rollup configuration  - `output.exports` for all packages was swapped from `auto` to `named` (to avoid warnings, I assume). Unfortunately this [broke](https://github.com/vuejs/vue-test-utils-next/runs/3437177804?check_suite_focus=true#step:7:12) `vue-compat` commonJS package where single default export is **expected** to be spreaded so `@vue/compat` will be a drop-in replacement for `vue`. 

Now, for example, when you require `@vue/compat` in node.js environment (for example when running vue-test-utils) you need to access `defineComponent` as `require('@vue/compat').default.defineComponent` instead of `require('@vue/compat').defineComponent`

Since `@vue/compat` is expected to serve as "drop-in" replacement for `vue` this PR is forcing `output.expots = default` for `vue-compat` package which is exactly the expected case - rollup expects single default export 