### PR TITLE
dx(script-setup): add generic type to defineExpose

### DIFF
--- a/packages/runtime-core/src/apiSetupHelpers.ts
+++ b/packages/runtime-core/src/apiSetupHelpers.ts
@@ -118,7 +118,7 @@ export function defineEmits() {
  * This is only usable inside `<script setup>`, is compiled away in the
  * output and should **not** be actually called at runtime.
  */
-export function defineExpose(exposed?: Record<string, any>) {
+export function defineExpose<Exposed extends Record<string, any> = Record<string, any>>(exposed?: Exposed) {
   if (__DEV__) {
     warnRuntimeUsage(`defineExpose`)
   }


### PR DESCRIPTION
Currently, the public API for a component defined using `defineExpose` is not typed when this component is used elsewhere (as discussed in #4397).

My current workaround is to define the API as an interface and casting the object in the component:

`MyComponent.d.ts`

```ts
export interface IMyComponent {

    doSomething(): void;

}
```

`MyComponent.vue`
```vue
<script setup lang="ts">
    import type { IMyComponent } from './MyComponent';

    const publicAPI: IMyComponent = {
        doSomething() {
            // ...
        },
    };

    defineExpose(publicAPI);
</script>
```

But writing that is cumbersome, I'd prefer doing the following:

```ts
defineExpose<IMyComponent>({
    doSomething() {
        // ...
    },
});
```

So that's what this PR allows :). Given that it's optional, it shouldn't affect people who isn't using this approach.

I tried extracting this pattern into my own method which I called `definePublicAPI`, but I was getting a warning so I guess `defineExpose` cannot be used for composition.