### PR TITLE
fix(watch): remove redundant parameter default value

### DIFF
--- a/packages/runtime-core/src/apiWatch.ts
+++ b/packages/runtime-core/src/apiWatch.ts
@@ -428,7 +428,7 @@ export function createPathGetter(ctx: any, path: string) {
   }
 }
 
-export function traverse(value: unknown, seen: Set<unknown> = new Set()) {
+export function traverse(value: unknown, seen?: Set<unknown>) {
   if (!isObject(value) || (value as any)[ReactiveFlags.SKIP]) {
     return value
   }


### PR DESCRIPTION
Ref: https://github.com/vuejs/vue-next/commit/2937530beff5c6bb57286c2556307859e37aa809#diff-59e3ee98b310f26c42283eaed3c0d4b53eee884d097d9fa89b7e1b546453b411

Actually, I'm not sure the thoughts behind the above refactoring, my guess is to delay initialization for better performance. If so, this PR is necessary.