### PR TITLE
fix(reactivity): optimize size retrieval in createInstrumentations

### DIFF
--- a/packages/reactivity/src/collectionHandlers.ts
+++ b/packages/reactivity/src/collectionHandlers.ts
@@ -125,7 +125,7 @@ function createInstrumentations(
     get size() {
       const target = (this as unknown as IterableCollections)[ReactiveFlags.RAW]
       !readonly && track(toRaw(target), TrackOpTypes.ITERATE, ITERATE_KEY)
-      return Reflect.get(target, 'size', target)
+      return target.size
     },
     has(this: CollectionTypes, key: unknown): boolean {
       const target = this[ReactiveFlags.RAW]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Streamlined how sizes are read for reactive Map/Set collections, reducing overhead for size checks.
  - Users may notice marginal performance improvements when viewing or computing sizes of these collections; no behavioral changes are expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->