### PR TITLE
fix(compiler-core): transform empty `v-bind` dynamic argument content correctly

### DIFF
--- a/packages/compiler-core/src/transforms/vBind.ts
+++ b/packages/compiler-core/src/transforms/vBind.ts
@@ -65,7 +65,7 @@ export const transformBind: DirectiveTransform = (dir, _node, context) => {
     arg.children.unshift(`(`)
     arg.children.push(`) || ""`)
   } else if (!arg.isStatic) {
-    arg.content = `${arg.content} || ""`
+    arg.content = arg.content ? `${arg.content} || ""` : `""`
   }
 
   // .sync is replaced by v-model:arg


### PR DESCRIPTION
https://play.vuejs.org/#eNp9kL1OxDAQhF8l2vrIFVBF5iRAV0ABCOgwRXCW4OCsLf+ESFHe/WxH91OcrrPnm/HOeoI7Y8ohIFTAnLDS+ELV1N5y6ByHDVsv4oYTJ+axN6r2GG9FwRo5FMPVt6Sm+vyKgWnOgShHztYnZliBd0LTj2zLzmmKw6b0BAeheyMV2hfjpaY4sSoySaxWSv8/Zc3bgKu9Ln5R/J3ROzcmjcOrRYd2QA4H5mvbol/w9v0Zx3g+wF43QUX3BfiGTquQOi62+0BNrH3iy20fe6Otl9R+uO3okdx+qVQ0Oefs5xB//OHC6se61+VNznGaYd4BRH+Mtw==

![image](https://github.com/user-attachments/assets/14da0437-e0aa-4d18-b7b1-f28495ff38f5)