### PR TITLE
fix(vue): make the Vue in render function context same as the runtime context (fix #5196)

### DIFF
--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -75,7 +75,11 @@ function compileToFunction(
   // In the global build we know `Vue` is available globally so we can avoid
   // the wildcard object.
   const render = (
-    __GLOBAL__ ? new Function(code)() : new Function('Vue', code)(runtimeDom)
+    __GLOBAL__
+      // https://github.com/vuejs/vue-next/issues/5196
+      // @ts-ignore
+      ? new Function('Vue', code)(Vue)
+      : new Function('Vue', code)(runtimeDom)
   ) as RenderFunction
 
   // mark the function as runtime compiled


### PR DESCRIPTION
> the Function constructor creates functions which execute in the global scope only[^1]

[^1]: [https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function#:~:text=the%20Function%20constructor%20creates%20functions%20that%20execute%20in%20the%20global%20scope%20only.).

In the issuer demo, the Vue is loaded by global but not accessiable in global scope actually. So the render function will cause the error that `Vue is not defined`.

Here we can pass the `Vue` that in the runtime into render function to make `Vue` is accessible in the render function context.

