### PR TITLE
chore: update `test` command

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "size-baseline": "node scripts/build.js runtime-dom runtime-core reactivity shared -f esm-bundler && cd packages/size-check && vite build",
     "lint": "eslint --ext .ts packages/*/src/**.ts",
     "format": "prettier --write --parser typescript \"packages/**/*.ts?(x)\"",
-    "test": "run-s test-unit test-e2e",
+    "test": "run-s \"test-unit -- {@}\" \"test-e2e -- {@}\" --",
     "test-unit": "jest --filter ./scripts/filter-unit.js",
     "test-e2e": "node scripts/build.js vue -f global -d && jest --filter ./scripts/filter-e2e.js --runInBand",
     "test-dts": "node scripts/build.js shared reactivity runtime-core runtime-dom -dt -f esm-bundler && npm run test-dts-only",


### PR DESCRIPTION
CI failed: https://github.com/vuejs/vue-next/runs/4207501061?check_suite_focus=true
Because option of `run-s` is invalid.
See: https://github.com/mysticatea/npm-run-all/blob/master/docs/run-s.md