### PR TITLE
fix(compiler-sfc): shouldn't add `;` when use top level await with si…

### DIFF
--- a/packages/compiler-sfc/__tests__/compileScript.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileScript.spec.ts
@@ -1118,6 +1118,14 @@ const emit = defineEmits(['a', 'b'])
         false
       )
     })
+
+    test('if statement with expression statement consequent type', () => {
+      assertAwaitDetection(`if (ok) await foo`, code => {
+        return code.includes(
+          `if (ok) (([__temp,__restore]=_withAsyncContext(()=>(foo))),__temp=await __temp,__restore(),__temp)`
+        )
+      })
+    })
   })
 
   describe('errors', () => {

--- a/packages/compiler-sfc/src/compileScript.ts
+++ b/packages/compiler-sfc/src/compileScript.ts
@@ -913,13 +913,9 @@ export function compileScript(
       (node.type === 'VariableDeclaration' && !node.declare) ||
       node.type.endsWith('Statement')
     ) {
-      let isIfExpStmt = false
-      if (
+      const isIfExpStmt =
         node.type === 'IfStatement' &&
         node.consequent.type === 'ExpressionStatement'
-      ) {
-        isIfExpStmt = true
-      }
       ;(walk as any)(node, {
         enter(child: Node, parent: Node) {
           if (isFunctionType(child)) {

--- a/packages/compiler-sfc/src/compileScript.ts
+++ b/packages/compiler-sfc/src/compileScript.ts
@@ -913,6 +913,13 @@ export function compileScript(
       (node.type === 'VariableDeclaration' && !node.declare) ||
       node.type.endsWith('Statement')
     ) {
+      let isIfExpStmt = false
+      if (
+        node.type === 'IfStatement' &&
+        node.consequent.type === 'ExpressionStatement'
+      ) {
+        isIfExpStmt = true
+      }
       ;(walk as any)(node, {
         enter(child: Node, parent: Node) {
           if (isFunctionType(child)) {
@@ -920,7 +927,10 @@ export function compileScript(
           }
           if (child.type === 'AwaitExpression') {
             hasAwait = true
-            processAwait(child, parent.type === 'ExpressionStatement')
+            processAwait(
+              child,
+              parent.type === 'ExpressionStatement' && !isIfExpStmt
+            )
           }
         }
       })


### PR DESCRIPTION
fix #4596 