### PR TITLE
fix(hydration): also set vShow name if __FEATURE_PROD_HYDRATION_MISMATCH_DETAILS__ flag is enabled

### DIFF
--- a/packages/runtime-dom/src/directives/vShow.ts
+++ b/packages/runtime-dom/src/directives/vShow.ts
@@ -45,7 +45,7 @@ export const vShow: ObjectDirective<VShowElement> & { name?: 'show' } = {
   },
 }
 
-if (__DEV__) {
+if (__DEV__ || __FEATURE_PROD_HYDRATION_MISMATCH_DETAILS__) {
   vShow.name = 'show'
 }
 


### PR DESCRIPTION
close #13744

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures the visibility directive’s name is assigned in more build scenarios, improving the clarity of hydration mismatch details and related diagnostics.
  * Enhances developer-facing messages and tooling output by consistently exposing directive names where applicable.
  * No impact on runtime behavior or public APIs; end-users may see clearer warnings or logs in environments that surface hydration or rendering diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->