### PR TITLE
chore: remove deprecated String.prototype.substr

### DIFF
--- a/packages/compiler-core/__tests__/utils.spec.ts
+++ b/packages/compiler-core/__tests__/utils.spec.ts
@@ -56,14 +56,6 @@ describe('getInnerRange', () => {
     expect(loc2.end.offset).toBe(4)
   })
 
-  test('at end', () => {
-    const loc2 = getInnerRange(loc1, 4)
-    expect(loc2.start.column).toBe(1)
-    expect(loc2.start.line).toBe(2)
-    expect(loc2.start.offset).toBe(4)
-    expect(loc2.end).toEqual(loc1.end)
-  })
-
   test('in between', () => {
     const loc2 = getInnerRange(loc1, 4, 3)
     expect(loc2.start.column).toBe(1)

--- a/packages/compiler-core/src/parse.ts
+++ b/packages/compiler-core/src/parse.ts
@@ -825,9 +825,9 @@ function parseAttribute(
             context,
             ErrorCodes.X_MISSING_DYNAMIC_DIRECTIVE_ARGUMENT_END
           )
-          content = content.substring(1)
+          content = content.slice(1)
         } else {
-          content = content.substring(1, content.length - 1)
+          content = content.slice(1, content.length - 1)
         }
       } else if (isSlot) {
         // #1241 special case for v-slot: vuetify relies extensively on slot
@@ -855,7 +855,7 @@ function parseAttribute(
       valueLoc.source = valueLoc.source.slice(1, -1)
     }
 
-    const modifiers = match[3] ? match[3].substring(1).split('.') : []
+    const modifiers = match[3] ? match[3].slice(1).split('.') : []
     if (isPropShorthand) modifiers.push('prop')
 
     // 2.x compat v-bind:foo.sync -> v-model:foo
@@ -1167,7 +1167,7 @@ function isEnd(
 function startsWithEndTagOpen(source: string, tag: string): boolean {
   return (
     startsWith(source, '</') &&
-    source.substring(2, 2 + tag.length).toLowerCase() === tag.toLowerCase() &&
+    source.slice(2, 2 + tag.length).toLowerCase() === tag.toLowerCase() &&
     /[\t\r\n\f />]/.test(source[2 + tag.length] || '>')
   )
 }

--- a/packages/compiler-core/src/parse.ts
+++ b/packages/compiler-core/src/parse.ts
@@ -825,9 +825,9 @@ function parseAttribute(
             context,
             ErrorCodes.X_MISSING_DYNAMIC_DIRECTIVE_ARGUMENT_END
           )
-          content = content.substr(1)
+          content = content.substring(1)
         } else {
-          content = content.substr(1, content.length - 2)
+          content = content.substring(1, content.length - 1)
         }
       } else if (isSlot) {
         // #1241 special case for v-slot: vuetify relies extensively on slot
@@ -855,7 +855,7 @@ function parseAttribute(
       valueLoc.source = valueLoc.source.slice(1, -1)
     }
 
-    const modifiers = match[3] ? match[3].substr(1).split('.') : []
+    const modifiers = match[3] ? match[3].substring(1).split('.') : []
     if (isPropShorthand) modifiers.push('prop')
 
     // 2.x compat v-bind:foo.sync -> v-model:foo
@@ -1167,7 +1167,7 @@ function isEnd(
 function startsWithEndTagOpen(source: string, tag: string): boolean {
   return (
     startsWith(source, '</') &&
-    source.substr(2, tag.length).toLowerCase() === tag.toLowerCase() &&
+    source.substring(2, 2 + tag.length).toLowerCase() === tag.toLowerCase() &&
     /[\t\r\n\f />]/.test(source[2 + tag.length] || '>')
   )
 }

--- a/packages/compiler-core/src/utils.ts
+++ b/packages/compiler-core/src/utils.ts
@@ -189,10 +189,10 @@ export const isMemberExpression = __BROWSER__
 export function getInnerRange(
   loc: SourceLocation,
   offset: number,
-  length?: number
+  length: number
 ): SourceLocation {
   __TEST__ && assert(offset <= loc.source.length)
-  const source = loc.source.substr(offset, length)
+  const source = loc.source.substring(offset, offset + length)
   const newLoc: SourceLocation = {
     source,
     start: advancePositionWithClone(loc.start, loc.source, offset),

--- a/packages/compiler-core/src/utils.ts
+++ b/packages/compiler-core/src/utils.ts
@@ -192,7 +192,7 @@ export function getInnerRange(
   length: number
 ): SourceLocation {
   __TEST__ && assert(offset <= loc.source.length)
-  const source = loc.source.substring(offset, offset + length)
+  const source = loc.source.slice(offset, offset + length)
   const newLoc: SourceLocation = {
     source,
     start: advancePositionWithClone(loc.start, loc.source, offset),

--- a/packages/compiler-dom/src/decodeHtml.ts
+++ b/packages/compiler-dom/src/decodeHtml.ts
@@ -42,7 +42,7 @@ export const decodeHtml: ParserOptions['decodeEntities'] = (
           )
         }
         for (let length = maxCRNameLength; !value && length > 0; --length) {
-          name = rawText.substring(1, 1 + length)
+          name = rawText.slice(1, 1 + length)
           value = (namedCharacterReferences as Record<string, string>)[name]
         }
         if (value) {

--- a/packages/compiler-dom/src/decodeHtml.ts
+++ b/packages/compiler-dom/src/decodeHtml.ts
@@ -42,7 +42,7 @@ export const decodeHtml: ParserOptions['decodeEntities'] = (
           )
         }
         for (let length = maxCRNameLength; !value && length > 0; --length) {
-          name = rawText.substr(1, length)
+          name = rawText.substring(1, 1 + length)
           value = (namedCharacterReferences as Record<string, string>)[name]
         }
         if (value) {

--- a/packages/global.d.ts
+++ b/packages/global.d.ts
@@ -46,15 +46,8 @@ declare module '@vue/repl' {
   export { Repl, ReplStore }
 }
 
-// for String
 declare interface String {
   /**
-   * Returns the substring at the specified location within a String object.
    * @deprecated Please use String.prototype.slice instead of String.prototype.substring in the repository.
-   * @see https://github.com/vuejs/vue-next/pull/4699.
-   * @param start The zero-based index number indicating the beginning of the substring.
-   * @param end Zero-based index number indicating the end of the substring. The substring includes the characters up to, but not including, the character indicated by end.
-   * If end is omitted, the characters from start through the end of the original string are returned.
-   */
   substring(start: number, end?: number): string;
 }

--- a/packages/global.d.ts
+++ b/packages/global.d.ts
@@ -49,5 +49,6 @@ declare module '@vue/repl' {
 declare interface String {
   /**
    * @deprecated Please use String.prototype.slice instead of String.prototype.substring in the repository.
+   */
   substring(start: number, end?: number): string;
 }

--- a/packages/global.d.ts
+++ b/packages/global.d.ts
@@ -45,3 +45,16 @@ declare module '@vue/repl' {
   const ReplStore: any
   export { Repl, ReplStore }
 }
+
+// for String
+declare interface String {
+  /**
+   * Returns the substring at the specified location within a String object.
+   * @deprecated Please use String.prototype.slice instead of String.prototype.substring in the repository.
+   * @see https://github.com/vuejs/vue-next/pull/4699.
+   * @param start The zero-based index number indicating the beginning of the substring.
+   * @param end Zero-based index number indicating the end of the substring. The substring includes the characters up to, but not including, the character indicated by end.
+   * If end is omitted, the characters from start through the end of the original string are returned.
+   */
+  substring(start: number, end?: number): string;
+}

--- a/packages/sfc-playground/src/Header.vue
+++ b/packages/sfc-playground/src/Header.vue
@@ -60,7 +60,7 @@ async function fetchVersions(): Promise<string[]> {
   )
   const releases: any[] = await res.json()
   const versions = releases.map(r =>
-    /^v/.test(r.tag_name) ? r.tag_name.substring(1) : r.tag_name
+    /^v/.test(r.tag_name) ? r.tag_name.slice(1) : r.tag_name
   )
   // if the latest version is a pre-release, list all current pre-releases
   // otherwise filter out pre-releases

--- a/packages/sfc-playground/src/Header.vue
+++ b/packages/sfc-playground/src/Header.vue
@@ -60,7 +60,7 @@ async function fetchVersions(): Promise<string[]> {
   )
   const releases: any[] = await res.json()
   const versions = releases.map(r =>
-    /^v/.test(r.tag_name) ? r.tag_name.substr(1) : r.tag_name
+    /^v/.test(r.tag_name) ? r.tag_name.substring(1) : r.tag_name
   )
   // if the latest version is a pre-release, list all current pre-releases
   // otherwise filter out pre-releases

--- a/packages/shared/src/escapeHtml.ts
+++ b/packages/shared/src/escapeHtml.ts
@@ -34,14 +34,14 @@ export function escapeHtml(string: unknown) {
     }
 
     if (lastIndex !== index) {
-      html += str.substring(lastIndex, index)
+      html += str.slice(lastIndex, index)
     }
 
     lastIndex = index + 1
     html += escaped
   }
 
-  return lastIndex !== index ? html + str.substring(lastIndex, index) : html
+  return lastIndex !== index ? html + str.slice(lastIndex, index) : html
 }
 
 // https://www.w3.org/TR/html52/syntax.html#comments


### PR DESCRIPTION
String.prototype.substr is deprecated.

`String.prototype.substr()` is defined in [Annex B](https://262.ecma-international.org/9.0/#sec-string.prototype.substr) of the ECMA-262 standard, whose [introduction](https://262.ecma-international.org/9.0/#sec-additional-ecmascript-features-for-web-browsers) states: "… Programmers should not use or assume the existence of these features and behaviours when writing new ECMAScript code. …"
