### PR TITLE
feat(types): enhanced types on `@vue/reactivity` `watch`

### DIFF
--- a/packages/reactivity/src/index.ts
+++ b/packages/reactivity/src/index.ts
@@ -86,6 +86,7 @@ export {
   traverse,
   onWatcherCleanup,
   WatchErrorCodes,
+  type MultiWatchSources,
   type WatchOptions,
   type WatchScheduler,
   type WatchStopHandle,

--- a/packages/runtime-core/src/apiWatch.ts
+++ b/packages/runtime-core/src/apiWatch.ts
@@ -1,6 +1,7 @@
 import {
   type WatchOptions as BaseWatchOptions,
   type DebuggerOptions,
+  type MultiWatchSources,
   type ReactiveMarker,
   type WatchCallback,
   type WatchEffect,
@@ -80,8 +81,6 @@ export function watchSyncEffect(
     __DEV__ ? extend({}, options as any, { flush: 'sync' }) : { flush: 'sync' },
   )
 }
-
-export type MultiWatchSources = (WatchSource<unknown> | object)[]
 
 // overload: single source + cb
 export function watch<T, Immediate extends Readonly<boolean> = false>(
@@ -223,7 +222,7 @@ function doWatch(
     }
   }
 
-  const watchHandle = baseWatch(source, cb, baseWatchOptions)
+  const watchHandle = baseWatch(source, cb as any, baseWatchOptions)
 
   if (__SSR__ && isInSSRComponentSetup) {
     if (ssrCleanup) {

--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -224,9 +224,9 @@ export type {
   DebuggerEventExtraInfo,
   Raw,
   Reactive,
+  MultiWatchSources,
 } from '@vue/reactivity'
 export type {
-  MultiWatchSources,
   WatchEffect,
   WatchOptions,
   WatchEffectOptions as WatchOptionsBase,


### PR DESCRIPTION
close #13807

I effectively reused the type signatures from `apiWatch.ts` with an additional overload for `WatchEffect` as the first argument

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Exposed the MultiWatchSources type in the public API, making it directly available to TypeScript users.
- Refactor
  - Consolidated MultiWatchSources to source from the reactivity types, removing local aliases and aligning type exports across packages.
- Chores
  - Adjusted internal typings in watch-related logic to rely on the centralized type and simplified callback typing.
- Notes
  - No runtime behavior changes; impact is limited to TypeScript type availability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->