### PR TITLE
Return a more reasonable type for arrays.

### DIFF
--- a/packages/reactivity/src/ref.ts
+++ b/packages/reactivity/src/ref.ts
@@ -278,7 +278,7 @@ export type UnwrapRefSimple<T> = T extends
   | RefUnwrapBailTypes[keyof RefUnwrapBailTypes]
   ? T
   : T extends Array<any>
-  ? { [K in keyof T]: UnwrapRefSimple<T[K]> }
+  ? Array<UnwrapRefSimple<T[number]>>
   : T extends object & { [ShallowReactiveMarker]?: never }
   ? {
       [P in keyof T]: P extends symbol ? T[P] : UnwrapRef<T[P]>


### PR DESCRIPTION
Actually it caused a type error in my command line, which complained for missing properties: [Symbol.iterator], [Symbol.unscopables].