### PR TITLE
fix(runtime-dom): handle Symbol attributes

### DIFF
--- a/packages/runtime-dom/__tests__/patchAttrs.spec.ts
+++ b/packages/runtime-dom/__tests__/patchAttrs.spec.ts
@@ -45,6 +45,12 @@ describe('runtime-dom: attrs patching', () => {
     expect(el.getAttribute('foo')).toBe(null)
   })
 
+  test('symbol attributes', () => {
+    const el = document.createElement('button')
+    patchProp(el, 'aria-label', null, Symbol('Close'))
+    expect(el.getAttribute('aria-label')).toBe('Symbol(Close)')
+  })
+
   // #949
   test('onxxx but non-listener attributes', () => {
     const el = document.createElement('div')

--- a/packages/runtime-dom/src/modules/attrs.ts
+++ b/packages/runtime-dom/src/modules/attrs.ts
@@ -1,6 +1,7 @@
 import {
   includeBooleanAttr,
   isSpecialBooleanAttr,
+  isSymbol,
   makeMap,
   NOOP
 } from '@vue/shared'
@@ -36,7 +37,12 @@ export function patchAttr(
     if (value == null || (isBoolean && !includeBooleanAttr(value))) {
       el.removeAttribute(key)
     } else {
-      el.setAttribute(key, isBoolean ? '' : value)
+      // Symbols are explicitly stringified as the underlying library
+      // does not handle them https://github.com/jsdom/webidl-conversions/issues/14
+      el.setAttribute(
+        key,
+        isBoolean ? '' : isSymbol(value) ? value.toString() : value
+      )
     }
   }
 }


### PR DESCRIPTION
Currently, passing a `Symbol` to an attribute throws in `runtime-dom` with:

```
TypeError: Failed to execute 'setAttribute' on 'Element': parameter 2 is a symbol, which cannot be converted to a string.
```

This is because the underlying library used for conversion does not handle Symbol (see https://github.com/jsdom/webidl-conversions/issues/14).

This issue cascades into VTU-next as `shallowMount` attempts to write props values as attributes.
See https://github.com/vuejs/vue-test-utils-next/issues/1076 for more context.