### PR TITLE
fix(compiler-core): only merge true handlers

### DIFF
--- a/packages/compiler-core/src/transforms/transformElement.ts
+++ b/packages/compiler-core/src/transforms/transformElement.ts
@@ -806,7 +806,7 @@ function dedupeProperties(properties: Property[]): Property[] {
     const name = prop.key.content
     const existing = knownProps.get(name)
     if (existing) {
-      if (name === 'style' || name === 'class' || name.startsWith('on')) {
+      if (name === 'style' || name === 'class' || isOn(name)) {
         mergeAsArray(existing, prop)
       }
       // unexpected duplicate, should have emitted error during parse


### PR DESCRIPTION
[Minimal Repro](https://sfc.vuejs.org/#eyJBcHAudnVlIjoiPHNjcmlwdCBzZXR1cD5cbmxldCBmID0gKCkgPT4gYWxlcnQoXCJjYWxsZWRcIilcbjwvc2NyaXB0PlxuPHRlbXBsYXRlPlxuICA8cCBvbmNsaWNrPVwiZlwiIDpvbmNsaWNrPVwiZlwiIHYtYmluZDpvbmNsaWNrPVwiZlwiPiBvbmNsaWNrPC9wPlxuICA8cCBvbkNsaWNrPVwiZlwiIDpvbkNsaWNrPVwiZlwiIHYtYmluZDpvbkNsaWNrPVwiZlwiPm9uQ2xpY2s8L3A+XG48L3RlbXBsYXRlPiIsImltcG9ydC1tYXAuanNvbiI6IntcbiAgXCJpbXBvcnRzXCI6IHt9XG59In0=)

Users can provide :onClick as event handler since vnode structure is flat. However, only /^on[^a-z]/ is accepted as event pros and props like `onclick` are bogus.
This fix makes dedupeProperties consistent with the runtime.