### PR TITLE
fix(types): ensure that DeepReadonly handles Ref type properly (fix  #4701)

### DIFF
--- a/packages/reactivity/src/reactive.ts
+++ b/packages/reactivity/src/reactive.ts
@@ -132,6 +132,8 @@ export type DeepReadonly<T> = T extends Builtin
   ? WeakSet<DeepReadonly<U>>
   : T extends Promise<infer U>
   ? Promise<DeepReadonly<U>>
+  : T extends Ref<infer U>
+  ? Ref<DeepReadonly<U>>
   : T extends {}
   ? { readonly [K in keyof T]: DeepReadonly<T[K]> }
   : Readonly<T>


### PR DESCRIPTION
Without this check, refs are handled like ordinary objects, and the `keyof` iteration exposes the private `RefSymbol` which can lead to problems when creating type declarations.


Note: I wasn't sure how to write a test for this as it doesn't happen within the vue-next repo, only in a consuming library that creates a declaration file during buld.
fix  #4701 