### PR TITLE
fix(devtools): fix memory leak when devtools is not installed

### DIFF
--- a/packages/runtime-core/src/devtools.ts
+++ b/packages/runtime-core/src/devtools.ts
@@ -36,11 +36,9 @@ let buffer: { event: string; args: any[] }[] = []
 let devtoolsNotInstalled = false
 
 function emit(event: string, ...args: any[]) {
-  if (devtoolsNotInstalled) {
-    buffer = []
-  } else if (devtools) {
+  if (devtools) {
     devtools.emit(event, ...args)
-  } else {
+  } else if (!devtoolsNotInstalled) {
     buffer.push({ event, args })
   }
 }

--- a/packages/runtime-core/src/devtools.ts
+++ b/packages/runtime-core/src/devtools.ts
@@ -33,8 +33,12 @@ export let devtools: DevtoolsHook
 
 let buffer: { event: string; args: any[] }[] = []
 
+let devtoolsNotInstalled = false
+
 function emit(event: string, ...args: any[]) {
-  if (devtools) {
+  if (devtoolsNotInstalled) {
+    buffer = []
+  } else if (devtools) {
     devtools.emit(event, ...args)
   } else {
     buffer.push({ event, args })
@@ -56,7 +60,10 @@ export function setDevtoolsHook(hook: DevtoolsHook, target: any) {
     // clear buffer after 3s - the user probably doesn't have devtools installed
     // at all, and keeping the buffer will cause memory leaks (#4738)
     setTimeout(() => {
-      buffer = []
+      if (!devtools) {
+        devtoolsNotInstalled = true
+        buffer = []
+      }
     }, 3000)
   }
 }


### PR DESCRIPTION
fix: #4829 fix: #4738

Clear buffer after 3s once is not enough. When devtools is not installed, buffer will increase via `emit`.

````ts
function emit(event: string, ...args: any[]) {
  if (devtools) {
    devtools.emit(event, ...args)
  } else {
    buffer.push({ event, args })
  }
}
````