### PR TITLE
chore: require path fail

### DIFF
--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -4,6 +4,9 @@ const targets = (exports.targets = fs.readdirSync('packages').filter(f => {
   if (!fs.statSync(`packages/${f}`).isDirectory()) {
     return false
   }
+  if(!fs.existsSync(`packages/${f}/package.json`)){
+    return false
+  }
   const pkg = require(`../packages/${f}/package.json`)
   if (pkg.private && !pkg.buildOptions) {
     return false


### PR DESCRIPTION
When I git clone vue-next master. Pnpm install all staff . after `yarn dev` it crashed because of `Cannot find module '../packages/ref-transform/package.json'`