### PR TITLE
fix(runtime-core): type refs and el backdoor issue for this type

### DIFF
--- a/packages-private/dts-test/defineComponent.test-d.tsx
+++ b/packages-private/dts-test/defineComponent.test-d.tsx
@@ -1804,6 +1804,35 @@ describe('__typeEmits backdoor, call signature syntax', () => {
   c.$emit('update', 123)
 })
 
+describe('__typeRefs backdoor, for this type', () => {
+  type Refs = {
+    foo: number
+  }
+  defineComponent({
+    __typeRefs: {} as { child: ComponentInstance<typeof Child> },
+    mounted() {
+      expectType<ComponentInstance<typeof Child>>(this.$refs.child)
+    },
+  })
+  const Child = defineComponent({
+    __typeRefs: {} as Refs,
+    methods: {
+      test() {
+        expectType<number>(this.$refs.foo)
+      },
+    },
+  })
+})
+
+describe('__typeEl backdoor, for this type', () => {
+  defineComponent({
+    __typeEl: {} as HTMLAnchorElement,
+    mounted() {
+      expectType<HTMLAnchorElement>(this.$el)
+    },
+  })
+})
+
 describe('__typeRefs backdoor, object syntax', () => {
   type Refs = {
     foo: number

--- a/packages/runtime-core/src/apiDefineComponent.ts
+++ b/packages/runtime-core/src/apiDefineComponent.ts
@@ -272,7 +272,9 @@ export function defineComponent<
         Slots,
         LocalComponents,
         Directives,
-        Exposed
+        Exposed,
+        TypeRefs,
+        TypeEl
       >
     >,
 ): DefineComponent<


### PR DESCRIPTION
This fix addresses a typing issue related to __typeRefs and __typeEl, which are used to define $refs and $el in the Options API
