### PR TITLE
fix(types): require function default value in `withDefaults` macro only for objects and arrays

### DIFF
--- a/packages/runtime-core/src/apiSetupHelpers.ts
+++ b/packages/runtime-core/src/apiSetupHelpers.ts
@@ -128,19 +128,15 @@ type NotUndefined<T> = T extends undefined ? never : T
 
 type InferDefaults<T> = {
   [K in keyof T]?: NotUndefined<T[K]> extends
-    | number
-    | string
-    | boolean
-    | symbol
-    | Function
-    ? NotUndefined<T[K]>
-    : (props: T) => NotUndefined<T[K]>
+    | Record<string, unknown>
+    | ReadonlyArray<any>
+    ? (props: T) => NotUndefined<T[K]>
+    : NotUndefined<T[K]>
 }
 
-type PropsWithDefaults<Base, Defaults> = Base &
-  {
-    [K in keyof Defaults]: K extends keyof Base ? NotUndefined<Base[K]> : never
-  }
+type PropsWithDefaults<Base, Defaults> = Base & {
+  [K in keyof Defaults]: K extends keyof Base ? NotUndefined<Base[K]> : never
+}
 
 /**
  * Vue `<script setup>` compiler macro for providing props default values when

--- a/test-dts/setupHelpers.test-d.ts
+++ b/test-dts/setupHelpers.test-d.ts
@@ -21,28 +21,33 @@ describe('defineProps w/ type declaration', () => {
 })
 
 describe('defineProps w/ type declaration + withDefaults', () => {
-  const res = withDefaults(
+  const props = withDefaults(
     defineProps<{
       number?: number
-      arr?: string[]
-      obj?: { x: number }
-      fn?: (e: string) => void
-      x?: string
+      array?: string[]
+      readonlyArray?: readonly string[]
+      object?: { a: number }
+      function?: (x: string) => void
+      string?: string
+      null?: null
     }>(),
     {
-      number: 123,
-      arr: () => [],
-      obj: () => ({ x: 123 }),
-      fn: () => {}
+      number: 1,
+      array: () => [],
+      readonlyArray: () => [],
+      object: () => ({ a: 1 }),
+      function: () => {}
     }
   )
 
-  res.number + 1
-  res.arr.push('hi')
-  res.obj.x
-  res.fn('hi')
-  // @ts-expect-error
-  res.x.slice()
+  expectType<number>(props.number)
+  expectType<string[]>(props.array)
+  expectType<readonly string[]>(props.readonlyArray)
+  expectType<{ a: number }>(props.object)
+  expectType<(x: string) => void>(props.function)
+  // should remain optional if no default is given
+  expectType<string | null | undefined>(props.string)
+  expectType<null | undefined>(props.null)
 })
 
 describe('defineProps w/ runtime declaration', () => {


### PR DESCRIPTION
I saw an issue coming up in #4868 and it seems to be related to a type problem in the `withDefaults` function. Default values for props containing `null` (union or directly) are required to be given in function form but should be treated like other primitives.

[Playground link with reproduction](https://www.typescriptlang.org/play?#code/C4TwDgpgBAcg9sAqgOwCYQGYEtkVQHgBUA+KAXikKggA9gI0BnKAVzUxzygH4pcA3CACcoALkoAoCaEhQAksgzCAIpgCGLADbBGRUhQDeEqFADaAaSg4oAawgg4GSgF1u4+EnbZcBQheektPRMxiZQAD58LAC2AEbCoSaRjMBCOADmiRFQsXBwmhBqyFnJIHH5JVAAYmwAxsBYcMVhPLAIKOjeeET+xFniABRgQnBgjOKEAJTkpB4dHD495gESAL5SMtAACiNjAOpYwAAWqhga2roAQmqMEAA0UKfnOvpQ17dQAGShRi0WVshbPZHI91FodM5xJYggxUMw7A4nO9oLw5l5OARkb0xHwIIIhKF1hJ0LVNGohNAMHUGk0oJ1ODtRrpCOAIIyxsQBpNxAAlQqoJqaEBEVnsxh9YkQUnkynUxqAgDuhxOYIu+DFDye4OYMKY8kUKlVOnVu3FnNCwyZ4g1oU6z3GoLO2ok3KgYoOxy1ao1jvtEpw9CEZ1q21NUF+UDUbigKTSyEyJli0eQWk0aykAHoM77wVAMHARLErMw1Hm5bTYixgDGjnAtKgctBUoV6A3NFg7FAEEdhFBhlhoocsIJGNJWVAAILkfVKIRe41ivpAA)