### PR TITLE
fix(compiler-sfc): support global augments with named exports

### DIFF
--- a/packages/compiler-sfc/__tests__/compileScript/resolveType.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileScript/resolveType.spec.ts
@@ -1342,6 +1342,33 @@ describe('resolveType', () => {
       expect(deps && [...deps]).toStrictEqual(Object.keys(files))
     })
 
+    test('global types with named exports', () => {
+      const files = {
+        '/global.d.ts': `
+          declare global {
+            export interface ExportedInterface { foo: number }
+            export type ExportedType = { bar: boolean }
+          }
+          export {}
+        `,
+      }
+
+      const globalTypeFiles = { globalTypeFiles: Object.keys(files) }
+
+      expect(
+        resolve(`defineProps<ExportedInterface>()`, files, globalTypeFiles)
+          .props,
+      ).toStrictEqual({
+        foo: ['Number'],
+      })
+
+      expect(
+        resolve(`defineProps<ExportedType>()`, files, globalTypeFiles).props,
+      ).toStrictEqual({
+        bar: ['Boolean'],
+      })
+    })
+
     test('global types with ambient references', () => {
       const files = {
         // with references

--- a/packages/compiler-sfc/src/script/resolveType.ts
+++ b/packages/compiler-sfc/src/script/resolveType.ts
@@ -1296,7 +1296,12 @@ function recordTypes(
         }
       } else if (stmt.type === 'TSModuleDeclaration' && stmt.global) {
         for (const s of (stmt.body as TSModuleBlock).body) {
-          recordType(s, types, declares)
+          if (s.type === 'ExportNamedDeclaration' && s.declaration) {
+            // Handle export declarations inside declare global
+            recordType(s.declaration, types, declares)
+          } else {
+            recordType(s, types, declares)
+          }
         }
       }
     } else {


### PR DESCRIPTION
spotted in https://github.com/nuxt/nuxt/issues/29757

although a bit strange, it is valid typescript:

```ts
declare global {
    export interface Test2 {
        prop2: number
    }
}
export {}
```

[typescript playground](https://www.typescriptlang.org/play/?#code/CYUwxgNghgTiAEBzCB7ARlC8DeAoeB8IAHgA4owAu8AlgHaUgwBmUYCAKiAM6UBMOfIWGkYKUnwBc8OgFcAtmiZCCAX1zqS5KjnW4wKOr3gBBaV14CAvIOEagA)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Correctly resolves ambient global types that use named exports inside declare global blocks, ensuring globally exported interfaces/types are detected and usable (e.g., in defineProps). Previously, these could be missed during type collection, leading to unresolved props.
* **Tests**
  * Added test coverage for global types with named exports via a global declaration block to prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->