### PR TITLE
fix(compiler-sfc): externalRE support automatic http/https prefix url…

### DIFF
--- a/packages/compiler-sfc/__tests__/__snapshots__/templateTransformAssetUrl.spec.ts.snap
+++ b/packages/compiler-sfc/__tests__/__snapshots__/templateTransformAssetUrl.spec.ts.snap
@@ -67,6 +67,7 @@ export function render(_ctx, _cache) {
     _createElementVNode(\\"img\\", { src: _imports_1 }),
     _createElementVNode(\\"img\\", { src: _imports_1 }),
     _createElementVNode(\\"img\\", { src: \\"http://example.com/fixtures/logo.png\\" }),
+    _createElementVNode(\\"img\\", { src: \\"//example.com/fixtures/logo.png\\" }),
     _createElementVNode(\\"img\\", { src: \\"/fixtures/logo.png\\" }),
     _createElementVNode(\\"img\\", { src: \\"data:image/png;base64,i\\" })
   ], 64 /* STABLE_FRAGMENT */))
@@ -99,7 +100,8 @@ export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock(_Fragment, null, [
     _createElementVNode(\\"img\\", { src: _imports_0 }),
     _createElementVNode(\\"img\\", { src: _imports_1 }),
-    _createElementVNode(\\"img\\", { src: \\"https://foo.bar/baz.png\\" })
+    _createElementVNode(\\"img\\", { src: \\"https://foo.bar/baz.png\\" }),
+    _createElementVNode(\\"img\\", { src: \\"//foo.bar/baz.png\\" })
   ], 64 /* STABLE_FRAGMENT */))
 }"
 `;

--- a/packages/compiler-sfc/__tests__/templateTransformAssetUrl.spec.ts
+++ b/packages/compiler-sfc/__tests__/templateTransformAssetUrl.spec.ts
@@ -29,6 +29,7 @@ describe('compiler sfc: transform asset url', () => {
 			<img src="~fixtures/logo.png"/>
 			<img src="~/fixtures/logo.png"/>
 			<img src="http://example.com/fixtures/logo.png"/>
+			<img src="//example.com/fixtures/logo.png"/>
 			<img src="/fixtures/logo.png"/>
 			<img src="data:image/png;base64,i"/>
 		`)
@@ -76,7 +77,8 @@ describe('compiler sfc: transform asset url', () => {
     const { code } = compileWithAssetUrls(
       `<img src="./bar.png"/>` +
         `<img src="/bar.png"/>` +
-        `<img src="https://foo.bar/baz.png"/>`,
+        `<img src="https://foo.bar/baz.png"/>` +
+        `<img src="//foo.bar/baz.png"/>`,
       {
         includeAbsolute: true
       }

--- a/packages/compiler-sfc/__tests__/templateUtils.spec.ts
+++ b/packages/compiler-sfc/__tests__/templateUtils.spec.ts
@@ -36,6 +36,12 @@ describe('compiler sfc:templateUtils isExternalUrl', () => {
     const result = isExternalUrl(url)
     expect(result).toBe(true)
   })
+
+  test('should return true when String starts with //', () => {
+    const url = '//vuejs.org/'
+    const result = isExternalUrl(url)
+    expect(result).toBe(true)
+  })
 })
 
 describe('compiler sfc:templateUtils isDataUrl', () => {

--- a/packages/compiler-sfc/src/templateUtils.ts
+++ b/packages/compiler-sfc/src/templateUtils.ts
@@ -6,7 +6,7 @@ export function isRelativeUrl(url: string): boolean {
   return firstChar === '.' || firstChar === '~' || firstChar === '@'
 }
 
-const externalRE = /^https?:\/\//
+const externalRE = /^(https?:)?\/\//
 export function isExternalUrl(url: string): boolean {
   return externalRE.test(url)
 }


### PR DESCRIPTION
fix #4920 

## Problem

externalRE in compiler-sfc is not supported automatic http/https prefix url pattern.

For detail, check #4920 please.

