### PR TITLE
feat(runtime-core)-decrease-traverse-times

### DIFF
--- a/packages/runtime-core/src/apiWatch.ts
+++ b/packages/runtime-core/src/apiWatch.ts
@@ -7,7 +7,6 @@ import {
   ReactiveFlags,
   EffectScheduler,
   DebuggerOptions,
-  isProxy,
   toRaw
 } from '@vue/reactivity'
 import { SchedulerJob, queuePreFlushCb } from './scheduler'
@@ -431,7 +430,7 @@ export function createPathGetter(ctx: any, path: string) {
 }
 
 export function traverse(value: unknown, seen?: Set<unknown>) {
-    if (!isObject(value) || (value as any)[ReactiveFlags.SKIP] || !(isProxy(value) || isRef(value))) {
+    if (!isObject(value) || (value as any)[ReactiveFlags.SKIP] || !(isReactive(value) || isRef(value))) {
       return value
     }
     seen = seen || new Set()


### PR DESCRIPTION
when i learn watch api, i find that doWatch function will invoke traverse function in order to collect deps deeply, but when a object is not proxy or ref, i think it makes no sense to traverse that object, so i modify the code in order to decrease meaningless traverse