### PR TITLE
fix(runtime-core): return the exposeProxy from mount

### DIFF
--- a/packages/runtime-core/__tests__/apiExpose.spec.ts
+++ b/packages/runtime-core/__tests__/apiExpose.spec.ts
@@ -1,4 +1,4 @@
-import { nodeOps, render } from '@vue/runtime-test'
+import { createApp, nodeOps, render } from '@vue/runtime-test'
 import { defineComponent, h, ref } from '../src'
 
 describe('api: expose', () => {
@@ -168,6 +168,26 @@ describe('api: expose', () => {
     })
     const root = nodeOps.createElement('div')
     render(h(Parent), root)
+  })
+
+  test('with mount', () => {
+    const Component = defineComponent({
+      setup(_, { expose }) {
+        expose({
+          foo: 1
+        })
+        return {
+          bar: 2
+        }
+      },
+      render() {
+        return h('div')
+      }
+    })
+    const root = nodeOps.createElement('div')
+    const vm = createApp(Component).mount(root) as any
+    expect(vm.foo).toBe(1)
+    expect(vm.bar).toBe(undefined)
   })
 
   test('expose should allow access to built-in instance properties', () => {

--- a/packages/runtime-core/src/apiCreateApp.ts
+++ b/packages/runtime-core/src/apiCreateApp.ts
@@ -3,7 +3,8 @@ import {
   Data,
   validateComponentName,
   Component,
-  ComponentInternalInstance
+  ComponentInternalInstance,
+  getExposeProxy
 } from './component'
 import {
   ComponentOptions,
@@ -309,7 +310,7 @@ export function createAppAPI<HostElement>(
             devtoolsInitApp(app, version)
           }
 
-          return vnode.component!.proxy
+          return getExposeProxy(vnode.component!) || vnode.component!.proxy
         } else if (__DEV__) {
           warn(
             `App has already been mounted.\n` +


### PR DESCRIPTION
When using `expose` or `defineExpose`, the 'public' instance (`exposeProxy`) is used for template refs, `$parent` and `$root`. The instance returned by `mount` is currently still the internal instance.

```js
const vm = createApp({
  setup(_, { expose }) {
    expose({ a: 1 })
    return () => h('div')
  }
}).mount('#app')

console.log(vm.a) // undefined as vm is the internal instance
```

This PR changes `mount` to return the `exposeProxy`.

I couldn't find any mention of `mount` in either the RFC or the associated discussion thread:

* RFC: https://github.com/vuejs/rfcs/blob/master/active-rfcs/0042-expose-api.md
* Discussion: https://github.com/vuejs/rfcs/discussions/345

I'm assuming it was simply overlooked, but if there is a good reason why `mount` should return the internal instance then it should probably be added to that thread.

I'm not sure whether this might impact tooling or testing, which *might* be relying on using `mount` to get to the internals of a `<script setup>` component. While I wouldn't necessarily call this a 'breaking change', I think it might be considered breaking enough to need to wait for 3.3.