### PR TITLE
fix(compiler): pick last char when dynamic directive doesn't close

### DIFF
--- a/packages/compiler-core/__tests__/__snapshots__/parse.spec.ts.snap
+++ b/packages/compiler-core/__tests__/__snapshots__/parse.spec.ts.snap
@@ -6260,7 +6260,7 @@ Object {
         Object {
           "arg": Object {
             "constType": 0,
-            "content": "se",
+            "content": "sef",
             "isStatic": false,
             "loc": Object {
               "end": Object {

--- a/packages/compiler-core/src/parse.ts
+++ b/packages/compiler-core/src/parse.ts
@@ -814,9 +814,10 @@ function parseAttribute(
             context,
             ErrorCodes.X_MISSING_DYNAMIC_DIRECTIVE_ARGUMENT_END
           )
+          content = content.substr(1)
+        } else {
+          content = content.substr(1, content.length - 2)
         }
-
-        content = content.substr(1, content.length - 2)
       } else if (isSlot) {
         // #1241 special case for v-slot: vuetify relies extensively on slot
         // names containing dots. v-slot doesn't have any modifiers and Vue 2.x


### PR DESCRIPTION
Example: 
`<div :[miss="exp"/>` compiles to `[mis]` instead of `[miss]`

[Vue template compiler link](https://vue-next-template-explorer.netlify.app/#%7B%22src%22%3A%22%3Cdiv%20%5B%20%3A%5Bmiss%3D%5C%22exp%5C%22%2F%3E%22%2C%22ssr%22%3Afalse%2C%22options%22%3A%7B%22mode%22%3A%22function%22%2C%22filename%22%3A%22Foo.vue%22%2C%22prefixIdentifiers%22%3Afalse%2C%22hoistStatic%22%3Afalse%2C%22cacheHandlers%22%3Afalse%2C%22scopeId%22%3Anull%2C%22inline%22%3Atrue%2C%22ssrCssVars%22%3A%22%7B%20color%20%7D%22%2C%22compatConfig%22%3A%7B%22MODE%22%3A3%7D%2C%22whitespace%22%3A%22condense%22%2C%22bindingMetadata%22%3A%7B%22TestComponent%22%3A%22setup%22%2C%22foo%22%3A%22setup%22%2C%22bar%22%3A%22props%22%7D%2C%22optimizeImports%22%3Afalse%7D%7D)

![image](https://user-images.githubusercontent.com/2883231/131967478-0a95fd9a-fafe-48cb-907e-8881bbc86d0d.png)

