### PR TITLE
fix(compiler-sfc): Handle empty strings during template usage analysis of setup bindings. (fix #4599)

### DIFF
--- a/packages/compiler-sfc/__tests__/__snapshots__/compileScript.spec.ts.snap
+++ b/packages/compiler-sfc/__tests__/__snapshots__/compileScript.spec.ts.snap
@@ -202,6 +202,22 @@ return { props, a, emit }
 }"
 `;
 
+exports[`SFC compile <script setup> dev mode import usage check attribute expressions 1`] = `
+"import { defineComponent as _defineComponent } from 'vue'
+import { bar, baz } from './x'
+        
+export default /*#__PURE__*/_defineComponent({
+  setup(__props, { expose }) {
+  expose()
+
+        const cond = true
+        
+return { cond, bar, baz }
+}
+
+})"
+`;
+
 exports[`SFC compile <script setup> dev mode import usage check components 1`] = `
 "import { defineComponent as _defineComponent } from 'vue'
 import { FooBar, FooBaz, FooQux, foo } from './x'

--- a/packages/compiler-sfc/__tests__/compileScript.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileScript.spec.ts
@@ -350,7 +350,7 @@ defineExpose({ foo: 123 })
         const cond = true
         </script>
         <template>
-          <div :class="[cond ? '' ? bar() : 'default']" :style="baz"></div>
+          <div :class="[cond ? '' : bar(), 'default']" :style="baz"></div>
         </template>
         `)
       expect(content).toMatch(`return { cond, bar, baz }`)

--- a/packages/compiler-sfc/__tests__/compileScript.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileScript.spec.ts
@@ -342,6 +342,21 @@ defineExpose({ foo: 123 })
       assertCode(content)
     })
 
+    // https://github.com/vuejs/vue-next/issues/4599
+    test('attribute expressions', () => {
+      const { content } = compile(`
+        <script setup lang="ts">
+        import { bar, baz } from './x'
+        const cond = true
+        </script>
+        <template>
+          <div :class="[cond ? '' ? bar() : 'default']" :style="baz"></div>
+        </template>
+        `)
+      expect(content).toMatch(`return { cond, bar, baz }`)
+      assertCode(content)
+    })
+
     test('vue interpolations', () => {
       const { content } = compile(`
       <script setup lang="ts">

--- a/packages/compiler-sfc/src/compileScript.ts
+++ b/packages/compiler-sfc/src/compileScript.ts
@@ -1823,7 +1823,7 @@ function resolveTemplateUsageCheckString(sfc: SFCDescriptor) {
 
 function stripStrings(exp: string) {
   return exp
-    .replace(/'[^']+'|"[^"]+"/g, '')
+    .replace(/'[^']*'|"[^"]*"/g, '')
     .replace(/`[^`]+`/g, stripTemplateString)
 }
 


### PR DESCRIPTION
empty strings could trip up usage detection in templates during `script setup` compilation.

fix #4599