### PR TITLE
fix(suspense): avoid set dynamicChildren if block is empty

### DIFF
--- a/packages/runtime-core/src/components/Suspense.ts
+++ b/packages/runtime-core/src/components/Suspense.ts
@@ -750,7 +750,7 @@ function normalizeSuspenseSlot(s: any) {
     s = singleChild
   }
   s = normalizeVNode(s)
-  if (block && !s.dynamicChildren) {
+  if (block && block.length && !s.dynamicChildren) {
     s.dynamicChildren = block.filter(c => c !== s)
   }
   return s


### PR DESCRIPTION
fix #4556