### PR TITLE
fix(shared): ignore object prototype during normalizeClass calc

### DIFF
--- a/packages/shared/__tests__/normalizeProp.spec.ts
+++ b/packages/shared/__tests__/normalizeProp.spec.ts
@@ -16,4 +16,16 @@ describe('normalizeClass', () => {
       'foo baz'
     )
   })
+
+  test('ignores prototype when calculating class list from object keys', () => {
+    ;(Object as any).prototype.fubar = true
+    try {
+      expect(normalizeClass({ foo: true, bar: false, baz: true })).toEqual(
+        'foo baz'
+      )
+    } finally {
+      // try/finally to avoid any chance of global test env pollution:
+      delete (Object as any).prototype.fubar
+    }
+  })
 })

--- a/packages/shared/__tests__/normalizeProp.spec.ts
+++ b/packages/shared/__tests__/normalizeProp.spec.ts
@@ -1,4 +1,35 @@
-import { normalizeClass } from '../src'
+import { normalizeStyle, normalizeClass } from '../src'
+
+describe('normalizeStyle', () => {
+  test('handles string correctly', () => {
+    expect(normalizeStyle('foo')).toEqual('foo')
+  })
+
+  test('handles array correctly', () => {
+    expect(
+      normalizeStyle(['foo: blue', { foo: 'red', bar: 5 }, 'bar: 8'])
+    ).toEqual({ foo: 'red', bar: '8' })
+  })
+
+  test('handles object correctly', () => {
+    expect(normalizeStyle({ foo: 'blue', bar: 5 })).toEqual({
+      foo: 'blue',
+      bar: 5
+    })
+  })
+
+  test('ignores prototype when calculating style from input object keys', () => {
+    ;(Object as any).prototype.fubar = 'fizzbuz'
+    try {
+      expect(
+        normalizeStyle(['foo: blue', { foo: 'red', bar: 5 }, 'bar: 8'])
+      ).toEqual({ foo: 'red', bar: '8' })
+    } finally {
+      // try/finally to avoid any chance of global test env pollution:
+      delete (Object as any).prototype.fubar
+    }
+  })
+})
 
 describe('normalizeClass', () => {
   test('handles string correctly', () => {

--- a/packages/shared/src/normalizeProp.ts
+++ b/packages/shared/src/normalizeProp.ts
@@ -14,8 +14,9 @@ export function normalizeStyle(
         ? parseStringStyle(item)
         : (normalizeStyle(item) as NormalizedStyle)
       if (normalized) {
-        for (const key in normalized) {
-          res[key] = normalized[key]
+        const keys = Object.keys(normalized)
+        for (let j = 0; j < keys.length; j++) {
+          res[keys[j]] = normalized[keys[j]]
         }
       }
     }

--- a/packages/shared/src/normalizeProp.ts
+++ b/packages/shared/src/normalizeProp.ts
@@ -74,9 +74,10 @@ export function normalizeClass(value: unknown): string {
       }
     }
   } else if (isObject(value)) {
-    for (const name in value) {
-      if (value[name]) {
-        res += name + ' '
+    const keys = Object.keys(value)
+    for (let i = 0; i < keys.length; i++) {
+      if (value[keys[i]]) {
+        res += keys[i] + ' '
       }
     }
   }


### PR DESCRIPTION
Fix for a small issue with object iteration in `normalizeClass`. Due to usage of `for name in value` to iterate over `{ key: bool }` records, it's possible for unexpected keys to end up in the resulting class string – keys that aren't directly present on the input object, but exist on its prototype. `for name of Object.keys(value)` would fix the issue, but after some basic benchmarking it seems like a traditional index-based for loop is ever-so-slightly more performant than both `for-in` and `for-of`.

One thing that may be of slight concern is any memory implications of copying the object's keys into the intermediate `keys` array? But I would expect these objects to be small in general (maybe a bad assumption to make).

Minimal reproduction [here](
https://sfc.vuejs.org/#eyJBcHAudnVlIjoiPHNjcmlwdCBzZXR1cD5cbmltcG9ydCB7IHJlZiB9IGZyb20gJ3Z1ZSdcbiBcbmNvbnN0IG1zZyA9IHJlZignSGVsbG8gV29ybGQhJyk7XG5jb25zdCBpc0ZyaWVuZGx5ID0gcmVmKHRydWUpO1xuIFxuT2JqZWN0LnByb3RvdHlwZS5lbmVteSA9IHRydWU7XG48L3NjcmlwdD5cbiBcbjx0ZW1wbGF0ZT5cbiAgPGgxIDpjbGFzcz1cInsgZnJpZW5kOiBpc0ZyaWVuZGx5IH1cIj57eyBtc2cgfX08L2gxPlxuICA8aW5wdXQgdi1tb2RlbD1cIm1zZ1wiPlxuPC90ZW1wbGF0ZT5cbiBcbjxzdHlsZT5cbiAgLmZyaWVuZCB7IGNvbG9yOiBibHVlOyB9XG4gIC5lbmVteSB7IGNvbG9yOiByZWQ7IH1cbjwvc3R5bGU+IiwiaW1wb3J0LW1hcC5qc29uIjoie1xuICBcImltcG9ydHNcIjoge1xuICAgIFwidnVlXCI6IFwiaHR0cHM6Ly9zZmMudnVlanMub3JnL3Z1ZS5ydW50aW1lLmVzbS1icm93c2VyLmpzXCJcbiAgfVxufSJ9):

```vue
<script setup>
import { ref } from 'vue'
 
const msg = ref('Hello World!');
const isFriendly = ref(true);
 
Object.prototype.enemy = true;
</script>
 
<template>
  <h1 :class="{ friend: isFriendly }">{{ msg }}</h1>
  <input v-model="msg">
</template>
 
<style>
  .friend { color: blue; }
  .enemy { color: red; }
</style>
```

The resulting "Hello World!" text should be blue, not red, since the `.enemy` class is never intentionally applied in the template. Instead the `.friend` class is directly applied; however `.enemy` is _also_ applied since it exists in the base object prototype.

Some basic benchmarking [here](https://jsbench.me/jskwy0743c) (for whatever these are worth -- can't say I have any particular insight into how they're being run. Is there any official benchmark tooling available for Vue lib changes?)
https://jsbench.me/jskwy0743c

In particular:
```javascript
res = "";
for (const name in value) {
  if (value[name]) {
    res += name + " ";
  }
}
// 77.46 ops/s ± 1.19%
// 4.34 % slower
```
```javascript
res = "";
const keys = Object.keys(value);
for (let i = 0; i < keys.length; i++)  {
  if (value[keys[i]]) {
    res += keys[i] + " ";
  }
}
// 80.5 ops/s ± 0.81%
// Fastest
```