### PR TITLE
fix(compile-sfc):  add symbol judge in prop type checks.

### DIFF
--- a/packages/compiler-sfc/__tests__/__snapshots__/compileScript.spec.ts.snap
+++ b/packages/compiler-sfc/__tests__/__snapshots__/compileScript.spec.ts.snap
@@ -971,6 +971,7 @@ export default /*#__PURE__*/_defineComponent({
     interface: { type: Object, required: true },
     alias: { type: Array, required: true },
     method: { type: Function, required: true },
+    symbol: { type: Symbol, required: true },
     union: { type: [String, Number], required: true },
     literalUnion: { type: String, required: true },
     literalUnionNumber: { type: Number, required: true },

--- a/packages/compiler-sfc/__tests__/compileScript.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileScript.spec.ts
@@ -706,6 +706,7 @@ const emit = defineEmits(['a', 'b'])
         interface: Test
         alias: Alias
         method(): void
+        symbol: symbol
 
         union: string | number
         literalUnion: 'foo' | 'bar'
@@ -735,6 +736,7 @@ const emit = defineEmits(['a', 'b'])
       expect(content).toMatch(`interface: { type: Object, required: true }`)
       expect(content).toMatch(`alias: { type: Array, required: true }`)
       expect(content).toMatch(`method: { type: Function, required: true }`)
+      expect(content).toMatch(`symbol: { type: Symbol, required: true }`)
       expect(content).toMatch(
         `union: { type: [String, Number], required: true }`
       )
@@ -767,6 +769,7 @@ const emit = defineEmits(['a', 'b'])
         interface: BindingTypes.PROPS,
         alias: BindingTypes.PROPS,
         method: BindingTypes.PROPS,
+        symbol: BindingTypes.PROPS,
         union: BindingTypes.PROPS,
         literalUnion: BindingTypes.PROPS,
         literalUnionNumber: BindingTypes.PROPS,

--- a/packages/compiler-sfc/src/compileScript.ts
+++ b/packages/compiler-sfc/src/compileScript.ts
@@ -1541,6 +1541,9 @@ function inferRuntimeType(
     case 'TSIntersectionType':
       return ['Object']
 
+    case 'TSSymbolKeyword':
+      return ['Symbol']
+
     default:
       return [`null`] // no runtime check
   }


### PR DESCRIPTION
fix: #4592 