### PR TITLE
chore(vue): package `index.mjs`

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -9,6 +9,7 @@
   "jsdelivr": "dist/vue.global.js",
   "files": [
     "index.js",
+    "index.mjs",
     "dist",
     "compiler-sfc",
     "server-renderer",


### PR DESCRIPTION
After https://github.com/vuejs/vue-next/commit/570c955b4896db2e0deb46d3eb30bbc9eba7747b we now have a root-level `index.mjs`. But it's [not packaged](https://unpkg.com/browse/vue@3.2.18/) as it needs to be added to `files` array.

resolves https://github.com/vuejs/vue-next/issues/4677