### PR TITLE
Update KeepAlive.ts

### DIFF
--- a/packages/runtime-core/src/components/KeepAlive.ts
+++ b/packages/runtime-core/src/components/KeepAlive.ts
@@ -186,7 +186,7 @@ const KeepAliveImpl: ComponentOptions = {
     function pruneCache(filter?: (name: string) => boolean) {
       cache.forEach((vnode, key) => {
         const name = getComponentName(vnode.type as ConcreteComponent)
-        if (name && (!filter || !filter(name))) {
+        if (name && (!filter || !filter(name) || !filter(key as string))) {
           pruneCacheEntry(key)
         }
       })


### PR DESCRIPTION
close #7928

此修改使得 `include`|`exclude` 可以识别组件 `key` 标识  
This modification allows `include` to identify the component's `key` identity

未经过测试  
Not yet tested