### PR TITLE
fix(runtime-core): update traverseStaticChildren for teleport

### DIFF
--- a/packages/runtime-core/__tests__/components/Teleport.spec.ts
+++ b/packages/runtime-core/__tests__/components/Teleport.spec.ts
@@ -471,4 +471,45 @@ describe('renderer: teleport', () => {
     expect(dir.mounted).toHaveBeenCalledTimes(1)
     expect(dir.unmounted).toHaveBeenCalledTimes(1)
   })
+
+  // #4942
+  test('should call traverseStaticChildren with text-children', async () => {
+    const target = nodeOps.createElement('div')
+    const root = nodeOps.createElement('div')
+    const text = ref('foo')
+    const show = ref(true)
+
+    const App = {
+      setup() {
+        return {
+          text,
+          show,
+          target
+        }
+      },
+      render: compile(`
+      <div v-if="show">
+        {{ text }}
+        <teleport :to="target">
+          zoo
+        </teleport>
+      </div>
+      `)
+    }
+    render(h(App), root)
+
+    show.value = false
+    await nextTick()
+
+    show.value = true
+    await nextTick()
+
+    text.value = ''
+    await nextTick()
+
+    show.value = false
+    await nextTick()
+
+    expect(serializeInner(target)).toBe(``)
+  })
 })

--- a/packages/runtime-core/src/renderer.ts
+++ b/packages/runtime-core/src/renderer.ts
@@ -2465,6 +2465,10 @@ export function invokeVNodeHook(
  * Inside keyed `template` fragment static children, if a fragment is moved,
  * the children will always be moved. Therefore, in order to ensure correct move
  * position, el should be inherited from previous nodes.
+ *
+ * #4942
+ * When a Teleport has text children, it should inhert element from preVNode to
+ * access the right element.
  */
 export function traverseStaticChildren(n1: VNode, n2: VNode, shallow = false) {
   const ch1 = n1.children
@@ -2475,7 +2479,10 @@ export function traverseStaticChildren(n1: VNode, n2: VNode, shallow = false) {
       // guaranteed to be vnodes
       const c1 = ch1[i] as VNode
       let c2 = ch2[i] as VNode
-      if (c2.shapeFlag & ShapeFlags.ELEMENT && !c2.dynamicChildren) {
+      if (
+        c2.shapeFlag & (ShapeFlags.ELEMENT | ShapeFlags.TEXT_CHILDREN) &&
+        !c2.dynamicChildren
+      ) {
         if (c2.patchFlag <= 0 || c2.patchFlag === PatchFlags.HYDRATE_EVENTS) {
           c2 = ch2[i] = cloneIfMounted(ch2[i] as VNode)
           c2.el = c1.el


### PR DESCRIPTION
fix #4942 .
An egde case.Because of the hoist vnode, the new vnode can't get right reference of element.