### PR TITLE
fix: the latest vue3 version cause ssr failed, devtools judge in server side is not exact

### DIFF
--- a/packages/runtime-core/src/devtools.ts
+++ b/packages/runtime-core/src/devtools.ts
@@ -55,8 +55,10 @@ export function setDevtoolsHook(hook: DevtoolsHook, target: any) {
     // (#4815)
     // eslint-disable-next-line no-restricted-globals
     typeof window !== 'undefined' &&
-    typeof window.HTMLElement !== 'undefined' &&
-    !navigator.userAgent.includes('jsdom')
+    // some envs mock window but not fully
+    window.HTMLElement &&
+    // also exclude jsdom
+    !window.navigator?.userAgent?.includes('jsdom')
   ) {
     const replay = (target.__VUE_DEVTOOLS_HOOK_REPLAY__ =
       target.__VUE_DEVTOOLS_HOOK_REPLAY__ || [])

--- a/packages/runtime-core/src/devtools.ts
+++ b/packages/runtime-core/src/devtools.ts
@@ -55,6 +55,7 @@ export function setDevtoolsHook(hook: DevtoolsHook, target: any) {
     // (#4815)
     // eslint-disable-next-line no-restricted-globals
     typeof window !== 'undefined' &&
+    typeof window.HTMLElement !== 'undefined' &&
     !navigator.userAgent.includes('jsdom')
   ) {
     const replay = (target.__VUE_DEVTOOLS_HOOK_REPLAY__ =


### PR DESCRIPTION
The latest version of vue3 cause ssr failed, devtools judge in server side is not exact. Mock window object is common in some ssr program for compatibility, maybe only use `typeof window` as condition is not exact