### PR TITLE
feat(runtime-core): add app.inject() API (close #4778)

### DIFF
--- a/packages/runtime-core/__tests__/apiCreateApp.spec.ts
+++ b/packages/runtime-core/__tests__/apiCreateApp.spec.ts
@@ -93,6 +93,14 @@ describe('api: createApp', () => {
     app.provide('foo', 1)
     app.provide('bar', 2)
 
+    const foo = app.inject('foo')
+    const bar = app.inject('bar')
+    app.inject('non-existant')
+
+    expect('[Vue warn]: injection "non-existant" not found.').toHaveBeenWarned()
+    expect(foo).toBe(1)
+    expect(bar).toBe(2)
+
     const root = nodeOps.createElement('div')
     app.mount(root)
     expect(serializeInner(root)).toBe(`3,2`)

--- a/packages/runtime-core/src/apiCreateApp.ts
+++ b/packages/runtime-core/src/apiCreateApp.ts
@@ -350,11 +350,11 @@ export function createAppAPI<HostElement>(
       },
 
       inject<T>(key: InjectionKey<T> | string) {
-        const value = context.provides[key as string]
-        if (__DEV__ && !((key as string) in context.provides)) {
+        if ((key as string) in context.provides) {
+          return context.provides[key as string]
+        } else if (__DEV__) {
           warn(`injection "${String(key)}" not found.`)
         }
-        return value
       }
     })
 

--- a/packages/runtime-core/src/apiCreateApp.ts
+++ b/packages/runtime-core/src/apiCreateApp.ts
@@ -41,6 +41,7 @@ export interface App<HostElement = any> {
   ): ComponentPublicInstance
   unmount(): void
   provide<T>(key: InjectionKey<T> | string, value: T): this
+  inject<T>(key: InjectionKey<T> | string): T | undefined
 
   // internal, but we need to expose these for the server-renderer and devtools
   _uid: number
@@ -346,6 +347,14 @@ export function createAppAPI<HostElement>(
         context.provides[key as string] = value
 
         return app
+      },
+
+      inject<T>(key: InjectionKey<T> | string) {
+        const value = context.provides[key as string]
+        if (__DEV__ && !((key as string) in context.provides)) {
+          warn(`injection "${String(key)}" not found.`)
+        }
+        return value
       }
     })
 


### PR DESCRIPTION
This PR Adds another instance method to the `app` instance, named `inject`.
It allows to read values that were previously provided globally with `app.provide()`

## Use Case

Primarily intersting to access stuff added by other plugins, so it qwill usually be used by library authors.

```ts
const pluginA = (app: App) => {
app.provide('foo', 'magic string')
}

const pluginB = (app: App) => {
  const magicString = app.inject('foo')
  if (magicString === 'magic string') {
    // do something
  }
}

app.use(pluginA)
ap.use(pluginB)
```


## Open Questions

* Should `app.inject()` also accept a second argument for a default value? So far I have left this out to keep it short and easy and keep size increase to a minimum.
* How to deal with scenarios where pluginA doesn't expose the `key`, i.e. only providing a `usePluginA()` composable that wraps `inject()` (which would only work in components)

close #4778