### PR TITLE
feat(runtime-dom): `useNativeSlots` helper

### DIFF
--- a/packages/runtime-dom/src/apiCustomElement.ts
+++ b/packages/runtime-dom/src/apiCustomElement.ts
@@ -241,7 +241,10 @@ export class VueElement
    */
   private _childStyles?: Map<string, HTMLStyleElement[]>
   private _ob?: MutationObserver | null = null
-  private _slots?: Record<string, Node[]>
+  _slots: Record<string, Node[]> = {}
+  // differs from `_slots` by only exposing slot values that actually have corresponding
+  // slot outlets defined by this component
+  _componentDefinedSlots: Record<string, Node[]> = {}
 
   constructor(
     /**
@@ -275,9 +278,13 @@ export class VueElement
     // avoid resolving component if it's not connected
     if (!this.isConnected) return
 
-    // avoid re-parsing slots if already resolved
-    if (!this.shadowRoot && !this._resolved) {
-      this._parseSlots()
+    if (this.shadowRoot) {
+      this._root.addEventListener('slotchange', this._slotChangeEventListener)
+    } else {
+      // avoid re-parsing slots if already resolved
+      if (!this._resolved) {
+        this._parseSlots()
+      }
     }
     this._connected = true
 
@@ -326,6 +333,18 @@ export class VueElement
     }
   }
 
+  _slotChangeEventListener = (event: Event): void => {
+    if (event.target instanceof HTMLSlotElement) {
+      const slotName = event.target.name || 'default'
+      const assignedNodes = event.target.assignedNodes()
+      if (!assignedNodes.length) {
+        delete this._componentDefinedSlots[slotName]
+      } else {
+        this._componentDefinedSlots[slotName] = assignedNodes
+      }
+    }
+  }
+
   disconnectedCallback(): void {
     this._connected = false
     nextTick(() => {
@@ -333,6 +352,12 @@ export class VueElement
         if (this._ob) {
           this._ob.disconnect()
           this._ob = null
+        }
+        if (this.shadowRoot) {
+          this._root.removeEventListener(
+            'slotchange',
+            this._slotChangeEventListener,
+          )
         }
         // unmount
         this._app && this._app.unmount()
@@ -621,7 +646,7 @@ export class VueElement
    * Only called when shadowRoot is false
    */
   private _parseSlots() {
-    const slots: VueElement['_slots'] = (this._slots = {})
+    const slots: VueElement['_slots'] = this._slots
     let n
     while ((n = this.firstChild)) {
       const slotName =
@@ -640,9 +665,10 @@ export class VueElement
     for (let i = 0; i < outlets.length; i++) {
       const o = outlets[i] as HTMLSlotElement
       const slotName = o.getAttribute('name') || 'default'
-      const content = this._slots![slotName]
+      const content = this._slots[slotName]
       const parent = o.parentNode!
       if (content) {
+        this._componentDefinedSlots[slotName] = content
         for (const n of content) {
           // for :slotted css
           if (scopeId && n.nodeType === 1) {
@@ -715,4 +741,13 @@ export function useHost(caller?: string): VueElement | null {
 export function useShadowRoot(): ShadowRoot | null {
   const el = __DEV__ ? useHost('useShadowRoot') : useHost()
   return el && el.shadowRoot
+}
+
+/**
+ * Retrieve the nodes assigned to each `<slot>` of the current custom element.
+ * Only usable in setup() of a `defineCustomElement` component.
+ */
+export function useNativeSlots(): Record<string, Node[]> | null {
+  const el = __DEV__ ? useHost('useNativeSlots') : useHost()
+  return el && el._componentDefinedSlots
 }

--- a/packages/runtime-dom/src/index.ts
+++ b/packages/runtime-dom/src/index.ts
@@ -260,6 +260,7 @@ export {
   defineCustomElement,
   defineSSRCustomElement,
   useShadowRoot,
+  useNativeSlots,
   useHost,
   VueElement,
   type VueElementConstructor,


### PR DESCRIPTION
close #12498

This PR introduces a `runtime-dom` helper `useNativeSlots` which can be used for fetching DOM nodes associated with native HTML slots for Vue custom elements.

It returns an object containing the slot outlet names defined in the component as keys, with each value corresponding to an array of DOM nodes that the parent component passed in for the slot outlets.

Example usage:
```
// Child.vue
<script setup>
import { useNativeSlots, onMounted } from 'vue'
const nativeSlots = useSlots()
onMounted(() => {
   // with parent slot values passed in this example: `{ 'slotA': [<div>, <span>], 'slotB': [<p>] }`
  console.log(nativeSlots)
})
</script>

<template>
  <slot name="slotA"></slot>
  <slot name="slotB"></slot>
  <slot name="slotC"></slot>
</template>
```
```
// Parent.vue
<script setup>
import Child from './Child.vue'
</script>

<template>
  <Child>
    <div slot="slotA">1</div>
    <span slot="slotA">2</span>
    <p slot="slotB">3</p>
  </Child>
</template>
```

### Acknowledgements:
* This does not work in vapor mode
* There are some limitations with this feature when used with `shadowRoot: false` mode associated with #13206, #13234