### PR TITLE
chore: fix ci build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - run: pnpm install
 
       - name: Run unit tests
-        run: pnpm run test -- --ci
+        run: pnpm run test
 
   test-dts:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Jobs are currently failing with:
```
> @3.2.22 test /home/runner/work/vue-next/vue-next
> run-s test-unit test-e2e "--ci"

ERROR: Invalid Option: --ci
```