### PR TITLE
fix(runtime-core): always pass context arg to functional components

### DIFF
--- a/packages/runtime-core/src/componentRenderUtils.ts
+++ b/packages/runtime-core/src/componentRenderUtils.ts
@@ -110,24 +110,19 @@ export function renderComponentRoot(
         markAttrsAccessed()
       }
       result = normalizeVNode(
-        render.length > 1
-          ? render(
-              __DEV__ ? shallowReadonly(props) : props,
-              __DEV__
-                ? {
-                    get attrs() {
-                      markAttrsAccessed()
-                      return shallowReadonly(attrs)
-                    },
-                    slots,
-                    emit,
-                  }
-                : { attrs, slots, emit },
-            )
-          : render(
-              __DEV__ ? shallowReadonly(props) : props,
-              null as any /* we know it doesn't need it */,
-            ),
+        render(
+          __DEV__ ? shallowReadonly(props) : props,
+          __DEV__
+            ? {
+                get attrs() {
+                  markAttrsAccessed()
+                  return shallowReadonly(attrs)
+                },
+                slots,
+                emit,
+              }
+            : { attrs, slots, emit },
+        ),
       )
       fallthroughAttrs = Component.props
         ? attrs


### PR DESCRIPTION
ref #13182

Always pass context argument to functional components even if the function signature does not define 2 arguments, to support e.g. accessing arguments through the built-in JS `arguments` array.

As an additional note: this provides alignment with Vue 2 behavior.

I'm happy to close this PR if there a desired reason besides performance for why the current behavior exists.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Unified the way functional component render functions are called, ensuring they always receive both props and a context object as arguments. This change streamlines internal logic without affecting end-user APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->