### PR TITLE
fix(runtime-core): return hook() in wrappedHook to handle the async call in KeepAliveHook.

### DIFF
--- a/packages/runtime-core/__tests__/components/KeepAlive.spec.ts
+++ b/packages/runtime-core/__tests__/components/KeepAlive.spec.ts
@@ -16,7 +16,9 @@ import {
   cloneVNode,
   provide,
   defineAsyncComponent,
-  Component
+  Component,
+  createApp,
+  onActivated
 } from '@vue/runtime-test'
 import { KeepAliveProps } from '../../src/components/KeepAlive'
 
@@ -873,5 +875,32 @@ describe('KeepAlive', () => {
     toggle.value = true
     await nextTick()
     expect(serializeInner(root)).toBe('<p>1</p>')
+  })
+
+  // #4976
+  test('handle error in async onActivated', async () => {
+    const err = new Error('foo')
+    const handler = jest.fn()
+
+    const app = createApp({
+      setup() {
+        return () => h(KeepAlive, null, () => h(Child))
+      }
+    })
+
+    const Child = {
+      setup() {
+        onActivated(async () => {
+          throw err
+        })
+      },
+      render() {}
+    }
+
+    app.config.errorHandler = handler
+    app.mount(nodeOps.createElement('div'))
+
+    await nextTick()
+    expect(handler).toHaveBeenCalledWith(err, {}, 'activated hook')
   })
 })

--- a/packages/runtime-core/__tests__/errorHandling.spec.ts
+++ b/packages/runtime-core/__tests__/errorHandling.spec.ts
@@ -9,8 +9,6 @@ import {
   nextTick,
   defineComponent,
   watchEffect,
-  KeepAlive,
-  onActivated,
   createApp
 } from '@vue/runtime-test'
 
@@ -55,7 +53,6 @@ describe('error handling', () => {
 
   test('propagation stoppage', () => {
     const err = new Error('foo')
-    const err2 = new Error('bar')
     const fn = jest.fn()
 
     const Comp = {
@@ -74,7 +71,7 @@ describe('error handling', () => {
           fn(err, info, 'child')
           return false
         })
-        return () => h(KeepAlive, null, () => h(GrandChild))
+        return () => h(GrandChild)
       }
     }
 
@@ -83,22 +80,17 @@ describe('error handling', () => {
         onMounted(() => {
           throw err
         })
-        onActivated(() => {
-          throw err2
-        })
         return () => null
       }
     }
 
     render(h(Comp), nodeOps.createElement('div'))
-    expect(fn).toHaveBeenCalledTimes(2)
+    expect(fn).toHaveBeenCalledTimes(1)
     expect(fn).toHaveBeenCalledWith(err, 'mounted hook', 'child')
-    expect(fn).toHaveBeenCalledWith(err2, 'activated hook', 'child')
   })
 
-  test.only('async error handling', async () => {
+  test('async error handling', async () => {
     const err = new Error('foo')
-    const err2 = new Error('bar')
     const fn = jest.fn()
 
     const Comp = {
@@ -107,7 +99,7 @@ describe('error handling', () => {
           fn(err, info)
           return false
         })
-        return () => h(KeepAlive, null, () => h(Child))
+        return () => h(Child)
       }
     }
 
@@ -116,9 +108,6 @@ describe('error handling', () => {
         onMounted(async () => {
           throw err
         })
-        onActivated(async () => {
-          throw err2
-        })
       },
       render() {}
     }
@@ -126,9 +115,7 @@ describe('error handling', () => {
     render(h(Comp), nodeOps.createElement('div'))
     expect(fn).not.toHaveBeenCalled()
     await new Promise(r => setTimeout(r))
-    expect(fn).toHaveBeenCalledTimes(2)
     expect(fn).toHaveBeenCalledWith(err, 'mounted hook')
-    expect(fn).toHaveBeenCalledWith(err2, 'activated hook')
   })
 
   test('error thrown in onErrorCaptured', () => {

--- a/packages/runtime-core/src/components/KeepAlive.ts
+++ b/packages/runtime-core/src/components/KeepAlive.ts
@@ -381,7 +381,7 @@ function registerKeepAliveHook(
         }
         current = current.parent
       }
-      hook()
+      return hook()
     })
   injectHook(type, wrappedHook, target)
   // In addition to registering it on the target instance, we walk up the parent


### PR DESCRIPTION
fix #4976 