### PR TITLE
feat(shared): expose rawChildrenMap in context

### DIFF
--- a/packages/compiler-core/src/index.ts
+++ b/packages/compiler-core/src/index.ts
@@ -19,7 +19,8 @@ export {
   createStructuralDirectiveTransform,
   NodeTransform,
   StructuralDirectiveTransform,
-  DirectiveTransform
+  DirectiveTransform,
+  RawChildrenMap
 } from './transform'
 export { generate, CodegenContext, CodegenResult } from './codegen'
 export {

--- a/packages/compiler-core/src/transform.ts
+++ b/packages/compiler-core/src/transform.ts
@@ -39,6 +39,7 @@ import {
 import { isVSlot, makeBlock } from './utils'
 import { hoistStatic, isSingleElementRoot } from './transforms/hoistStatic'
 import { CompilerCompatOptions } from './compat/compatConfig'
+import { PlainElementNode } from '@vue/compiler-dom'
 
 // There are two types of transforms:
 //
@@ -81,6 +82,8 @@ export interface ImportItem {
   path: string
 }
 
+export type RawChildrenMap = WeakMap<PlainElementNode, TemplateLiteral['elements'][0]>
+
 export interface TransformContext
   extends Required<
       Omit<TransformOptions, 'filename' | keyof CompilerCompatOptions>
@@ -117,6 +120,7 @@ export interface TransformContext
   hoist(exp: string | JSChildNode | ArrayExpression): SimpleExpressionNode
   cache<T extends JSChildNode>(exp: T, isVNode?: boolean): CacheExpression | T
   constantCache: Map<TemplateChildNode, ConstantTypes>
+  rawChildrenMap: RawChildrenMap
 
   // 2.x Compat only
   filters?: Set<string>
@@ -194,6 +198,7 @@ export function createTransformContext(
     currentNode: root,
     childIndex: 0,
     inVOnce: false,
+    rawChildrenMap: new WeakMap(),
 
     // methods
     helper(name) {
@@ -334,6 +339,10 @@ export function transform(root: RootNode, options: TransformOptions) {
 
   if (__COMPAT__) {
     root.filters = [...context.filters!]
+  }
+
+  return {
+    context
   }
 }
 

--- a/packages/compiler-ssr/src/index.ts
+++ b/packages/compiler-ssr/src/index.ts
@@ -50,7 +50,7 @@ export function compile(
   // on slot vnode branches.
   rawOptionsMap.set(ast, options)
 
-  transform(ast, {
+  const { context } = transform(ast, {
     ...options,
     hoistStatic: false,
     nodeTransforms: [
@@ -84,7 +84,7 @@ export function compile(
 
   // traverse the template AST and convert into SSR codegen AST
   // by replacing ast.codegenNode.
-  ssrCodegenTransform(ast, options)
+  ssrCodegenTransform(ast, options, context.rawChildrenMap)
 
   return generate(ast, options)
 }

--- a/packages/compiler-ssr/src/transforms/ssrTransformElement.ts
+++ b/packages/compiler-ssr/src/transforms/ssrTransformElement.ts
@@ -48,13 +48,6 @@ import {
 } from '../runtimeHelpers'
 import { SSRTransformContext, processChildren } from '../ssrCodegenTransform'
 
-// for directives with children overwrite (e.g. v-html & v-text), we need to
-// store the raw children so that they can be added in the 2nd pass.
-const rawChildrenMap = new WeakMap<
-  PlainElementNode,
-  TemplateLiteral['elements'][0]
->()
-
 export const ssrTransformElement: NodeTransform = (node, context) => {
   if (
     node.type !== NodeTypes.ELEMENT ||
@@ -62,6 +55,10 @@ export const ssrTransformElement: NodeTransform = (node, context) => {
   ) {
     return
   }
+
+  // for directives with children overwrite (e.g. v-html & v-text), we need to
+  // store the raw children so that they can be added in the 2nd pass.
+  const { rawChildrenMap } = context
 
   return function ssrPostTransformElement() {
     // element
@@ -385,7 +382,7 @@ export function ssrProcessElement(
   // close open tag
   context.pushStringPart(`>`)
 
-  const rawChildren = rawChildrenMap.get(node)
+  const rawChildren = context.rawChildrenMap.get(node)
   if (rawChildren) {
     context.pushStringPart(rawChildren)
   } else if (node.children.length) {


### PR DESCRIPTION
This PR exposes the raw children map in the context so custom directives can do the same as `v-html` does:
https://github.com/vuejs/vue-next/blob/master/packages/compiler-ssr/src/transforms/ssrTransformElement.ts#L171

As a side effect it gets rid of this static (though weak) map:
https://github.com/vuejs/vue-next/blob/master/packages/compiler-ssr/src/transforms/ssrTransformElement.ts#L53-L56