### PR TITLE
fix(runtime-core): do not treat non-existent property as available

### DIFF
--- a/packages/runtime-core/__tests__/componentPublicInstance.spec.ts
+++ b/packages/runtime-core/__tests__/componentPublicInstance.spec.ts
@@ -195,6 +195,10 @@ describe('component: proxy', () => {
     expect('$foobar' in instanceProxy).toBe(false)
     expect('baz' in instanceProxy).toBe(false)
 
+    // triggering getter
+    instanceProxy.baz
+    expect('baz' in instanceProxy).toBe(false)
+
     // set non-existent (goes into proxyTarget sink)
     instanceProxy.baz = 1
     expect('baz' in instanceProxy).toBe(true)

--- a/packages/runtime-core/src/componentOptions.ts
+++ b/packages/runtime-core/src/componentOptions.ts
@@ -537,15 +537,10 @@ function createDuplicateChecker() {
   }
 }
 
-export let shouldCacheAccess = true
-
 export function applyOptions(instance: ComponentInternalInstance) {
   const options = resolveMergedOptions(instance)
   const publicThis = instance.proxy! as any
   const ctx = instance.ctx
-
-  // do not cache property access on public proxy during state initialization
-  shouldCacheAccess = false
 
   // call beforeCreate first before accessing other options since
   // the hook may mutate resolved options (#2791)
@@ -679,9 +674,6 @@ export function applyOptions(instance: ComponentInternalInstance) {
       }
     }
   }
-
-  // state initialization complete at this point - start caching access
-  shouldCacheAccess = true
 
   if (computedOptions) {
     for (const key in computedOptions) {

--- a/packages/runtime-core/src/componentPublicInstance.ts
+++ b/packages/runtime-core/src/componentPublicInstance.ts
@@ -32,7 +32,6 @@ import {
   OptionTypesType,
   OptionTypesKeys,
   resolveMergedOptions,
-  shouldCacheAccess,
   MergedComponentOptionsOverride
 } from './componentOptions'
 import { EmitsOptions, EmitFn } from './componentEmits'
@@ -251,8 +250,7 @@ const enum AccessTypes {
   SETUP,
   DATA,
   PROPS,
-  CONTEXT,
-  OTHER
+  CONTEXT
 }
 
 export interface ComponentRenderContext {
@@ -321,8 +319,6 @@ export const PublicInstanceProxyHandlers: ProxyHandler<any> = {
       } else if (ctx !== EMPTY_OBJ && hasOwn(ctx, key)) {
         accessCache![key] = AccessTypes.CONTEXT
         return ctx[key]
-      } else if (!__FEATURE_OPTIONS_API__ || shouldCacheAccess) {
-        accessCache![key] = AccessTypes.OTHER
       }
     }
 


### PR DESCRIPTION
`PublicComponentInstance` was treating any property as available (`has` will return true) due to caching it inside accessCache with flag 4 (`OTHER`). This flag is unused across entire codebase, so my naive approach is to remove it