### PR TITLE
test(runtime-core): remove incorrect suspense test in vnode spec

### DIFF
--- a/packages/runtime-core/__tests__/vnode.spec.ts
+++ b/packages/runtime-core/__tests__/vnode.spec.ts
@@ -553,18 +553,6 @@ describe('vnode', () => {
       expect(vnode.dynamicChildren).toStrictEqual([vnode1])
     })
 
-    test('with suspense', () => {
-      const hoist = createVNode('div')
-      let vnode1
-      const vnode =
-        (openBlock(),
-        createBlock('div', null, [
-          hoist,
-          (vnode1 = createVNode(() => {}, null, 'text')),
-        ]))
-      expect(vnode.dynamicChildren).toStrictEqual([vnode1])
-    })
-
     // #1039
     // <component :is="foo">{{ bar }}</component>
     // - content is compiled as slot


### PR DESCRIPTION
The test case for 'suspense' was misleading as its implementation was a copy of the functional component test. It is removed because the core logic for block tracking in createBaseVNode only explicitly checks for COMPONENT shape flags. Testing every non-component type is unnecessary. Removing this test improves the clarity and focus of the spec.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Removed a test case related to suspense and dynamic children to improve test suite stability and reduce false negatives.
  * Clarified expectations by eliminating a brittle scenario that no longer reflects current behavior.
  * No changes to runtime behavior, features, performance, or public APIs.
  * End users will see no functional differences; this is a maintenance-focused update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->