### PR TITLE
fix (runtime-dom) Failed to execute 'insertBefore'

### DIFF
--- a/packages/runtime-dom/src/nodeOps.ts
+++ b/packages/runtime-dom/src/nodeOps.ts
@@ -8,7 +8,11 @@ const staticTemplateCache = new Map<string, DocumentFragment>()
 
 export const nodeOps: Omit<RendererOptions<Node, Element>, 'patchProp'> = {
   insert: (child, parent, anchor) => {
-    parent.insertBefore(child, anchor || null)
+    try {
+      parent.insertBefore(child, anchor || null);
+    } catch (e) {
+      parent.insertBefore(child, null);
+    }
   },
 
   remove: child => {


### PR DESCRIPTION
DOMException: Failed to execute 'insertBefore' on 'Node': The node before which the new node is to be inserted is not a child of this node.
使用Fragments，如果第一行是v-if是false，或者第一行`<!-- <p></p> -->`这样的注释，使用router.push跳转到别的路由会导致上面的提示报错
应该会有更好的解决方案，只是给予参考