### PR TITLE
fix(compiler-sfc): #4581 getImportsExpressionExp with hash

### DIFF
--- a/packages/compiler-sfc/src/templateTransformAssetUrl.ts
+++ b/packages/compiler-sfc/src/templateTransformAssetUrl.ts
@@ -2,6 +2,7 @@ import path from 'path'
 import {
   ConstantTypes,
   createSimpleExpression,
+  SimpleExpressionNode,
   ExpressionNode,
   NodeTransform,
   NodeTypes,
@@ -154,17 +155,17 @@ function getImportsExpressionExp(
 ): ExpressionNode {
   if (path) {
     const existing = context.imports.find(i => i.path === path)
+    let exp: SimpleExpressionNode
+    let name: string
     if (existing) {
-      return existing.exp as ExpressionNode
+      exp = existing.exp as SimpleExpressionNode
+      name = exp.content
+    } else {
+      name = `_imports_${context.imports.length}`
+      exp = createSimpleExpression(name, false, loc, ConstantTypes.CAN_HOIST)
+      context.imports.push({ exp, path })
     }
-    const name = `_imports_${context.imports.length}`
-    const exp = createSimpleExpression(
-      name,
-      false,
-      loc,
-      ConstantTypes.CAN_HOIST
-    )
-    context.imports.push({ exp, path })
+
     if (hash && path) {
       return context.hoist(
         createSimpleExpression(


### PR DESCRIPTION
Fixes #4581 

Subsequent calls with an url already in the import cache
and with a hash returns the correct expression including each time the
hash if one.

NOTE: this relies on the fact that `exp.content` is assigned the variable `name`, since it's the only way to get it back from the cache.