### PR TITLE
chore: migrate vitest to use `projects`

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -28,6 +28,7 @@ export default defineConfig({
     environmentMatchGlobs: [
       ['packages/{vue,vue-compat,runtime-dom}/**', 'jsdom'],
     ],
+    projects: ['./vitest.unit.config.ts', './vitest.e2e.config.ts'],
     sequence: {
       hooks: 'list',
     },

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -1,6 +1,0 @@
-import { defineWorkspace } from 'vitest/config'
-
-export default defineWorkspace([
-  './vitest.unit.config.ts',
-  './vitest.e2e.config.ts',
-])


### PR DESCRIPTION
This PR removes the `vitest.workspase.ts` file since it is deprecated. Vitest 4 supports only `projects` field.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Tests
  - Enabled multi-project execution with distinct unit and end-to-end configurations, while preserving existing environment matching and coverage settings.
  - Test discovery and runs now load both configurations automatically under the test runner’s projects setup.
  - Removed the separate workspace configuration in favor of the new projects-based approach to keep test configuration centralized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->