### PR TITLE
fix: Ref transform being applied to variables named `hasOwnProperty`.

### DIFF
--- a/packages/ref-transform/src/refTransform.ts
+++ b/packages/ref-transform/src/refTransform.ts
@@ -310,7 +310,7 @@ export function transformAST(
     parentStack: Node[]
   ): boolean {
     if (id.name in scope) {
-      if (scope[id.name]) {
+      if (scope[id.name] === true) {
         if (isStaticProperty(parent) && parent.shorthand) {
           // let binding used in a property shorthand
           // { foo } -> { foo: foo.value }


### PR DESCRIPTION
Given the variable `var hasOwnProperty = Object.prototype.hasOwnProperty` running through the transformer will result in

https://github.com/vuejs/vue-next/blob/master/packages/ref-transform/src/refTransform.ts#L313
`id.name` being `hasOwnProperty` which will return truthy for all objects. So instead we check for strict equality. We will only get properties flagged `true` in the scope passing through to be transformed.

This problem is blowing up all applications when using `refTransform: true` as @vue/shared is doing this exact thing here
https://github.com/vuejs/vue-next/blob/master/packages/shared/src/index.ts#L54

When running vite in dev mode the line below is being transformed to
```
var hasOwn = (val, key) => hasOwnProperty.value.call(val, key);
```

This small update will fix that.