### PR TITLE
fix(runtime-core): ensure that binding.instance in custom directive hooks has access to exposed properties on closed instances (fix: #5018)

### DIFF
--- a/packages/runtime-core/__tests__/directives.spec.ts
+++ b/packages/runtime-core/__tests__/directives.spec.ts
@@ -7,7 +7,8 @@ import {
   DirectiveHook,
   VNode,
   DirectiveBinding,
-  nextTick
+  nextTick,
+  defineComponent
 } from '@vue/runtime-test'
 import { currentInstance, ComponentInternalInstance } from '../src/component'
 
@@ -394,5 +395,30 @@ describe('directives', () => {
     await nextTick()
     expect(beforeUpdate).toHaveBeenCalledTimes(1)
     expect(count.value).toBe(1)
+  })
+
+  test('should receive exposeProxy for closed instances', async () => {
+    let res: string
+    const App = defineComponent({
+      setup(_, { expose }) {
+        expose({
+          msg: 'Test'
+        })
+
+        return () =>
+          withDirectives(h('p', 'Lore Ipsum'), [
+            [
+              {
+                mounted(el, { instance }) {
+                  res = (instance as any).msg as string
+                }
+              }
+            ]
+          ])
+      }
+    })
+    const root = nodeOps.createElement('div')
+    render(h(App), root)
+    expect(res!).toBe('Test')
   })
 })

--- a/packages/runtime-core/src/directives.ts
+++ b/packages/runtime-core/src/directives.ts
@@ -14,7 +14,7 @@ return withDirectives(h(comp), [
 import { VNode } from './vnode'
 import { isFunction, EMPTY_OBJ, makeMap } from '@vue/shared'
 import { warn } from './warning'
-import { ComponentInternalInstance, Data } from './component'
+import { ComponentInternalInstance, Data, getExposeProxy } from './component'
 import { currentRenderingInstance } from './componentRenderContext'
 import { callWithAsyncErrorHandling, ErrorCodes } from './errorHandling'
 import { ComponentPublicInstance } from './componentPublicInstance'
@@ -93,7 +93,9 @@ export function withDirectives<T extends VNode>(
     __DEV__ && warn(`withDirectives can only be used inside render functions.`)
     return vnode
   }
-  const instance = internalInstance.proxy
+  const instance =
+    (getExposeProxy(internalInstance) as ComponentPublicInstance) ||
+    internalInstance.proxy
   const bindings: DirectiveBinding[] = vnode.dirs || (vnode.dirs = [])
   for (let i = 0; i < directives.length; i++) {
     let [dir, value, arg, modifiers = EMPTY_OBJ] = directives[i]

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -34,7 +34,7 @@
     },
     "./dist/*": "./dist/*",
     "./package.json": "./package.json",
-    "./ref-macros.d.ts": "./ref-macros.d.ts"
+    "./ref-macros": "./ref-macros.d.ts"
   },
   "buildOptions": {
     "name": "Vue",


### PR DESCRIPTION
For closed instances (those crreated with `<script setup>` or a normal setup function in which `expose()` has been called), we currently expose a different proxy for i.e. refs. 

This proxy provides access  to the public instance methods provided by Vue and the explicitly exposed custom properties.

This PR not also exposes this same proxy to custom directives in `binding-instance` so that custom directives can access exposed properties correctly.

fix: #5018