### PR TITLE
fix(types): make `toRef` return correct type(fix #4732)

### DIFF
--- a/packages/reactivity/__tests__/ref.spec.ts
+++ b/packages/reactivity/__tests__/ref.spec.ts
@@ -268,6 +268,16 @@ describe('reactivity/ref', () => {
     // should keep ref
     const r = { x: ref(1) }
     expect(toRef(r, 'x')).toBe(r.x)
+
+    // #4732
+    const baz = {
+      foo: {
+        bar: ref(42)
+      }
+    }
+    const foo = toRef(baz, 'foo')
+    expect(isRef(foo.value.bar)).toBe(true)
+    expect(foo.value.bar.value).toBe(42)
   })
 
   test('toRefs', () => {

--- a/packages/reactivity/src/ref.ts
+++ b/packages/reactivity/src/ref.ts
@@ -65,7 +65,7 @@ export function isRef(r: any): r is Ref {
   return Boolean(r && r.__v_isRef === true)
 }
 
-export function ref<T extends object>(value: T): ToRef<T>
+export function ref<T extends object>(value: T): [T] extends [Ref] ? T : Ref<UnwrapRef<T>>
 export function ref<T>(value: T): Ref<UnwrapRef<T>>
 export function ref<T = any>(): Ref<T | undefined>
 export function ref(value?: unknown) {
@@ -212,7 +212,7 @@ class ObjectRefImpl<T extends object, K extends keyof T> {
   }
 }
 
-export type ToRef<T> = [T] extends [Ref] ? T : Ref<UnwrapRef<T>>
+export type ToRef<T> = [T] extends [Ref] ? T : Ref<T>
 export function toRef<T extends object, K extends keyof T>(
   object: T,
   key: K


### PR DESCRIPTION
Fix: #4732, `toRef` shouldn't unwrap refs, It's just a type error.