### PR TITLE
refactor(runtime-core): use fill instead

### DIFF
--- a/packages/runtime-core/src/renderer.ts
+++ b/packages/runtime-core/src/renderer.ts
@@ -1911,8 +1911,7 @@ function baseCreateRenderer(
       // and oldIndex = 0 is a special value indicating the new node has
       // no corresponding old node.
       // used for determining longest stable subsequence
-      const newIndexToOldIndexMap = new Array(toBePatched)
-      for (i = 0; i < toBePatched; i++) newIndexToOldIndexMap[i] = 0
+      const newIndexToOldIndexMap = new Array(toBePatched).fill(0)
 
       for (i = s1; i <= e1; i++) {
         const prevChild = c1[i]


### PR DESCRIPTION
Use fill instead of initializing the array

This will make packaged code more streamlined