### PR TITLE
fix(runtime-core): disable tracking block in h function

### DIFF
--- a/packages/runtime-core/src/h.ts
+++ b/packages/runtime-core/src/h.ts
@@ -205,9 +205,11 @@ export function h(type: any, propsOrChildren?: any, children?: any): VNode {
   // #6913 disable tracking block in h function
   const doCreateVNode = (type: any, props?: any, children?: any) => {
     setBlockTracking(-1)
-    const vnode = createVNode(type, props, children)
-    setBlockTracking(1)
-    return vnode
+    try {
+      return createVNode(type, props, children)
+    } finally {
+      setBlockTracking(1)
+    }
   }
 
   const l = arguments.length


### PR DESCRIPTION
close #6913

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Fixed edge cases where certain programmatically-created virtual elements could be incorrectly tracked, preventing unexpected rendering glitches.

- Performance
  - Reduced unnecessary render tracking during virtual element creation, improving runtime stability and reducing wasted work.

- Documentation
  - Added clarifying comments about render tracking behavior during virtual element creation to aid future maintenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->