### PR TITLE
chore(compat): Fix example config syntax error

### DIFF
--- a/packages/vue-compat/README.md
+++ b/packages/vue-compat/README.md
@@ -89,6 +89,7 @@ The following workflow walks through the steps of migrating an actual Vue 2 app 
              }
            }
          })
+     }
    }
    ```
 


### PR DESCRIPTION
The chainWebpack arrow function wasn’t being closed.