### PR TITLE
refactor(types): refactor the `InferPropType` type

### DIFF
--- a/packages/runtime-core/src/apiDefineComponent.ts
+++ b/packages/runtime-core/src/apiDefineComponent.ts
@@ -41,11 +41,7 @@ export type DefineComponent<
   E extends EmitsOptions = {},
   EE extends string = string,
   PP = PublicProps,
-  Props = Readonly<
-    PropsOrPropOptions extends ComponentPropsOptions
-      ? ExtractPropTypes<PropsOrPropOptions>
-      : PropsOrPropOptions
-  > &
+  Props = Readonly<ExtractPropTypes<PropsOrPropOptions>> &
     ({} extends E ? {} : EmitsToProps<E>),
   Defaults = ExtractDefaultPropTypes<PropsOrPropOptions>
 > = ComponentPublicInstanceConstructor<

--- a/test-dts/defineComponent.test-d.tsx
+++ b/test-dts/defineComponent.test-d.tsx
@@ -275,6 +275,7 @@ describe('with object props', () => {
       hhh={false}
       ggg="foo"
       jjj={() => ''}
+      kkk={null}
       // should allow class/style as attrs
       class="bar"
       style={{ color: 'red' }}
@@ -294,6 +295,7 @@ describe('with object props', () => {
       fff={(a, b) => ({ a: a > +b })}
       hhh={false}
       jjj={() => ''}
+      kkk={1}
     />
   )
 
@@ -331,6 +333,30 @@ describe('with object props', () => {
       }
     }
   })
+})
+
+describe('DefineComponent with HTMLAttributes', () => {
+  type HTMLAttributes = {
+    onClick: Function,
+    someProp: 1 | 2
+  }
+  const props = {
+    propA: Number,
+    propB: [String, Number],
+    propC: {
+      type: String,
+      default: '1111'
+    }
+  }
+  const onClick = () => {}
+  const Comp = defineComponent<HTMLAttributes & typeof props>({
+    setup() {
+      return <div></div>
+    },
+  })
+  expectType<JSX.Element>(<Comp propB={'123'} someProp={1} onClick={onClick} propC={''} />)
+  // @ts-expect-error
+  expectError(<Comp notExist={1} />)
 })
 
 describe('type inference w/ optional props declaration', () => {


### PR DESCRIPTION
Fix: #4689
Please allow me to remind you pay attention to this pr. Due to historic reasons, Props's type inference has two styles.

### vue2 style
````ts
const props = props: {
  msg1:  Number,
  msg2: {
    type: Number,
    required: true
  }
}

defineComponent<typeof props>({
  setup(props) {
    //....
  }
})
````
`msg2` is required, `msg1` not.

### TS style
````ts
const MyComponent = defineComponent<{ a?: number; msg: number }>({
    setup(props) {
       //.....
    }
})
````
`msg2` is required, `msg1` not.
___

It's easily see what the differences: 

- If we defined one prop is vue2 style, we must use a special field called `required` to ensure it's required.
- If we defined one prop is TS style, we can just use `?` to control whether required.

It seems that they are easily distinguished, but it's not a easy thing in the code.

Like #4689, there is a minimum repetition:

![impicture_20211203_203831](https://user-images.githubusercontent.com/26522151/144603989-86ff5ba2-f4fb-4582-9e85-9b9735d7a48b.png)

Because it mixed vue2 style and Ts style, but we did not consider this before.