### PR TITLE
fix(runtime-core): the same function (argument to onMounted) reference should be called

### DIFF
--- a/packages/runtime-core/__tests__/apiLifecycle.spec.ts
+++ b/packages/runtime-core/__tests__/apiLifecycle.spec.ts
@@ -374,4 +374,73 @@ describe('api: lifecycle hooks', () => {
       newValue: 3
     })
   })
+
+  // #4861
+  it('the same function (argument to onMounted) reference should be called', async () => {
+    const root = nodeOps.createElement('div')
+    let mountsCount = 0
+    let _mountsCount = 0
+    let unmountsCount = 0
+    let _unmountsCount = 0
+
+    function handleMounted () {
+      mountsCount++
+    }
+
+    function _handleMounted () {
+      _mountsCount++
+    }
+
+    function handleUnmounted ()  {
+      unmountsCount++
+    }
+
+    function _handleUnmounted ()  {
+      _unmountsCount++
+    }
+
+    const Comp = {
+      setup() {
+        onMounted(handleMounted)
+        // this `handleMounted` can be deduped
+        onMounted(handleMounted)
+
+        onMounted(() => _handleMounted())
+        onUnmounted(handleUnmounted)
+        onMounted(() => _handleUnmounted())
+
+        return () => h('div')
+      }
+    }
+    const isShow = ref(false)
+    const App = {
+      setup() {
+        return () => {
+          return isShow.value ? h(Comp): null
+        }
+      }
+    }
+    render(h(App), root)
+
+    isShow.value  = true
+    await nextTick()
+    expect(mountsCount).toBe(1)
+    expect(_mountsCount).toBe(1)
+
+
+    isShow.value  = false
+    await nextTick()
+    expect(unmountsCount).toBe(1)
+    expect(_unmountsCount).toBe(1)
+
+    isShow.value  = true
+    await nextTick()
+    expect(_mountsCount).toBe(2)
+    expect(mountsCount).toBe(2)
+
+    isShow.value  = false
+    await nextTick()
+    expect(unmountsCount).toBe(2)
+    expect(_unmountsCount).toBe(2)
+  })
 })

--- a/packages/runtime-core/src/apiLifecycle.ts
+++ b/packages/runtime-core/src/apiLifecycle.ts
@@ -28,7 +28,11 @@ export function injectHook(
     const wrappedHook =
       hook.__weh ||
       (hook.__weh = (...args: unknown[]) => {
-        if (target.isUnmounted) {
+        if (target.isMounted && target.isUnmounted) {
+
+          // do nothing, just skip the `else if (target.isUnmounted)` judgment
+          // #4861
+        } else if (target.isUnmounted) {
           return
         }
         // disable tracking inside all lifecycle hooks


### PR DESCRIPTION
Fix [#4861](https://github.com/vuejs/vue-next/issues/4861)
After reading the comments on this issue, two members thought it might not be a bug
But one member tagged it as a bug
So I think this issue is officially recognized as a bug
The code to fix it is very simple
I'll talk about the idea of fixing it and ask others to help me see if what I think is correct

If you pass a new function to unMounted every time, then there is no problem
Because the `target` that `injectHook`'s argument is new every time

Only if the functions passed to unMounted are all the same function reference, the `injectHook` closure comes in with the old `target`

So if `target.isMounted` and `target.isUnmounted` are both true, then can be considered to continue at this point