### PR TITLE
fix(compiler-sfc): improve expose codegen if user did not explicitly call `defineExpose`

### DIFF
--- a/packages/compiler-sfc/__tests__/__snapshots__/compileScript.spec.ts.snap
+++ b/packages/compiler-sfc/__tests__/__snapshots__/compileScript.spec.ts.snap
@@ -7,7 +7,7 @@ exports[`SFC compile <script setup> <script> and <script setup> co-usage script 
       
 export default {
   setup(__props, { expose }) {
-  expose()
+  expose();
 
       x()
       
@@ -22,7 +22,7 @@ exports[`SFC compile <script setup> <script> and <script setup> co-usage script 
       
 export default {
   setup(__props, { expose }) {
-  expose()
+  expose();
 
       x()
       
@@ -101,7 +101,7 @@ exports[`SFC compile <script setup> async/await detection expression statement 1
 
 export default {
   async setup(__props, { expose }) {
-  expose()
+  expose();
 
 let __temp, __restore
 ;(
@@ -120,7 +120,7 @@ exports[`SFC compile <script setup> async/await detection nested await 1`] = `
 
 export default {
   async setup(__props, { expose }) {
-  expose()
+  expose();
 
 let __temp, __restore
 ;(
@@ -144,7 +144,7 @@ exports[`SFC compile <script setup> async/await detection nested await 2`] = `
 
 export default {
   async setup(__props, { expose }) {
-  expose()
+  expose();
 
 let __temp, __restore
 ;(
@@ -168,7 +168,7 @@ exports[`SFC compile <script setup> async/await detection nested await 3`] = `
 
 export default {
   async setup(__props, { expose }) {
-  expose()
+  expose();
 
 let __temp, __restore
 ;(
@@ -197,7 +197,7 @@ exports[`SFC compile <script setup> async/await detection nested leading await i
 
 export default {
   async setup(__props, { expose }) {
-  expose()
+  expose();
 
 let __temp, __restore
 foo()
@@ -223,7 +223,7 @@ exports[`SFC compile <script setup> async/await detection nested statements 1`] 
 
 export default {
   async setup(__props, { expose }) {
-  expose()
+  expose();
 
 let __temp, __restore
 if (ok) { (
@@ -246,7 +246,7 @@ exports[`SFC compile <script setup> async/await detection ref 1`] = `
 
 export default {
   async setup(__props, { expose }) {
-  expose()
+  expose();
 
 let __temp, __restore
 let a = _ref(1 + ((
@@ -264,7 +264,7 @@ return { a }
 exports[`SFC compile <script setup> async/await detection should ignore await inside functions 1`] = `
 "export default {
   setup(__props, { expose }) {
-  expose()
+  expose();
 async function foo() { await bar }
 return { foo }
 }
@@ -275,7 +275,7 @@ return { foo }
 exports[`SFC compile <script setup> async/await detection should ignore await inside functions 2`] = `
 "export default {
   setup(__props, { expose }) {
-  expose()
+  expose();
 const foo = async () => { await bar }
 return { foo }
 }
@@ -286,7 +286,7 @@ return { foo }
 exports[`SFC compile <script setup> async/await detection should ignore await inside functions 3`] = `
 "export default {
   setup(__props, { expose }) {
-  expose()
+  expose();
 const obj = { async method() { await bar }}
 return { obj }
 }
@@ -297,7 +297,7 @@ return { obj }
 exports[`SFC compile <script setup> async/await detection should ignore await inside functions 4`] = `
 "export default {
   setup(__props, { expose }) {
-  expose()
+  expose();
 const cls = class Foo { async method() { await bar }}
 return { cls }
 }
@@ -310,7 +310,7 @@ exports[`SFC compile <script setup> async/await detection single line conditions
 
 export default {
   async setup(__props, { expose }) {
-  expose()
+  expose();
 
 let __temp, __restore
 if (false) (
@@ -329,7 +329,7 @@ exports[`SFC compile <script setup> async/await detection variable 1`] = `
 
 export default {
   async setup(__props, { expose }) {
-  expose()
+  expose();
 
 let __temp, __restore
 const a = 1 + ((
@@ -347,7 +347,7 @@ return { a }
 exports[`SFC compile <script setup> binding analysis for destructur 1`] = `
 "export default {
   setup(__props, { expose }) {
-  expose()
+  expose();
 
       const { foo, b: bar, ['x' + 'y']: baz, x: { y, zz: { z }}} = {}
       
@@ -361,7 +361,7 @@ exports[`SFC compile <script setup> defineEmits() 1`] = `
 "export default {
   emits: ['foo', 'bar'],
   setup(__props, { expose, emit: myEmit }) {
-  expose()
+  expose();
 
 
 
@@ -389,7 +389,7 @@ exports[`SFC compile <script setup> defineProps w/ external definition 1`] = `
 export default {
   props: propsModel,
   setup(__props, { expose }) {
-  expose()
+  expose();
 
 const props = __props
 
@@ -407,7 +407,7 @@ exports[`SFC compile <script setup> defineProps w/ leading code 1`] = `
 export default {
   props: {},
   setup(__props, { expose }) {
-  expose()
+  expose();
 
 const props = __props
 
@@ -424,7 +424,7 @@ exports[`SFC compile <script setup> defineProps() 1`] = `
   foo: String
 },
   setup(__props, { expose }) {
-  expose()
+  expose();
 
 const props = __props
 
@@ -442,7 +442,7 @@ exports[`SFC compile <script setup> defineProps/defineEmits in multi-variable de
   props: ['item'],
   emits: ['a'],
   setup(__props, { expose, emit }) {
-  expose()
+  expose();
 
 const props = __props
 
@@ -459,7 +459,7 @@ exports[`SFC compile <script setup> defineProps/defineEmits in multi-variable de
   props: ['item'],
   emits: ['a'],
   setup(__props, { expose, emit }) {
-  expose()
+  expose();
 
 const props = __props
 
@@ -477,7 +477,7 @@ import { bar, baz } from './x'
         
 export default /*#__PURE__*/_defineComponent({
   setup(__props, { expose }) {
-  expose()
+  expose();
 
         const cond = true
         
@@ -493,7 +493,7 @@ import { FooBar, FooBaz, FooQux, foo } from './x'
         
 export default /*#__PURE__*/_defineComponent({
   setup(__props, { expose }) {
-  expose()
+  expose();
 
         const fooBar: FooBar = 1
         
@@ -509,7 +509,7 @@ import { vMyDir } from './x'
         
 export default /*#__PURE__*/_defineComponent({
   setup(__props, { expose }) {
-  expose()
+  expose();
 
         
 return { vMyDir }
@@ -524,7 +524,7 @@ import { VAR, VAR2, VAR3 } from './x'
         
 export default /*#__PURE__*/_defineComponent({
   setup(__props, { expose }) {
-  expose()
+  expose();
 
         
 return { VAR, VAR3 }
@@ -539,7 +539,7 @@ import { FooBaz, Last } from './x'
         
 export default /*#__PURE__*/_defineComponent({
   setup(__props, { expose }) {
-  expose()
+  expose();
 
         
 return { FooBaz, Last }
@@ -554,7 +554,7 @@ import { x, y, z, x$y } from './x'
       
 export default /*#__PURE__*/_defineComponent({
   setup(__props, { expose }) {
-  expose()
+  expose();
 
       
 return { x, z, x$y }
@@ -576,7 +576,7 @@ export default {
           foo: () => bar > 1
         },
   setup(__props, { expose }) {
-  expose()
+  expose();
 
         
         
@@ -598,7 +598,7 @@ exports[`SFC compile <script setup> errors should allow defineProps/Emit() refer
             foo: bar => bar > 1
           },
   setup(__props, { expose }) {
-  expose()
+  expose();
 
           const bar = 1
           
@@ -616,7 +616,7 @@ import { ref } from 'vue'
       
 export default {
   setup(__props, { expose }) {
-  expose()
+  expose();
 
       let foo = _ref(1)
       
@@ -631,7 +631,7 @@ exports[`SFC compile <script setup> imports import dedupe between <script> and <
         
 export default {
   setup(__props, { expose }) {
-  expose()
+  expose();
 
         x()
         
@@ -648,7 +648,7 @@ export default {
   props: ['foo'],
   emits: ['bar'],
   setup(__props, { expose }) {
-  expose()
+  expose();
 
       
       
@@ -666,7 +666,7 @@ exports[`SFC compile <script setup> imports should extract comment for import or
         
 export default {
   setup(__props, { expose }) {
-  expose()
+  expose();
 
         
 return { a, b }
@@ -681,7 +681,7 @@ exports[`SFC compile <script setup> imports should hoist and expose imports 1`] 
         
 export default {
   setup(__props, { expose }) {
-  expose()
+  expose();
 
           
 return { ref }
@@ -984,7 +984,7 @@ exports[`SFC compile <script setup> should expose top level declarations 1`] = `
       
 export default {
   setup(__props, { expose }) {
-  expose()
+  expose();
 
       let a = 1
       const b = 2
@@ -1008,7 +1008,7 @@ const enum Foo { A = 123 }
         
 export default /*#__PURE__*/_defineComponent({
   setup(__props, { expose }) {
-  expose()
+  expose();
 
         
 return { Foo }
@@ -1024,7 +1024,7 @@ export interface Emits { (e: 'foo' | 'bar'): void }
 export default /*#__PURE__*/_defineComponent({
   emits: [\\"foo\\", \\"bar\\"],
   setup(__props, { expose, emit }: { emit: ({ (e: 'foo' | 'bar'): void }), expose: any, slots: any, attrs: any }) {
-  expose()
+  expose();
 
       
       
@@ -1041,7 +1041,7 @@ export type Emits = { (e: 'foo' | 'bar'): void }
 export default /*#__PURE__*/_defineComponent({
   emits: [\\"foo\\", \\"bar\\"],
   setup(__props, { expose, emit }: { emit: ({ (e: 'foo' | 'bar'): void }), expose: any, slots: any, attrs: any }) {
-  expose()
+  expose();
 
       
       
@@ -1058,7 +1058,7 @@ interface Emits { (e: 'foo' | 'bar'): void }
 export default /*#__PURE__*/_defineComponent({
   emits: [\\"foo\\", \\"bar\\"],
   setup(__props, { expose, emit }: { emit: ({ (e: 'foo' | 'bar'): void }), expose: any, slots: any, attrs: any }) {
-  expose()
+  expose();
 
       
       
@@ -1075,7 +1075,7 @@ export type Emits = (e: 'foo' | 'bar') => void
 export default /*#__PURE__*/_defineComponent({
   emits: [\\"foo\\", \\"bar\\"],
   setup(__props, { expose, emit }: { emit: ((e: 'foo' | 'bar') => void), expose: any, slots: any, attrs: any }) {
-  expose()
+  expose();
 
       
       
@@ -1092,7 +1092,7 @@ type Emits = (e: 'foo' | 'bar') => void
 export default /*#__PURE__*/_defineComponent({
   emits: [\\"foo\\", \\"bar\\"],
   setup(__props, { expose, emit }: { emit: ((e: 'foo' | 'bar') => void), expose: any, slots: any, attrs: any }) {
-  expose()
+  expose();
 
       
       
@@ -1109,7 +1109,7 @@ type Emits = { (e: 'foo' | 'bar'): void }
 export default /*#__PURE__*/_defineComponent({
   emits: [\\"foo\\", \\"bar\\"],
   setup(__props, { expose, emit }: { emit: ({ (e: 'foo' | 'bar'): void }), expose: any, slots: any, attrs: any }) {
-  expose()
+  expose();
 
       
       
@@ -1125,7 +1125,7 @@ exports[`SFC compile <script setup> with TypeScript defineEmits w/ type (type li
 export default /*#__PURE__*/_defineComponent({
   emits: [\\"foo\\", \\"bar\\", \\"baz\\"],
   setup(__props, { expose, emit }: { emit: ({(e: 'foo' | 'bar'): void; (e: 'baz', id: number): void;}), expose: any, slots: any, attrs: any }) {
-  expose()
+  expose();
 
       
       
@@ -1141,7 +1141,7 @@ exports[`SFC compile <script setup> with TypeScript defineEmits w/ type 1`] = `
 export default /*#__PURE__*/_defineComponent({
   emits: [\\"foo\\", \\"bar\\"],
   setup(__props, { expose, emit }: { emit: ((e: 'foo' | 'bar') => void), expose: any, slots: any, attrs: any }) {
-  expose()
+  expose();
 
       
       
@@ -1160,7 +1160,7 @@ export default /*#__PURE__*/_defineComponent({
     x: { type: Number, required: false }
   },
   setup(__props: any, { expose }) {
-  expose()
+  expose();
 
       
       
@@ -1180,7 +1180,7 @@ export default /*#__PURE__*/_defineComponent({
     x: { type: Number, required: false }
   },
   setup(__props: any, { expose }) {
-  expose()
+  expose();
 
         
       
@@ -1199,7 +1199,7 @@ export default /*#__PURE__*/_defineComponent({
     x: { type: Number, required: false }
   },
   setup(__props: any, { expose }) {
-  expose()
+  expose();
 
       
       
@@ -1218,7 +1218,7 @@ export default /*#__PURE__*/_defineComponent({
     x: { type: Number, required: false }
   },
   setup(__props: any, { expose }) {
-  expose()
+  expose();
 
       
       
@@ -1265,7 +1265,7 @@ export default /*#__PURE__*/_defineComponent({
     foo: { type: [Function, null], required: true }
   },
   setup(__props: any, { expose }) {
-  expose()
+  expose();
 
       
       
@@ -1284,7 +1284,7 @@ export default /*#__PURE__*/_defineComponent({
     x: { type: Number, required: false }
   },
   setup(__props: any, { expose }) {
-  expose()
+  expose();
 
       
       
@@ -1301,7 +1301,7 @@ export default /*#__PURE__*/_defineComponent({
   props: { foo: String },
   emits: ['a', 'b'],
   setup(__props, { expose, emit }) {
-  expose()
+  expose();
 
 const props = __props
 
@@ -1321,7 +1321,7 @@ export interface Foo {}
       
 export default /*#__PURE__*/_defineComponent({
   setup(__props, { expose }) {
-  expose()
+  expose();
 
         
 return {  }
@@ -1336,7 +1336,7 @@ enum Foo { A = 123 }
         
 export default /*#__PURE__*/_defineComponent({
   setup(__props, { expose }) {
-  expose()
+  expose();
 
         
 return { Foo }
@@ -1355,7 +1355,7 @@ enum Foo { A = 123 }
         
 export default /*#__PURE__*/_defineComponent({
   setup(__props, { expose }) {
-  expose()
+  expose();
 
         
 return { D, C, B, Foo }
@@ -1375,7 +1375,7 @@ export default /*#__PURE__*/_defineComponent({
     baz: { type: Boolean, required: true }
   }, { ...defaults }),
   setup(__props: any, { expose }) {
-  expose()
+  expose();
 
 const props = __props as {
         foo?: string
@@ -1402,7 +1402,7 @@ export default /*#__PURE__*/_defineComponent({
     qux: { type: Function, required: false, default() { return 1 } }
   },
   setup(__props: any, { expose }) {
-  expose()
+  expose();
 
 const props = __props as { foo: string, bar?: number, baz: boolean, qux(): number }
 

--- a/packages/compiler-sfc/__tests__/__snapshots__/compileScriptRefTransform.spec.ts.snap
+++ b/packages/compiler-sfc/__tests__/__snapshots__/compileScriptRefTransform.spec.ts.snap
@@ -5,7 +5,7 @@ exports[`sfc ref transform $ unwrapping 1`] = `
     
 export default {
   setup(__props, { expose }) {
-  expose()
+  expose();
 
     let foo = (ref())
     let a = (ref(1))
@@ -26,7 +26,7 @@ exports[`sfc ref transform $ref & $shallowRef declarations 1`] = `
 
 export default {
   setup(__props, { expose }) {
-  expose()
+  expose();
 
     let foo = _ref()
     let a = _ref(1)
@@ -47,7 +47,7 @@ exports[`sfc ref transform usage /w typescript 1`] = `
 
 export default /*#__PURE__*/_defineComponent({
   setup(__props, { expose }) {
-  expose()
+  expose();
 
         let msg = _ref<string | number>('foo');
         let bar = _ref <string | number>('bar');
@@ -79,7 +79,7 @@ exports[`sfc ref transform usage with normal <script> + <script setup> 1`] = `
     
 export default {
   setup(__props, { expose }) {
-  expose()
+  expose();
 
     let b = _ref(0)
     let c = 0

--- a/packages/compiler-sfc/__tests__/__snapshots__/cssVars.spec.ts.snap
+++ b/packages/compiler-sfc/__tests__/__snapshots__/cssVars.spec.ts.snap
@@ -54,7 +54,7 @@ exports[`CSS vars injection codegen should ignore comments 1`] = `
 
 export default {
   setup(__props, { expose }) {
-  expose()
+  expose();
 
 _useCssVars(_ctx => ({
   \\"xxxxxxxx-width\\": (width)
@@ -71,7 +71,7 @@ exports[`CSS vars injection codegen w/ <script setup> 1`] = `
 
 export default {
   setup(__props, { expose }) {
-  expose()
+  expose();
 
 _useCssVars(_ctx => ({
   \\"xxxxxxxx-color\\": (color)
@@ -88,7 +88,7 @@ exports[`CSS vars injection codegen w/ <script setup> using the same var multipl
 
 export default {
   setup(__props, { expose }) {
-  expose()
+  expose();
 
 _useCssVars(_ctx => ({
   \\"xxxxxxxx-color\\": (color)
@@ -128,7 +128,7 @@ export default {
           foo: String
         },
   setup(__props, { expose }) {
-  expose()
+  expose();
 
 _useCssVars(_ctx => ({
   \\"xxxxxxxx-color\\": (color),

--- a/packages/compiler-sfc/src/compileScript.ts
+++ b/packages/compiler-sfc/src/compileScript.ts
@@ -1367,7 +1367,7 @@ export function compileScript(
   // <script setup> components are closed by default. If the user did not
   // explicitly call `defineExpose`, call expose() with no args.
   const exposeCall =
-    hasDefineExposeCall || options.inlineTemplate ? `` : `  expose()\n`
+    hasDefineExposeCall || options.inlineTemplate ? `` : `  expose();\n`
   if (isTS) {
     // for TS, make sure the exported type is still valid type with
     // correct props information


### PR DESCRIPTION
Fix #4917