### PR TITLE
enhance the warning when not explicitly declare the variable

### DIFF
--- a/packages/runtime-core/src/componentPublicInstance.ts
+++ b/packages/runtime-core/src/componentPublicInstance.ts
@@ -386,6 +386,15 @@ export const PublicInstanceProxyHandlers: ProxyHandler<any> = {
             `but is not defined on instance.`
         )
       }
+    } else if (
+      __DEV__ &&
+      !__TEST__ &&
+      !(key[0] === '$' || key[0] === '_')
+    ) {
+      warn(
+        `Property ${JSON.stringify(key)} was accessed during render ` +
+          `but is not defined on instance.`
+      )
     }
   },
 


### PR DESCRIPTION
fix: #4305 

No idea how to add test,  because it will broken other test. So I add `!__TEST__` to avoid test fail.😢

You can clone this project: [https://github.com/caozhong1996/v3-warn-demo](https://github.com/caozhong1996/v3-warn-demo).

I added those code in `vue.js`:

````js
// line 7468
} else if (
  !(key[0] === '$' || key[0] === '_')
) {
  warn$1(
    `Property ${JSON.stringify(key)} was accessed during render ` +
      `but is not defined on instance.`
  )
}
```` 

![impicture_20211128_204342](https://user-images.githubusercontent.com/26522151/143768243-ad0e4280-94ba-4fe7-9bde-6476153117c6.png)
