### PR TITLE
Ensure value for OPTION elements is properly set in edge case (fix #4956)

### DIFF
--- a/packages/runtime-dom/__tests__/patchProps.spec.ts
+++ b/packages/runtime-dom/__tests__/patchProps.spec.ts
@@ -29,9 +29,12 @@ describe('runtime-dom: props patching', () => {
   // so we need to add tests for other elements
   test('value for non-text input', () => {
     const el = document.createElement('option')
+    el.textContent = 'foo' // #4956
     patchProp(el, 'value', null, 'foo')
+    expect(el.getAttribute('value')).toBe('foo')
     expect(el.value).toBe('foo')
     patchProp(el, 'value', null, null)
+    el.textContent = ''
     expect(el.value).toBe('')
     // #3475
     expect(el.getAttribute('value')).toBe(null)

--- a/packages/runtime-dom/src/modules/props.ts
+++ b/packages/runtime-dom/src/modules/props.ts
@@ -31,7 +31,12 @@ export function patchDOMProp(
     // non-string values will be stringified.
     el._value = value
     const newValue = value == null ? '' : value
-    if (el.value !== newValue) {
+    if (
+      el.value !== newValue ||
+      // #4956: for OPTION elements, we need to check for the value attribute because
+      // el.value returns el.textContent if attribute is absent (i.e. hasn't been set yet)
+      (el.tagName === 'OPTION' && el.getAttribute('value') !== newValue)
+    ) {
       el.value = newValue
     }
     if (value == null) {

--- a/packages/runtime-dom/src/modules/props.ts
+++ b/packages/runtime-dom/src/modules/props.ts
@@ -33,9 +33,10 @@ export function patchDOMProp(
     const newValue = value == null ? '' : value
     if (
       el.value !== newValue ||
-      // #4956: for OPTION elements, we need to check for the value attribute because
-      // el.value returns el.textContent if attribute is absent (i.e. hasn't been set yet)
-      (el.tagName === 'OPTION' && el.getAttribute('value') !== newValue)
+      // #4956: always set for OPTION elements because its value falls back to
+      // textContent if no value attribute is present. And setting .value for
+      // OPTION has no side effect
+      el.tagName === 'OPTION'
     ) {
       el.value = newValue
     }


### PR DESCRIPTION
This PR covers an edge case where the OPTION element has a `textContent` matching its assigned `value` attribute.

Previously, Vue would fail to properly assign the value in this case (and consequently, the `value` attribute was missing), because for OPTION elements, `el.value` falls back to `el.textContent` when no distinct value has been set (yet)

close #4956