### PR TITLE
chore: fix warning in ref-transform

### DIFF
--- a/packages/ref-transform/src/refTransform.ts
+++ b/packages/ref-transform/src/refTransform.ts
@@ -466,6 +466,6 @@ function warnOnce(msg: string) {
 
 function warn(msg: string) {
   console.warn(
-    `\x1b[1m\x1b[33m[@vue/compiler-sfc]\x1b[0m\x1b[33m ${msg}\x1b[0m\n`
+    `\x1b[1m\x1b[33m[@vue/ref-transform]\x1b[0m\x1b[33m ${msg}\x1b[0m\n`
   )
 }


### PR DESCRIPTION
Although It is integrated in @vue/compiler-sfc.

But the package can be used standalone as a low-level library.

So I think it's better to warn by @vue/ref-transform.