### PR TITLE
fix(runtime-vapor): fix readonly warning when useTemplateRef has same variable name as template ref

### DIFF
--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -565,4 +565,4 @@ export { createInternalObject } from './internalObject'
 /**
  * @internal
  */
-export { validateTemplateRef } from './rendererTemplateRef'
+export { createCanSetSetupRefChecker } from './rendererTemplateRef'

--- a/packages/runtime-core/src/rendererTemplateRef.ts
+++ b/packages/runtime-core/src/rendererTemplateRef.ts
@@ -77,7 +77,7 @@ export function setRef(
   const oldRef = oldRawRef && (oldRawRef as VNodeNormalizedRefAtom).r
   const refs = owner.refs === EMPTY_OBJ ? (owner.refs = {}) : owner.refs
   const setupState = owner.setupState
-  const canSetSetupRef = validateTemplateRef(setupState)
+  const canSetSetupRef = createCanSetSetupRefChecker(setupState)
 
   // dynamic ref changed. unset old ref
   if (oldRef != null && oldRef !== ref) {
@@ -148,7 +148,7 @@ export function setRef(
   }
 }
 
-export function validateTemplateRef(
+export function createCanSetSetupRefChecker(
   setupState: Data,
 ): (key: string) => boolean {
   const rawSetupState = toRaw(setupState)

--- a/packages/runtime-vapor/src/apiTemplateRef.ts
+++ b/packages/runtime-vapor/src/apiTemplateRef.ts
@@ -9,8 +9,8 @@ import {
   ErrorCodes,
   type SchedulerJob,
   callWithErrorHandling,
+  createCanSetSetupRefChecker,
   queuePostFlushCb,
-  validateTemplateRef,
   warn,
 } from '@vue/runtime-dom'
 import {
@@ -56,7 +56,7 @@ export function setRef(
   const refs =
     instance.refs === EMPTY_OBJ ? (instance.refs = {}) : instance.refs
 
-  const canSetSetupRef = validateTemplateRef(setupState)
+  const canSetSetupRef = createCanSetSetupRefChecker(setupState)
   // dynamic ref changed. unset old ref
   if (oldRef != null && oldRef !== ref) {
     if (isString(oldRef)) {


### PR DESCRIPTION
close #13665

align to https://github.com/vuejs/core/commit/bc63df01992fdbf0b6749ad234153725697ed896