### PR TITLE
fix(ssr): remove empty comment node in ssrRenderSlot which cause dom mismatch

### DIFF
--- a/packages/server-renderer/src/helpers/ssrRenderSlot.ts
+++ b/packages/server-renderer/src/helpers/ssrRenderSlot.ts
@@ -20,7 +20,6 @@ export function ssrRenderSlot(
   slotScopeId?: string
 ) {
   // template-compiled slots are always rendered as fragments
-  push(`<!--[-->`)
   const slotFn = slots[slotName]
   if (slotFn) {
     const slotBuffer: SSRBufferItem[] = []
@@ -59,7 +58,6 @@ export function ssrRenderSlot(
   } else if (fallbackRenderFn) {
     fallbackRenderFn()
   }
-  push(`<!--]-->`)
 }
 
 const commentRE = /^<!--.*-->$/


### PR DESCRIPTION
Excuse me, I can't confirm whether it's a bug or features.

If i use vue sfc as layout to render html boilerplate like

```js
// layout.vue
<template>
  <html>
    <head>
    </head>
    <body>
      <div id="app">
        <slot name="children" />
      </div>
    </body>
  </html>
</template>
```
And i have a App.vue will be rendered in slot
```js
<template>
  <router-view />
</template>
```

In ssr client-entry has below code

```js
app.mount('#app')
```

But `ssrRenderSlot` in server side will render empty comment node in `slot` tag, and we only hydrate base on `<div id="app">` node which cause dom mismatch in below code

```js
// server code
<div id="app>
<!--[-->
xxxhtml
<!--]-->
</div>

// client code 
<div id="app>xxxhtml</div>

```
When i remove `ssrRenderSlot` internal code `<!--[-->` the behavior can be succeed

In addtion, in Vue2 has not the empty comment node logic.
And there is different between vue2 and vue3 ssr demo, in vue2 App.vue contains `<div id="app">` but in vue3 ssr demo these code is writen in `index.html`. See [ssr-vue3](https://github.com/vitejs/vite/blob/main/packages/playground/ssr-vue/index.html) [vue2 hacknews](https://github.com/vuejs/vue-hackernews-2.0/blob/master/src/App.vue)