### PR TITLE
fix(compiler-core): no prefixing on attribute key

### DIFF
--- a/packages/compiler-core/__tests__/transforms/vFor.spec.ts
+++ b/packages/compiler-core/__tests__/transforms/vFor.spec.ts
@@ -638,6 +638,26 @@ describe('compiler: v-for', () => {
         })
       })
     })
+
+    test('template v-for key no prefixing on attribute key', () => {
+      const {
+        node: { codegenNode }
+      } = parseWithForTransform(
+        '<template v-for="item in items" key="key">test</template>',
+        { prefixIdentifiers: true }
+      )
+      const innerBlock = codegenNode.children.arguments[1].returns
+      expect(innerBlock).toMatchObject({
+        type: NodeTypes.VNODE_CALL,
+        tag: FRAGMENT,
+        props: createObjectMatcher({
+          key: {
+            type: NodeTypes.SIMPLE_EXPRESSION,
+            content: 'key'
+          }
+        })
+      })
+    })
   })
 
   describe('codegen', () => {

--- a/packages/compiler-core/src/transforms/vFor.ts
+++ b/packages/compiler-core/src/transforms/vFor.ts
@@ -68,7 +68,12 @@ export const transformFor = createStructuralDirectiveTransform(
           : keyProp.exp!)
       const keyProperty = keyProp ? createObjectProperty(`key`, keyExp!) : null
 
-      if (!__BROWSER__ && context.prefixIdentifiers && keyProperty) {
+      if (
+        !__BROWSER__ &&
+        context.prefixIdentifiers &&
+        keyProperty &&
+        keyProp!.type !== NodeTypes.ATTRIBUTE
+      ) {
         // #2085 process :key expression needs to be processed in order for it
         // to behave consistently for <template v-for> and <div v-for>.
         // In the case of `<template v-for>`, the node is discarded and never


### PR DESCRIPTION
` <template v-for="a in b" key="c"/>` should treat the `key` property as static string. But currently it is compiled to `_ctx.c` like expression.

[reproduction link](https://sfc.vuejs.org/#eyJBcHAudnVlIjoiPHRlbXBsYXRlPlxuICA8dGVtcGxhdGUgdi1mb3I9XCJhIGluIGJcIiBrZXk9XCJjXCI+XG4gICAgPHAvPlxuICA8L3RlbXBsYXRlPlxuPC90ZW1wbGF0ZT4iLCJpbXBvcnQtbWFwLmpzb24iOiJ7XG4gIFwiaW1wb3J0c1wiOiB7XG4gICAgXCJ2dWVcIjogXCJodHRwczovL3NmYy52dWVqcy5vcmcvdnVlLnJ1bnRpbWUuZXNtLWJyb3dzZXIuanNcIlxuICB9XG59In0=)

![image](https://user-images.githubusercontent.com/2883231/134453711-2af6ed9b-6938-440c-822e-f5053f53f451.png)
