### PR TITLE
fix(runtime-core): add array types to InferDefaults

### DIFF
--- a/packages/runtime-core/src/apiSetupHelpers.ts
+++ b/packages/runtime-core/src/apiSetupHelpers.ts
@@ -126,13 +126,16 @@ export function defineExpose(exposed?: Record<string, any>) {
 
 type NotUndefined<T> = T extends undefined ? never : T
 
+type DefaultTypes =
+  | number
+  | string
+  | boolean
+  | symbol
+  | Function
+  | DefaultTypes[]
+
 type InferDefaults<T> = {
-  [K in keyof T]?: NotUndefined<T[K]> extends
-    | number
-    | string
-    | boolean
-    | symbol
-    | Function
+  [K in keyof T]?: NotUndefined<T[K]> extends DefaultTypes
     ? NotUndefined<T[K]>
     : (props: T) => NotUndefined<T[K]>
 }


### PR DESCRIPTION
This fixes an issue where it fails to correctly infer defaults when using `withDefaults` with `defineProps`, where the props type includes an array type.

```ts
withDefaults(defineProps<{ foo: string[] }>(), {
	foo: ''
})

```
will yield this error `Type 'string' is not assignable to type '((props: Readonly<{ foo: string[]; }>) => string[]) | undefined'.`.

This happens because the `InferDefaults` type doesn't correctly recognize array types.

This changes the recognized types from `number | string | boolean | symbol | Function` to `type DefaultTypes = number | string | boolean | symbol | Function | DefaultTypes[]`