### PR TITLE
fix(compiler-sfc): add type for props include Function in prod mode

### DIFF
--- a/packages/compiler-sfc/__tests__/__snapshots__/compileScriptPropsTransform.spec.ts.snap
+++ b/packages/compiler-sfc/__tests__/__snapshots__/compileScriptPropsTransform.spec.ts.snap
@@ -84,7 +84,8 @@ export default /*#__PURE__*/_defineComponent({
     bar: { default: () => {} },
     baz: null,
     boola: { type: Boolean },
-    boolb: { type: [Boolean, Number] }
+    boolb: { type: [Boolean, Number] },
+    func: { type: Function, default: () => () => {} }
   },
   setup(__props: any) {
 

--- a/packages/compiler-sfc/__tests__/compileScriptPropsTransform.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileScriptPropsTransform.spec.ts
@@ -83,7 +83,7 @@ describe('sfc props transform', () => {
     const { content } = compile(
       `
       <script setup lang="ts">
-      const { foo = 1, bar = {} } = defineProps<{ foo?: number, bar?: object, baz?: any, boola?: boolean, boolb?: boolean | number }>()
+      const { foo = 1, bar = {}, func = () => {} } = defineProps<{ foo?: number, bar?: object, baz?: any, boola?: boolean, boolb?: boolean | number, func?: Function }>()
       </script>
     `,
       { isProd: true }
@@ -95,7 +95,8 @@ describe('sfc props transform', () => {
     bar: { default: () => {} },
     baz: null,
     boola: { type: Boolean },
-    boolb: { type: [Boolean, Number] }
+    boolb: { type: [Boolean, Number] },
+    func: { type: Function, default: () => () => {} }
   }`)
     assertCode(content)
   })

--- a/packages/compiler-sfc/src/compileScript.ts
+++ b/packages/compiler-sfc/src/compileScript.ts
@@ -692,8 +692,12 @@ export function compileScript(
           )}, required: ${required}${
             defaultString ? `, ${defaultString}` : ``
           } }`
-        } else if (type.some(el => el === 'Boolean' || el === 'Function')) {
-          // production: if boolean exists, should keep the type.
+        } else if (
+          type.some(
+            el => el === 'Boolean' || (defaultString && el === 'Function')
+          )
+        ) {
+          // #4783 production: if boolean or defaultString and function exists, should keep the type.
           return `${key}: { type: ${toRuntimeTypeString(type)}${
             defaultString ? `, ${defaultString}` : ``
           } }`

--- a/packages/compiler-sfc/src/compileScript.ts
+++ b/packages/compiler-sfc/src/compileScript.ts
@@ -692,11 +692,9 @@ export function compileScript(
           )}, required: ${required}${
             defaultString ? `, ${defaultString}` : ``
           } }`
-        } else if (type.indexOf('Boolean') > -1) {
+        } else if (type.some(el => el === 'Boolean' || el === 'Function')) {
           // production: if boolean exists, should keep the type.
-          return `${key}: { type: ${toRuntimeTypeString(
-            type
-          )}${
+          return `${key}: { type: ${toRuntimeTypeString(type)}${
             defaultString ? `, ${defaultString}` : ``
           } }`
         } else {
@@ -1631,10 +1629,7 @@ function extractRuntimeProps(
       if (m.type === 'TSMethodSignature') {
         type = ['Function']
       } else if (m.typeAnnotation) {
-        type = inferRuntimeType(
-          m.typeAnnotation.typeAnnotation,
-          declaredTypes
-        )
+        type = inferRuntimeType(m.typeAnnotation.typeAnnotation, declaredTypes)
       }
       props[m.key.name] = {
         key: m.key.name,


### PR DESCRIPTION
Solve the problem of the following scenarios: 
* Link to minimal reproduction : [sfc.vuejs.org](https://sfc.vuejs.org/#eyJBcHAudnVlIjoiPHNjcmlwdCBzZXR1cD5cbmltcG9ydCBDaGlsZCBmcm9tICcuL0NvbXAudnVlJ1xuPC9zY3JpcHQ+XG5cbjx0ZW1wbGF0ZT5cbiAgPENoaWxkIC8+XG48L3RlbXBsYXRlPiIsImltcG9ydC1tYXAuanNvbiI6IntcbiAgXCJpbXBvcnRzXCI6IHtcbiAgICBcInZ1ZVwiOiBcImh0dHBzOi8vc2ZjLnZ1ZWpzLm9yZy92dWUucnVudGltZS5lc20tYnJvd3Nlci5qc1wiXG4gICAgXCJ2dWVcIjogXCJodHRwczovL3NmYy52dWVqcy5vcmcvdnVlLnJ1bnRpbWUuZXNtLWJyb3dzZXIuanNcIlxuICB9XG59IiwiQ29tcC52dWUiOiI8c2NyaXB0IHNldHVwIGxhbmc9J3RzJz5cbiAgaW1wb3J0IHsgb25Nb3VudGVkIH0gZnJvbSAndnVlJ1xuICB2YXIgcHJvcHMgPSB3aXRoRGVmYXVsdHMoZGVmaW5lUHJvcHM8e2Y/OiBGdW5jdGlvbn0+KCkse2Y6KCk9PlsxLDIsM119KVxuICBvbk1vdW50ZWQoKCk9PntcbiAgICBjb25zb2xlLmxvZyhcImY6XCIscHJvcHMuZilcbiAgfSlcbjwvc2NyaXB0PiJ9)
* main code:

app.vue:
```ts
<script setup>
import Child from './Comp.vue'
</script>

<template>
  <Child />
</template>
```
Comp.vue:
```ts
<script setup lang='ts'>
  
import { onMounted } from 'vue'
  
var props = withDefaults(defineProps<{f?: Function}>(),{f:()=>[1,2,3]})

onMounted(()=>{
  console.log("f:",props.f)
})
  
</script>
```
* What is expected?
Expect the console print results to be consistent in `prod` mode and `dev` mode.
But in `dev` mode print : `f: ()=>[1,2,3]`
in  `prod` mode print : `f: [1,2,3]`