### PR TITLE
feat(compiler): evaluate static interpolations at compile time

### DIFF
--- a/packages/compiler-core/__tests__/__snapshots__/codegen.spec.ts.snap
+++ b/packages/compiler-core/__tests__/__snapshots__/codegen.spec.ts.snap
@@ -94,6 +94,15 @@ return function render(_ctx, _cache) {
 }"
 `;
 
+exports[`compiler: codegen > empty interpolation 1`] = `
+"
+return function render(_ctx, _cache) {
+  with (_ctx) {
+    return ""
+  }
+}"
+`;
+
 exports[`compiler: codegen > forNode 1`] = `
 "
 return function render(_ctx, _cache) {
@@ -180,6 +189,15 @@ const _createVNode = createVNode, _resolveDirective = resolveDirective
 
 export function render(_ctx, _cache) {
   return null
+}"
+`;
+
+exports[`compiler: codegen > static interpolation 1`] = `
+"
+return function render(_ctx, _cache) {
+  with (_ctx) {
+    return "hello1falseundefinednullhi"
+  }
 }"
 `;
 

--- a/packages/compiler-core/__tests__/codegen.spec.ts
+++ b/packages/compiler-core/__tests__/codegen.spec.ts
@@ -3,6 +3,7 @@ import {
   type DirectiveArguments,
   type ForCodegenNode,
   type IfConditionalExpression,
+  type InterpolationNode,
   NodeTypes,
   type RootNode,
   type VNodeCall,
@@ -189,6 +190,40 @@ describe('compiler: codegen', () => {
       }),
     )
     expect(code).toMatch(`return _${helperNameMap[TO_DISPLAY_STRING]}(hello)`)
+    expect(code).toMatchSnapshot()
+  })
+
+  test('static interpolation', () => {
+    const codegenNode: InterpolationNode = {
+      type: NodeTypes.INTERPOLATION,
+      loc: locStub,
+      content: createSimpleExpression(
+        `"hello" + 1 + false + undefined + null + ${'`hi`'}`,
+        true,
+        locStub,
+      ),
+    }
+    const { code } = generate(
+      createRoot({
+        codegenNode,
+      }),
+    )
+    expect(code).toMatch(`return "hello1falseundefinednullhi"`)
+    expect(code).toMatchSnapshot()
+  })
+
+  test('empty interpolation', () => {
+    const codegenNode: InterpolationNode = {
+      type: NodeTypes.INTERPOLATION,
+      loc: locStub,
+      content: createSimpleExpression(``, true, locStub),
+    }
+    const { code } = generate(
+      createRoot({
+        codegenNode,
+      }),
+    )
+    expect(code).toMatch(`return ""`)
     expect(code).toMatchSnapshot()
   })
 

--- a/packages/compiler-core/__tests__/transforms/__snapshots__/cacheStatic.spec.ts.snap
+++ b/packages/compiler-core/__tests__/transforms/__snapshots__/cacheStatic.spec.ts.snap
@@ -148,7 +148,7 @@ return function render(_ctx, _cache) {
     const { toDisplayString: _toDisplayString, createElementVNode: _createElementVNode, openBlock: _openBlock, createElementBlock: _createElementBlock } = _Vue
 
     return (_openBlock(), _createElementBlock("div", null, _cache[0] || (_cache[0] = [
-      _createElementVNode("span", null, "foo " + _toDisplayString(1) + " " + _toDisplayString(true), -1 /* CACHED */)
+      _createElementVNode("span", null, "foo " + "1" + " " + "true", -1 /* CACHED */)
     ])))
   }
 }"
@@ -162,7 +162,7 @@ return function render(_ctx, _cache) {
     const { toDisplayString: _toDisplayString, createElementVNode: _createElementVNode, openBlock: _openBlock, createElementBlock: _createElementBlock } = _Vue
 
     return (_openBlock(), _createElementBlock("div", null, _cache[0] || (_cache[0] = [
-      _createElementVNode("span", { foo: 0 }, _toDisplayString(1), -1 /* CACHED */)
+      _createElementVNode("span", { foo: 0 }, "1", -1 /* CACHED */)
     ])))
   }
 }"

--- a/packages/compiler-core/src/codegen.ts
+++ b/packages/compiler-core/src/codegen.ts
@@ -7,6 +7,7 @@ import {
   type CommentNode,
   type CompoundExpressionNode,
   type ConditionalExpression,
+  ConstantTypes,
   type ExpressionNode,
   type FunctionExpression,
   type IfStatement,
@@ -32,6 +33,7 @@ import { SourceMapGenerator } from 'source-map-js'
 import {
   advancePositionWithMutation,
   assert,
+  evaluateConstant,
   isSimpleIdentifier,
   toValidAssetId,
 } from './utils'
@@ -41,6 +43,7 @@ import {
   isArray,
   isString,
   isSymbol,
+  toDisplayString,
 } from '@vue/shared'
 import {
   CREATE_COMMENT,
@@ -760,6 +763,20 @@ function genExpression(node: SimpleExpressionNode, context: CodegenContext) {
 
 function genInterpolation(node: InterpolationNode, context: CodegenContext) {
   const { push, helper, pure } = context
+
+  if (
+    node.content.type === NodeTypes.SIMPLE_EXPRESSION &&
+    node.content.constType === ConstantTypes.CAN_STRINGIFY
+  ) {
+    if (node.content.content) {
+      push(JSON.stringify(toDisplayString(evaluateConstant(node.content))))
+    } else {
+      push(`""`)
+    }
+
+    return
+  }
+
   if (pure) push(PURE_ANNOTATION)
   push(`${helper(TO_DISPLAY_STRING)}(`)
   genNode(node.content, context)

--- a/packages/compiler-core/src/transforms/transformExpression.ts
+++ b/packages/compiler-core/src/transforms/transformExpression.ts
@@ -44,7 +44,9 @@ import { parseExpression } from '@babel/parser'
 import { IS_REF, UNREF } from '../runtimeHelpers'
 import { BindingTypes } from '../options'
 
-const isLiteralWhitelisted = /*@__PURE__*/ makeMap('true,false,null,this')
+const isLiteralWhitelisted = /*@__PURE__*/ makeMap(
+  'true,false,null,undefined,this',
+)
 
 export const transformExpression: NodeTransform = (node, context) => {
   if (node.type === NodeTypes.INTERPOLATION) {
@@ -119,7 +121,14 @@ export function processExpression(
     return node
   }
 
-  if (!context.prefixIdentifiers || !node.content.trim()) {
+  if (!node.content.trim()) {
+    // This allows stringification to continue in the presence of empty
+    // interpolations.
+    node.constType = ConstantTypes.CAN_STRINGIFY
+    return node
+  }
+
+  if (!context.prefixIdentifiers) {
     return node
   }
 

--- a/packages/compiler-core/src/utils.ts
+++ b/packages/compiler-core/src/utils.ts
@@ -37,7 +37,13 @@ import {
   TO_HANDLERS,
   WITH_MEMO,
 } from './runtimeHelpers'
-import { NOOP, isObject, isString } from '@vue/shared'
+import {
+  NOOP,
+  isObject,
+  isString,
+  isSymbol,
+  toDisplayString,
+} from '@vue/shared'
 import type { PropsExpression } from './transforms/transformElement'
 import { parseExpression } from '@babel/parser'
 import type { Expression, Node } from '@babel/types'
@@ -564,3 +570,32 @@ export function getMemoedVNodeCall(
 }
 
 export const forAliasRE: RegExp = /([\s\S]*?)\s+(?:in|of)\s+(\S[\s\S]*)/
+
+// __UNSAFE__
+// Reason: eval.
+// It's technically safe to eval because only constant expressions are possible
+// here, e.g. `{{ 1 }}` or `{{ 'foo' }}`
+// in addition, constant exps bail on presence of parens so you can't even
+// run JSFuck in here. But we mark it unsafe for security review purposes.
+// (see compiler-core/src/transforms/transformExpression)
+export function evaluateConstant(exp: ExpressionNode): string {
+  if (exp.type === NodeTypes.SIMPLE_EXPRESSION) {
+    return new Function(`return (${exp.content})`)()
+  } else {
+    // compound
+    let res = ``
+    exp.children.forEach(c => {
+      if (isString(c) || isSymbol(c)) {
+        return
+      }
+      if (c.type === NodeTypes.TEXT) {
+        res += c.content
+      } else if (c.type === NodeTypes.INTERPOLATION) {
+        res += toDisplayString(evaluateConstant(c.content))
+      } else {
+        res += evaluateConstant(c as ExpressionNode)
+      }
+    })
+    return res
+  }
+}

--- a/packages/compiler-dom/__tests__/transforms/__snapshots__/stringifyStatic.spec.ts.snap
+++ b/packages/compiler-dom/__tests__/transforms/__snapshots__/stringifyStatic.spec.ts.snap
@@ -158,6 +158,14 @@ return function render(_ctx, _cache) {
 }"
 `;
 
+exports[`stringify static html > static interpolation 1`] = `
+"const { createElementVNode: _createElementVNode, createStaticVNode: _createStaticVNode } = Vue
+
+return function render(_ctx, _cache) {
+  return _cache[0] || (_cache[0] = _createStaticVNode("<div>1</div><div>1</div><div>1</div><div>false</div><div></div><div></div><div></div><div>1</div><div>1</div><div>1</div><div>false</div><div></div><div></div><div></div><div>1</div><div>1</div><div>1</div><div>false</div><div></div><div></div><div></div>", 21))
+}"
+`;
+
 exports[`stringify static html > stringify v-html 1`] = `
 "const { createElementVNode: _createElementVNode, createStaticVNode: _createStaticVNode } = Vue
 

--- a/packages/compiler-dom/__tests__/transforms/stringifyStatic.spec.ts
+++ b/packages/compiler-dom/__tests__/transforms/stringifyStatic.spec.ts
@@ -525,4 +525,38 @@ describe('stringify static html', () => {
 
     expect(code).toMatchSnapshot()
   })
+
+  test('static interpolation', () => {
+    const interpolateElements = [
+      `"1"`,
+      '`1`',
+      '1',
+      'false',
+      'undefined',
+      'null',
+      '',
+    ]
+
+    const copiesNeededToTriggerStringify = Math.ceil(
+      StringifyThresholds.NODE_COUNT / interpolateElements.length,
+    )
+
+    const { code: interpolateCode } = compileWithStringify(
+      interpolateElements
+        .map(e => `<div>{{${e}}}</div>`)
+        .join('\n')
+        .repeat(copiesNeededToTriggerStringify),
+    )
+
+    const staticElements = [`1`, '1', '1', 'false', '', '', '']
+    const { code: staticCode } = compileWithStringify(
+      staticElements
+        .map(e => `<div>${e}</div>`)
+        .join('\n')
+        .repeat(copiesNeededToTriggerStringify),
+    )
+
+    expect(interpolateCode).toBe(staticCode)
+    expect(interpolateCode).toMatchSnapshot()
+  })
 })


### PR DESCRIPTION
This PR allows the compiler to evaluate static interpolations (and calls to `toDisplayString`) at compile time. 'Static' here means that the value is marked as `ConstantTypes.CAN_STRINGIFY`.

I found calls to `toDisplayString` with literal arguments in a real-world, large Vue project.  These can be optimised at compile time with little effort, removing a function call from the generated code and improving performance + code-size slightly.

This PR:

- Marks empty interpolations, or interpolation with `undefined`, as static and handles them when evaluating at compile time. This allows them to be stringified.
- Evaluates static calls to `toDisplayString` during codegen. This catches static calls that couldn't be strinngified (most).

Example input:
```vue
<template>
  <div>{{ "1" }}</div>
  <div>{{ `1` }}</div>
  <div>{{ 1 }}</div>
  <div>{{ false }}</div>
  <div>{{ null }}</div>
  <div>{{ undefined }}</div>
  <div>{{ }}</div>
</template>
```
Output before this PR ([plaground link](https://play.vuejs.org/#__PROD__eNp9kT1rwzAQhv+KuDk4mHYKJtCWDO3Qlrajhhj77CqRJaEPx2D03yMpxMkgsonneQ/e083wolQxOoQNVBYHxWuLWyoIqVo2bueZUCgpEO+rdQT3Zl/us7zM0q7mBrNGOM6zwokWOyawzdobq9ZLc1iBNY0UHeuLg5EirDXHIQqNHBTjqL+UZVIYChuSTHQ15/L0kZjVDldX3vxjc8zwg5kio/Ct0aAekcLibK17tBe9+/3EKbwXOcjW8ZB+IH/QSO5ix0vsNfxCqH2XS23fByW1ZaL/M7vJojDXpWLRmPQpTyHc9u3B6re6T8VzmqPCgz8DYdKv2g==)):
```js
function render(_ctx, _cache, $props, $setup, $data, $options) {
  return (_openBlock(), _createElementBlock(_Fragment, null, [
    _cache[0] || (_cache[0] = _createElementVNode("div", null, _toDisplayString("1"), -1 /* CACHED */)),
    _cache[1] || (_cache[1] = _createElementVNode("div", null, _toDisplayString(`1`), -1 /* CACHED */)),
    _cache[2] || (_cache[2] = _createElementVNode("div", null, _toDisplayString(1), -1 /* CACHED */)),
    _cache[3] || (_cache[3] = _createElementVNode("div", null, _toDisplayString(false), -1 /* CACHED */)),
    _cache[4] || (_cache[4] = _createElementVNode("div", null, _toDisplayString(null), -1 /* CACHED */)),
    _cache[5] || (_cache[5] = _createElementVNode("div", null, _toDisplayString(undefined), -1 /* CACHED */)),
    _createElementVNode("div", null, _toDisplayString(), 1 /* TEXT */)
  ], 64 /* STABLE_FRAGMENT */))
}
```
Output after this PR:
```js
function render(_ctx, _cache, $props, $setup, $data, $options) {
  return (_openBlock(), _createElementBlock(_Fragment, null, [
    _cache[0] || (_cache[0] = _createElementVNode("div", null, "1", -1 /* CACHED */)),
    _cache[1] || (_cache[1] = _createElementVNode("div", null, "1", -1 /* CACHED */)),
    _cache[2] || (_cache[2] = _createElementVNode("div", null, "1", -1 /* CACHED */)),
    _cache[3] || (_cache[3] = _createElementVNode("div", null, "false", -1 /* CACHED */)),
    _cache[4] || (_cache[4] = _createElementVNode("div", null, "", -1 /* CACHED */)),
    _cache[5] || (_cache[5] = _createElementVNode("div", null, "", -1 /* CACHED */)),
    _cache[6] || (_cache[6] = _createElementVNode("div", null, "", -1 /* CACHED */))
  ], 64 /* STABLE_FRAGMENT */))
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved handling of static and empty interpolations, resulting in more efficient code generation and output for constant expressions.
  * Added new tests to verify correct stringification of static interpolation nodes and ensure output consistency.

* **Bug Fixes**
  * Enhanced recognition of the string "undefined" as a literal value, improving constant folding and optimization.

* **Refactor**
  * Centralized and reused the constant expression evaluation utility, reducing code duplication and improving maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->