### PR TITLE
fix(sfc-playground): hide title to avoid overlap

### DIFF
--- a/packages/sfc-playground/src/Header.vue
+++ b/packages/sfc-playground/src/Header.vue
@@ -191,7 +191,7 @@ h1 img {
   }
 }
 
-@media (max-width: 480px) {
+@media (max-width: 520px) {
   h1 span {
     display: none;
   }


### PR DESCRIPTION
Right now when using a variable width size (I use it inside slides taking half the width), the title blocks clicks:

https://user-images.githubusercontent.com/664177/145827475-d6a8ceca-443a-4ffb-96e3-76dd67d39092.mp4

This change hides the title to avoid blocking the click:

https://user-images.githubusercontent.com/664177/145827650-71356ad6-6749-4fce-a707-12355f1c5d79.mp4


