### PR TITLE
fix: ensure ref-macros export plays nice with vue-tsc

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -34,7 +34,7 @@
     },
     "./dist/*": "./dist/*",
     "./package.json": "./package.json",
-    "./ref-macros.d.ts": "./ref-macros.d.ts"
+    "./ref-macros": "./ref-macros.d.ts"
   },
   "buildOptions": {
     "name": "Vue",


### PR DESCRIPTION
The fix in 124570973df4ddfdd38e43bf1e92b9710321e5d9 seems incomplete - it works in VSCode, but vue-tsc still throws: 

> vue-tsc --noEmit && vite build
> src/env.d.ts:2:23 - error TS2688: Cannot find type definition file for 'vue/ref-macros'.
> `2 /// <reference types="vue/ref-macros" />`

it seems that the `"exports"` entry for the ref-macros should not have the .d.ts extension:

```diff
  "exports": {
    // ....
    "./dist/*": "./dist/*",
    "./package.json": "./package.json",
-    "./ref-macros.d.ts": "./ref-macros.d.ts"
+    "./ref-macros": "./ref-macros.d.ts"
  },
```

Doing that change in an actual plain vite project and running build works without throwing an error. 

I used: https://github.com/malobre/vue3-ref-transform-type-reference-bug