### PR TITLE
fix(runtime-core): script-setup+ts: ensure proper hanlding of `null` as default prop value in types. (fix #4868)

### DIFF
--- a/packages/runtime-core/src/apiSetupHelpers.ts
+++ b/packages/runtime-core/src/apiSetupHelpers.ts
@@ -131,6 +131,7 @@ type InferDefaults<T> = {
 }
 
 type InferDefault<P, T> = T extends
+  | null
   | number
   | string
   | boolean


### PR DESCRIPTION
`null` was missing from the list of primitive types in `InferDefault`, so it caused a type error when used in `withDefaults()`

fix:  #4868