### PR TITLE
fix(compiler-core): dedupe renderSlot's default props

### DIFF
--- a/packages/compiler-core/__tests__/transforms/transformSlotOutlet.spec.ts
+++ b/packages/compiler-core/__tests__/transforms/transformSlotOutlet.spec.ts
@@ -346,6 +346,26 @@ describe('compiler: transform <slot> outlets', () => {
       callee: RENDER_SLOT,
       arguments: [`$slots`, `"default"`, `{}`, `undefined`, `true`]
     })
+    const fallback = parseWithSlots(`<slot>fallback</slot>`, {
+      slotted: false,
+      scopeId: 'foo'
+    })
+
+    const child = {
+      type: NodeTypes.JS_FUNCTION_EXPRESSION,
+      params: [],
+      returns: [
+        {
+          type: NodeTypes.TEXT,
+          content: `fallback`
+        }
+      ]
+    }
+    expect((fallback.children[0] as ElementNode).codegenNode).toMatchObject({
+      type: NodeTypes.JS_CALL_EXPRESSION,
+      callee: RENDER_SLOT,
+      arguments: [`$slots`, `"default"`, `{}`, child, `true`]
+    })
   })
 
   test(`error on unexpected custom directive on <slot>`, () => {

--- a/packages/compiler-core/src/transforms/transformSlotOutlet.ts
+++ b/packages/compiler-core/src/transforms/transformSlotOutlet.ts
@@ -20,29 +20,27 @@ export const transformSlotOutlet: NodeTransform = (node, context) => {
 
     const slotArgs: CallExpression['arguments'] = [
       context.prefixIdentifiers ? `_ctx.$slots` : `$slots`,
-      slotName
+      slotName,
+      '{}',
+      'undefined',
+      'true'
     ]
+    let expectedLen = 2
 
     if (slotProps) {
-      slotArgs.push(slotProps)
+      slotArgs[2] = slotProps
+      expectedLen = 3
     }
 
     if (children.length) {
-      if (!slotProps) {
-        slotArgs.push(`{}`)
-      }
-      slotArgs.push(createFunctionExpression([], children, false, false, loc))
+      slotArgs[3] = createFunctionExpression([], children, false, false, loc)
+      expectedLen = 4
     }
 
     if (context.scopeId && !context.slotted) {
-      if (!slotProps) {
-        slotArgs.push(`{}`)
-      }
-      if (!children.length) {
-        slotArgs.push(`undefined`)
-      }
-      slotArgs.push(`true`)
+      expectedLen = 5
     }
+    slotArgs.splice(expectedLen) // remove unused arguments
 
     node.codegenNode = createCallExpression(
       context.helper(RENDER_SLOT),


### PR DESCRIPTION
This patch fix the duplicated default props in`renderSlot` code generation and simplifies the logic by splicing a default argument array.

[Minimal reproduction](https://sfc.vuejs.org/#eyJBcHAudnVlIjoiPHRlbXBsYXRlPlxuICA8c2xvdD5mYWxsYmFjazwvc2xvdD5cbjwvdGVtcGxhdGU+XG48c3R5bGUgc2NvcGVkPnB7fTwvc3R5bGU+IiwiaW1wb3J0LW1hcC5qc29uIjoie1xuICBcImltcG9ydHNcIjoge31cbn0ifQ==)

`renderSlot` takes at most 5 arguments but the compiler generates 6. 
![image](https://user-images.githubusercontent.com/2883231/132884818-16e9c697-78d1-401a-acd1-a1c1e9180df3.png)

Note the last argument `true` should follow immediately after the fallback function. 

![image](https://user-images.githubusercontent.com/2883231/132885552-b51a93f0-62ce-4d50-b49c-4c1017f46f7a.png)

It looks like an accidental bug that default `slotProps` is pushed twice when children are defined and SFC has no slotted selector. 

![image](https://user-images.githubusercontent.com/2883231/132885694-7c00db82-994b-4345-9f83-1da415d2c2d4.png)

Instead we can provide a default arg array, set arguments in their position if defined, and finally splice the array to remove unused args.