### PR TITLE
test(reactivity) : fixed a small copy & paste mistake in ref.spec.ts

### DIFF
--- a/packages/reactivity/__tests__/ref.spec.ts
+++ b/packages/reactivity/__tests__/ref.spec.ts
@@ -35,7 +35,6 @@ describe('reactivity/ref', () => {
     // same value should not trigger
     a.value = 2
     expect(calls).toBe(2)
-    expect(dummy).toBe(2)
   })
 
   it('should make nested properties reactive', () => {


### PR DESCRIPTION
Hi , I saw this code in the `ref.spec.ts`:

https://github.com/vuejs/vue-next/blob/5eb72630a53a8dd82c2b8a9705c21a8075161a3d/packages/reactivity/__tests__/ref.spec.ts#L32-L38
you can see that `a.value = 2`  has repeated twice and I guess the second part is for checking that the calls won't change after setting a.value to same number but `expect(dummy).toBe(2) ` has repeated again and that's useless because it has a test at line 34