### PR TITLE
ci: update pnpm-lock.yaml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           node-version: 16
           cache: 'pnpm'
 
-      - run: pnpm install --frozen-lockfile=false
+      - run: pnpm install
 
       - name: Run unit tests
         run: pnpm run test -- --ci
@@ -44,7 +44,7 @@ jobs:
           node-version: 16
           cache: 'pnpm'
 
-      - run: pnpm install --frozen-lockfile=false
+      - run: pnpm install
 
       - name: Run type declaration tests
         run: pnpm run test-dts
@@ -67,7 +67,7 @@ jobs:
           node-version: 16
           cache: 'pnpm'
 
-      - run: pnpm install --frozen-lockfile=false
+      - run: pnpm install
       - run: pnpm run size
 
       # - name: Check build size

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           node-version: 16
           cache: 'pnpm'
 
-      - run: pnpm install
+      - run: pnpm install --frozen-lockfile=false
 
       - name: Run unit tests
         run: pnpm run test -- --ci
@@ -44,7 +44,7 @@ jobs:
           node-version: 16
           cache: 'pnpm'
 
-      - run: pnpm install
+      - run: pnpm install --frozen-lockfile=false
 
       - name: Run type declaration tests
         run: pnpm run test-dts
@@ -67,7 +67,7 @@ jobs:
           node-version: 16
           cache: 'pnpm'
 
-      - run: pnpm install
+      - run: pnpm install --frozen-lockfile=false
       - run: pnpm run size
 
       # - name: Check build size

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,7 +100,7 @@ importers:
     specifiers:
       '@babel/parser': ^7.15.0
       '@babel/types': ^7.15.0
-      '@vue/shared': 3.2.20
+      '@vue/shared': 3.2.21
       estree-walker: ^2.0.2
       source-map: ^0.6.1
     dependencies:
@@ -113,8 +113,8 @@ importers:
 
   packages/compiler-dom:
     specifiers:
-      '@vue/compiler-core': 3.2.20
-      '@vue/shared': 3.2.20
+      '@vue/compiler-core': 3.2.21
+      '@vue/shared': 3.2.21
     dependencies:
       '@vue/compiler-core': link:../compiler-core
       '@vue/shared': link:../shared
@@ -125,12 +125,12 @@ importers:
       '@babel/types': ^7.15.0
       '@types/estree': ^0.0.48
       '@types/lru-cache': ^5.1.0
-      '@vue/compiler-core': 3.2.20
-      '@vue/compiler-dom': 3.2.20
-      '@vue/compiler-ssr': 3.2.20
+      '@vue/compiler-core': 3.2.21
+      '@vue/compiler-dom': 3.2.21
+      '@vue/compiler-ssr': 3.2.21
       '@vue/consolidate': ^0.17.3
-      '@vue/ref-transform': 3.2.20
-      '@vue/shared': 3.2.20
+      '@vue/ref-transform': 3.2.21
+      '@vue/shared': 3.2.21
       estree-walker: ^2.0.2
       hash-sum: ^2.0.0
       lru-cache: ^5.1.1
@@ -168,15 +168,15 @@ importers:
 
   packages/compiler-ssr:
     specifiers:
-      '@vue/compiler-dom': 3.2.20
-      '@vue/shared': 3.2.20
+      '@vue/compiler-dom': 3.2.21
+      '@vue/shared': 3.2.21
     dependencies:
       '@vue/compiler-dom': link:../compiler-dom
       '@vue/shared': link:../shared
 
   packages/reactivity:
     specifiers:
-      '@vue/shared': 3.2.20
+      '@vue/shared': 3.2.21
     dependencies:
       '@vue/shared': link:../shared
 
@@ -184,8 +184,8 @@ importers:
     specifiers:
       '@babel/core': ^7.15.0
       '@babel/parser': ^7.15.0
-      '@vue/compiler-core': 3.2.20
-      '@vue/shared': 3.2.20
+      '@vue/compiler-core': 3.2.21
+      '@vue/shared': 3.2.21
       estree-walker: ^2.0.2
       magic-string: ^0.25.7
     dependencies:
@@ -199,16 +199,16 @@ importers:
 
   packages/runtime-core:
     specifiers:
-      '@vue/reactivity': 3.2.20
-      '@vue/shared': 3.2.20
+      '@vue/reactivity': 3.2.21
+      '@vue/shared': 3.2.21
     dependencies:
       '@vue/reactivity': link:../reactivity
       '@vue/shared': link:../shared
 
   packages/runtime-dom:
     specifiers:
-      '@vue/runtime-core': 3.2.20
-      '@vue/shared': 3.2.20
+      '@vue/runtime-core': 3.2.21
+      '@vue/shared': 3.2.21
       csstype: ^2.6.8
     dependencies:
       '@vue/runtime-core': link:../runtime-core
@@ -217,16 +217,16 @@ importers:
 
   packages/runtime-test:
     specifiers:
-      '@vue/runtime-core': 3.2.20
-      '@vue/shared': 3.2.20
+      '@vue/runtime-core': 3.2.21
+      '@vue/shared': 3.2.21
     dependencies:
       '@vue/runtime-core': link:../runtime-core
       '@vue/shared': link:../shared
 
   packages/server-renderer:
     specifiers:
-      '@vue/compiler-ssr': 3.2.20
-      '@vue/shared': 3.2.20
+      '@vue/compiler-ssr': 3.2.21
+      '@vue/shared': 3.2.21
     dependencies:
       '@vue/compiler-ssr': link:../compiler-ssr
       '@vue/shared': link:../shared
@@ -237,7 +237,7 @@ importers:
       '@vue/repl': ^0.4.3
       file-saver: ^2.0.5
       jszip: ^3.6.0
-      vue: workspace:*
+      vue: 3.2.21
     dependencies:
       '@vue/repl': 0.4.3
       file-saver: 2.0.5
@@ -265,11 +265,11 @@ importers:
 
   packages/vue:
     specifiers:
-      '@vue/compiler-dom': 3.2.20
-      '@vue/compiler-sfc': 3.2.20
-      '@vue/runtime-dom': 3.2.20
-      '@vue/server-renderer': 3.2.20
-      '@vue/shared': 3.2.20
+      '@vue/compiler-dom': 3.2.21
+      '@vue/compiler-sfc': 3.2.21
+      '@vue/runtime-dom': 3.2.21
+      '@vue/server-renderer': 3.2.21
+      '@vue/shared': 3.2.21
     dependencies:
       '@vue/compiler-dom': link:../compiler-dom
       '@vue/compiler-sfc': link:../compiler-sfc


### PR DESCRIPTION
Skip the `frozen-lockfile` check to make `CI` continue to work.
```
Run pnpm install
Scope: all 17 workspace projects
Lockfile is up-to-date, resolution step is skipped
 ERR_PNPM_OUTDATED_LOCKFILE  Cannot install with "frozen-lockfile" because pnpm-lock.yaml is not up-to-date with packages/compiler-core/package.json
```