### PR TITLE
fix(compiler-sfc): destructure StringLiteral key not register bindings (fix #4540)

### DIFF
--- a/packages/compiler-sfc/src/compileScript.ts
+++ b/packages/compiler-sfc/src/compileScript.ts
@@ -1347,8 +1347,8 @@ function walkObjectPattern(
 ) {
   for (const p of node.properties) {
     if (p.type === 'ObjectProperty') {
-      // key can only be Identifier in ObjectPattern
-      if (p.key.type === 'Identifier') {
+      // key can be Identifier in ObjectPattern or StringLiteral
+      if (p.key.type === 'Identifier' || p.key.type === 'StringLiteral') {
         if (p.key === p.value) {
           // const { x } = ...
           const type = isDefineCall


### PR DESCRIPTION
|   | Before Fix #4540  | After Fix #4540 |
|---|---|---|
| Screenshot | ![image](https://user-images.githubusercontent.com/14243906/132676937-0136476f-832b-48a5-88c5-24fffad6baab.png) | ![image](https://user-images.githubusercontent.com/14243906/132677145-763809f2-4a71-472f-8a4e-62df91b57a55.png)



