### PR TITLE
feat(sfc-playground): prevent ctrl+s default behavior

### DIFF
--- a/packages/sfc-playground/src/App.vue
+++ b/packages/sfc-playground/src/App.vue
@@ -31,6 +31,8 @@ watchEffect(() => history.replaceState({}, '', store.serialize()))
 <template>
   <Header :store="store" />
   <Repl
+    @keydown.ctrl.s.prevent
+    @keydown.meta.s.prevent
     :store="store"
     :showCompileOutput="true"
     :autoResize="true"


### PR DESCRIPTION
By default it opens the browser's 'save web page' dialog, which is annoying, because this shortcut is about 'save code change' in most code editors. And also since it's auto-save by default, so I think it can just be ignore.

------------

maybe I should commit this to @vue/repl?