### PR TITLE
feat(types): simplify `ExtractPropTypes` to avoid props JSDocs being removed

### DIFF
--- a/packages/runtime-core/src/componentProps.ts
+++ b/packages/runtime-core/src/componentProps.ts
@@ -121,9 +121,13 @@ type InferPropType<T> = [T] extends [null]
   : T
 
 export type ExtractPropTypes<O> = O extends object
-  ? { [K in keyof O]?: unknown } & // This is needed to keep the relation between the option prop and the props, allowing to use ctrl+click to navigate to the prop options. see: #3656
-      { [K in RequiredKeys<O>]: InferPropType<O[K]> } &
-      { [K in OptionalKeys<O>]?: InferPropType<O[K]> }
+  ? {
+      // use `keyof Pick<O, RequiredKeys<O>>` instead of `RequiredKeys<O>` to support IDE features
+      [K in keyof Pick<O, RequiredKeys<O>>]: InferPropType<O[K]>
+    } & {
+      // use `keyof Pick<O, OptionalKeys<O>>` instead of `OptionalKeys<O>` to support IDE features
+      [K in keyof Pick<O, OptionalKeys<O>>]?: InferPropType<O[K]>
+    }
   : { [K in string]: any }
 
 const enum BooleanFlags {

--- a/packages/runtime-core/src/componentProps.ts
+++ b/packages/runtime-core/src/componentProps.ts
@@ -120,15 +120,13 @@ type InferPropType<T> = [T] extends [null]
     : V
   : T
 
-export type ExtractPropTypes<O> = O extends object
-  ? {
-      // use `keyof Pick<O, RequiredKeys<O>>` instead of `RequiredKeys<O>` to support IDE features
-      [K in keyof Pick<O, RequiredKeys<O>>]: InferPropType<O[K]>
-    } & {
-      // use `keyof Pick<O, OptionalKeys<O>>` instead of `OptionalKeys<O>` to support IDE features
-      [K in keyof Pick<O, OptionalKeys<O>>]?: InferPropType<O[K]>
-    }
-  : { [K in string]: any }
+export type ExtractPropTypes<O> = {
+  // use `keyof Pick<O, RequiredKeys<O>>` instead of `RequiredKeys<O>` to support IDE features
+  [K in keyof Pick<O, RequiredKeys<O>>]: InferPropType<O[K]>
+} & {
+  // use `keyof Pick<O, OptionalKeys<O>>` instead of `OptionalKeys<O>` to support IDE features
+  [K in keyof Pick<O, OptionalKeys<O>>]?: InferPropType<O[K]>
+}
 
 const enum BooleanFlags {
   shouldCast,

--- a/packages/runtime-core/src/helpers/typeUtils.ts
+++ b/packages/runtime-core/src/helpers/typeUtils.ts
@@ -5,6 +5,7 @@ export type UnionToIntersection<U> = (
   : never
 
 // make keys required but keep undefined values
-export type LooseRequired<T> = { [P in string & keyof T]: T[P] }
+// use `keyof Pick<T, string & keyof T>` instead of `string & keyof T` to support IDE features
+export type LooseRequired<T> = { [P in keyof Pick<T, string & keyof T>]: T[P] }
 
 export type IfAny<T, Y, N> = 0 extends (1 & T) ? Y : N

--- a/packages/runtime-core/src/helpers/typeUtils.ts
+++ b/packages/runtime-core/src/helpers/typeUtils.ts
@@ -5,7 +5,6 @@ export type UnionToIntersection<U> = (
   : never
 
 // make keys required but keep undefined values
-// use `keyof Pick<T, string & keyof T>` instead of `string & keyof T` to support IDE features
-export type LooseRequired<T> = { [P in keyof Pick<T, string & keyof T>]: T[P] }
+export type LooseRequired<T> = { [P in string & keyof T]: T[P] }
 
 export type IfAny<T, Y, N> = 0 extends (1 & T) ? Y : N


### PR DESCRIPTION
Relate issues: https://github.com/johnsoncodehk/volar/issues/799, https://github.com/microsoft/TypeScript/issues/31992

Remove `O extends object` from `ExtractPropTypes` to avoid tsc remove props JSDoc comments.
And it can also help for improve component props hover info in IDE.

~In addition, changed `{ [K in KeysType]: T[K] }` to `{ [K in keyof Pick<K, KeysType>]: T[K] }` to fixed find references, renaming not working for props again. (#3656)~
Revert this change from `LooseRequired` because it cause tests failed.

Before simplify `ExtractPropTypes`:

```ts
import { PropType } from 'vue';
declare const _default: import("vue").DefineComponent<{
    /**
     * The icon name as per the reference at https://pepicons.com
     * @type {'airplane' | 'angle-down'}
     * @example 'airplane'
     */
    name: {
        type: PropType<Pepicon>;
        required: true;
    };
}, () => void, unknown, {}, {}, import("vue").ComponentOptionsMixin, import("vue").ComponentOptionsMixin, Record<string, any>, string, import("vue").VNodeProps & import("vue").AllowedComponentProps & import("vue").ComponentCustomProps, Readonly<{
    name?: unknown;
} & {
    name: Pepicon;
} & {}>, {}>;
export default _default;
```

After simplify `ExtractPropTypes`:

```ts
import { PropType } from 'vue';
declare const _default: import("vue").DefineComponent<{
    /**
     * The icon name as per the reference at https://pepicons.com
     * @type {'airplane' | 'angle-down'}
     * @example 'airplane'
     */
    name: {
        type: PropType<Pepicon>;
        required: true;
    };
}, () => void, unknown, {}, {}, import("vue").ComponentOptionsMixin, import("vue").ComponentOptionsMixin, Record<string, any>, string, import("vue").VNodeProps & import("vue").AllowedComponentProps & import("vue").ComponentCustomProps, Readonly<import("vue").ExtractPropTypes<{
    /**
     * The icon name as per the reference at https://pepicons.com
     * @type {'airplane' | 'angle-down'}
     * @example 'airplane'
     */
    name: {
        type: PropType<Pepicon>;
        required: true;
    };
}>>, {}>;
export default _default;
```