### PR TITLE
chore: Ignore .idea folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ temp
 explorations
 TODOs.md
 *.log
+.idea


### PR DESCRIPTION
Fixes #4837

(that ticket's been closed in the meantime, so I'll just copy-paste the description here)

Simple quality-of-life fix: Ignore intelliJ's workspace folder. intelliJ is my daily driver for working with code. Everytime I clone a repo and open up its contents in intelliJ, the IDE will automatically create the .idea folder for storing project-specific settings etc.

I'd rather not put .idea in my global git ignore since some projects prefer to deliberately add the workspace folders for sharing settings, live templates and stuff like that.