### PR TITLE
feat(compiler): allow HTML comments in template interpolation syntax

### DIFF
--- a/packages/compiler-core/__tests__/parse.spec.ts
+++ b/packages/compiler-core/__tests__/parse.spec.ts
@@ -194,6 +194,55 @@ describe('compiler: parse', () => {
       })
     })
 
+    test('simple interpolation', () => {
+      const ast = baseParse('{{<!--message-->}}')
+      const interpolation = ast.children[0] as InterpolationNode
+
+      expect(interpolation).toStrictEqual({
+        type: NodeTypes.INTERPOLATION,
+        content: {
+          type: NodeTypes.SIMPLE_EXPRESSION,
+          content: '',
+          isStatic: false,
+          constType: ConstantTypes.NOT_CONSTANT,
+          loc: {
+            start: { offset: 2, line: 1, column: 3 },
+            end: { offset: 2, line: 1, column: 3 },
+            source: ''
+          }
+        },
+        loc: {
+          start: { offset: 0, line: 1, column: 1 },
+          end: { offset: 18, line: 1, column: 19 },
+          source: '{{<!--message-->}}'
+        }
+      })
+    })
+    test('interpolation with comment', () => {
+      const ast = baseParse('{{<!--message-->message}}')
+      const interpolation = ast.children[0] as InterpolationNode
+
+      expect(interpolation).toStrictEqual({
+        type: NodeTypes.INTERPOLATION,
+        content: {
+          type: NodeTypes.SIMPLE_EXPRESSION,
+          content: 'message',
+          isStatic: false,
+          constType: ConstantTypes.NOT_CONSTANT,
+          loc: {
+            start: { offset: 6, line: 1, column: 7 },
+            end: { offset: 13, line: 1, column: 14 },
+            source: 'message'
+          }
+        },
+        loc: {
+          start: { offset: 0, line: 1, column: 1 },
+          end: { offset: 25, line: 1, column: 26 },
+          source: '{{<!--message-->message}}'
+        }
+      })
+    })
+
     test('it can have tag-like notation', () => {
       const ast = baseParse('{{ a<b }}')
       const interpolation = ast.children[0] as InterpolationNode


### PR DESCRIPTION
feat(compiler): Add support for parsing comments in template syntax

This commit introduces a new feature to the compiler that allows for parsing comments in the template syntax. Comments can now be written using the syntax <!---->, which will be treated as comments and not affect the parsing process.

To ensure the functionality of this feature, two new test cases have been added:

Test case: Parsing template with a comment
Description: This test verifies that the compiler can successfully parse a template that contains a comment.
Steps:
Create a template with a comment using the <!----> syntax.
Invoke the compiler to parse the template.
Expected result: The compiler should parse the template without any errors and treat the comment as a comment, not affecting the parsing of other elements.

Test case: Parsing templates with comments and valid content
Description: Verify that the compiler can successfully parse templates that contain both comments and valid content, and correctly handle the comment sections.
Steps:
Create a template that includes both comments and valid content, using the <!----> syntax for comments.
Invoke the compiler to parse the template.
Expected result: The compiler should be able to parse the template without errors, treating the valid content as valid and ignoring the comment sections.

In addition to the test cases, relevant method comments have been added to enhance code readability and maintainability.