### PR TITLE
feat(compiler-sfc): should not have non-element in sfc file

### DIFF
--- a/packages/compiler-sfc/__tests__/parse.spec.ts
+++ b/packages/compiler-sfc/__tests__/parse.spec.ts
@@ -425,5 +425,14 @@ h1 { color: red }
         `At least one <template> or <script> is required in a single file component`,
       )
     })
+
+    test('should throw error if have non-element children in a single file component.', () => {
+      assertWarning(
+        parse(
+          `<template></template><script></script><script></script>const a = 10;`,
+        ).errors,
+        `should not have non-element children in a single file component.`,
+      )
+    })
   })
 })

--- a/packages/compiler-sfc/src/parse.ts
+++ b/packages/compiler-sfc/src/parse.ts
@@ -163,6 +163,13 @@ export function parse(
   })
   ast.children.forEach(node => {
     if (node.type !== NodeTypes.ELEMENT) {
+      if (node.type !== NodeTypes.COMMENT) {
+        errors.push(
+          new SyntaxError(
+            'should not have non-element children in a single file component.',
+          ),
+        )
+      }
       return
     }
     // we only want to keep the nodes that are not empty


### PR DESCRIPTION
Sometimes due to some accidents, there may be some other codes in the sfc file besides the `template`, `script`, and `style` tags. 

In this case, vue will not throw an error, nor will it Relevant codes will be parsed. I hope that vue can throw errors in this case to help users quickly perceive these illegal codes, thereby keeping the sfc file code clean.