### PR TITLE
feat(keepAlive): expose pruneCacheEntry and add key match support on exclude/include changed.

### DIFF
--- a/packages/runtime-core/src/components/KeepAlive.ts
+++ b/packages/runtime-core/src/components/KeepAlive.ts
@@ -84,7 +84,7 @@ const KeepAliveImpl: ComponentOptions = {
     max: [String, Number]
   },
 
-  setup(props: KeepAliveProps, { slots }: SetupContext) {
+  setup(props: KeepAliveProps, { slots, expose }: SetupContext) {
     const instance = getCurrentInstance()!
     // KeepAlive communicates with the instantiated renderer via the
     // ctx where the renderer passes in its internals,
@@ -180,7 +180,7 @@ const KeepAliveImpl: ComponentOptions = {
     function pruneCache(filter?: (name: string) => boolean) {
       cache.forEach((vnode, key) => {
         const name = getComponentName(vnode.type as ConcreteComponent)
-        if (name && (!filter || !filter(name))) {
+        if (!filter || (name && !filter(name)) || !filter(key.toString())) {
           pruneCacheEntry(key)
         }
       })
@@ -236,6 +236,8 @@ const KeepAliveImpl: ComponentOptions = {
         unmount(cached)
       })
     })
+
+    expose({pruneCacheEntry});
 
     return () => {
       pendingCacheKey = null


### PR DESCRIPTION
So, we can 
1. Delete the cache use `this.$refs.keepAlive.pruneCacheEntry('COMPONENT_NAME/KEY')`;
2. Include/Exclude components with not only component name but also component key.