### PR TITLE
fix(runtime-core): add InferDefaults handling of array and object union types

### DIFF
--- a/packages/runtime-core/src/apiSetupHelpers.ts
+++ b/packages/runtime-core/src/apiSetupHelpers.ts
@@ -126,15 +126,21 @@ export function defineExpose(exposed?: Record<string, any>) {
 
 type NotUndefined<T> = T extends undefined ? never : T
 
+type BasePropTypes = number | string | boolean | symbol | Function
+
+type IsBasePropType<T> = T extends BasePropTypes ? T : never
+type IsNestedPropType<T> = T extends object | Array<BasePropTypes> ? T : never
+
 type InferDefaults<T> = {
-  [K in keyof T]?: NotUndefined<T[K]> extends
-    | number
-    | string
-    | boolean
-    | symbol
-    | Function
-    ? NotUndefined<T[K]>
-    : (props: T) => NotUndefined<T[K]>
+  [K in keyof T]?:
+    | (IsBasePropType<NotUndefined<T[K]>> extends BasePropTypes
+        ? IsBasePropType<NotUndefined<T[K]>>
+        : never)
+    | (IsNestedPropType<NotUndefined<T[K]>> extends
+        | object
+        | Array<BasePropTypes>
+        ? (props: T) => IsNestedPropType<NotUndefined<T[K]>>
+        : never)
 }
 
 type PropsWithDefaults<Base, Defaults> = Base &

--- a/packages/runtime-core/src/apiSetupHelpers.ts
+++ b/packages/runtime-core/src/apiSetupHelpers.ts
@@ -126,27 +126,22 @@ export function defineExpose(exposed?: Record<string, any>) {
 
 type NotUndefined<T> = T extends undefined ? never : T
 
-type BasePropTypes = number | string | boolean | symbol | Function
-
-type IsBasePropType<T> = T extends BasePropTypes ? T : never
-type IsNestedPropType<T> = T extends object | Array<BasePropTypes> ? T : never
-
 type InferDefaults<T> = {
-  [K in keyof T]?:
-    | (IsBasePropType<NotUndefined<T[K]>> extends BasePropTypes
-        ? IsBasePropType<NotUndefined<T[K]>>
-        : never)
-    | (IsNestedPropType<NotUndefined<T[K]>> extends
-        | object
-        | Array<BasePropTypes>
-        ? (props: T) => IsNestedPropType<NotUndefined<T[K]>>
-        : never)
+  [K in keyof T]?: InferDefault<T, NotUndefined<T[K]>>
 }
 
-type PropsWithDefaults<Base, Defaults> = Base &
-  {
-    [K in keyof Defaults]: K extends keyof Base ? NotUndefined<Base[K]> : never
-  }
+type InferDefault<P, T> = T extends
+  | number
+  | string
+  | boolean
+  | symbol
+  | Function
+  ? T
+  : (props: P) => T
+
+type PropsWithDefaults<Base, Defaults> = Base & {
+  [K in keyof Defaults]: K extends keyof Base ? NotUndefined<Base[K]> : never
+}
 
 /**
  * Vue `<script setup>` compiler macro for providing props default values when

--- a/test-dts/setupHelpers.test-d.ts
+++ b/test-dts/setupHelpers.test-d.ts
@@ -45,6 +45,21 @@ describe('defineProps w/ type declaration + withDefaults', () => {
   res.x.slice()
 })
 
+describe('defineProps w/ union type declaration + withDefaults', () => {
+  withDefaults(
+    defineProps<{
+      union1?: number | number[] | { x: number }
+      union2?: number | number[] | { x: number }
+      union3?: number | number[] | { x: number }
+    }>(),
+    {
+      union1: 123,
+      union2: () => [123],
+      union3: () => ({ x: 123 })
+    }
+  )
+})
+
 describe('defineProps w/ runtime declaration', () => {
   // runtime declaration
   const props = defineProps({


### PR DESCRIPTION
This fixes an issue where `InferDefaults` fails to handle union types with base types and array or object types.

`TS2322: Type 'number' is not assignable to type '((props: Readonly<{ foo: number | number[]; }>) => number | number[]) | undefined'.`
would throw for
```ts
withDefault(
  defineProps<{ foo: number | number[] }>(),
  { foo: 123 },
)
```

This adds handling of base types and array or object types separately, so that both types can exist in prop type unions.