### PR TITLE
fix: watchEffect should not track watch's callback when the instance is not mounted #5009

### DIFF
--- a/packages/runtime-core/__tests__/apiWatch.spec.ts
+++ b/packages/runtime-core/__tests__/apiWatch.spec.ts
@@ -1090,4 +1090,40 @@ describe('api: watch', () => {
     // own update effect
     expect(instance!.scope.effects.length).toBe(1)
   })
+
+  it.only('watchEffect should not track watch callback when instance is not mounted', async () => {
+    let _formData: { value: string }
+    const Comp = {
+      setup() {
+        const formData = reactive({
+          value: ''
+        })
+        _formData = formData
+        const options = reactive([{
+          value: 'value1'
+        }, {
+          value: 'value2'
+        }])
+        watch(formData, () => {
+          // just track formData.value
+          return formData.value
+        })
+        watchEffect(()=>{
+          formData.value = options[0].value
+        })
+        return () => ''
+      }
+    }
+    const root = nodeOps.createElement('div')
+    createApp(Comp).mount(root)
+
+    _formData!.value = 'value2'
+    await nextTick()
+    expect(_formData!.value).toBe('value2')
+
+    _formData!.value = 'value1'
+    await nextTick()
+    expect(_formData!.value).toBe('value1')
+  })
+
 })

--- a/packages/runtime-core/src/apiWatch.ts
+++ b/packages/runtime-core/src/apiWatch.ts
@@ -6,7 +6,9 @@ import {
   isReactive,
   ReactiveFlags,
   EffectScheduler,
-  DebuggerOptions
+  DebuggerOptions,
+  pauseTracking,
+  resetTracking
 } from '@vue/reactivity'
 import { SchedulerJob, queuePreFlushCb } from './scheduler'
 import {
@@ -350,7 +352,9 @@ function doWatch(
       } else {
         // with 'pre' option, the first call must happen before
         // the component is mounted so it is called synchronously.
+        pauseTracking()
         job()
+        resetTracking()
       }
     }
   }


### PR DESCRIPTION
The reason is in the issue #5009
I think the watch's callback shouldn't be tracked whether it is mounted or is not mounted. So i think it should `pauseTracking` before the watch's callback and then `resetTracking` after it.