### PR TITLE
chore: set node engine to v16

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     ]
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=16.5.0"
   },
   "devDependencies": {
     "@babel/types": "^7.12.0",


### PR DESCRIPTION
As some packages rely on the experimental "stream/web" package only available in node v16.5+,
this commit updates the `engines` property to reflect that.

https://nodejs.org/en/blog/release/v16.5.0/