### PR TITLE
fix(hmr): prevent __VUE_HMR_RUNTIME__ from being overwritten by vue runtime in 3rd-party libraries

### DIFF
--- a/packages/runtime-core/src/hmr.ts
+++ b/packages/runtime-core/src/hmr.ts
@@ -31,12 +31,12 @@ export interface HMRRuntime {
 // Note: for a component to be eligible for HMR it also needs the __hmrId option
 // to be set so that its instances can be registered / removed.
 if (__DEV__) {
-  const globalThis = getGlobalThis()
+  const g = getGlobalThis()
   // vite-plugin-vue/issues/644, #13202
   // custom-element libraries bundle Vue to simplify usage outside Vue projects but
   // it overwrite __VUE_HMR_RUNTIME__, causing HMR to break.
-  if (!globalThis.__VUE_HMR_RUNTIME__) {
-    globalThis.__VUE_HMR_RUNTIME__ = {
+  if (!g.__VUE_HMR_RUNTIME__) {
+    g.__VUE_HMR_RUNTIME__ = {
       createRecord: tryWrap(createRecord),
       rerender: tryWrap(rerender),
       reload: tryWrap(reload),


### PR DESCRIPTION
close https://github.com/vitejs/vite-plugin-vue/issues/644

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Guarded installation of the HMR runtime to avoid overwriting an existing global instance, improving compatibility with tooling and custom-element environments and reducing development-time conflicts.
  * Maintains existing HMR behavior and DEV-only gating; no changes to production builds or public APIs, preserving current integrations and surface compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->