### PR TITLE
fix(compiler-dom): nodes with v-once shouldn't be stringified

### DIFF
--- a/packages/compiler-dom/__tests__/transforms/__snapshots__/stringifyStatic.spec.ts.snap
+++ b/packages/compiler-dom/__tests__/transforms/__snapshots__/stringifyStatic.spec.ts.snap
@@ -12,6 +12,24 @@ return function render(_ctx, _cache) {
 }"
 `;
 
+exports[`stringify static html > eligible content + v-once node 1`] = `
+"const { setBlockTracking: _setBlockTracking, toDisplayString: _toDisplayString, createTextVNode: _createTextVNode, createElementVNode: _createElementVNode, createStaticVNode: _createStaticVNode, openBlock: _openBlock, createElementBlock: _createElementBlock } = Vue
+
+return function render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("div", null, [
+    _cache[0] || (
+      _setBlockTracking(-1, true),
+      (_cache[0] = _createElementVNode("div", null, [
+        _createTextVNode(_toDisplayString(_ctx.msg), 1 /* TEXT */)
+      ])).cacheIndex = 0,
+      _setBlockTracking(1),
+      _cache[0]
+    ),
+    _cache[1] || (_cache[1] = _createStaticVNode("<span class=\\"foo\\">foo</span><span class=\\"foo\\">foo</span><span class=\\"foo\\">foo</span><span class=\\"foo\\">foo</span><span class=\\"foo\\">foo</span>", 5))
+  ]))
+}"
+`;
+
 exports[`stringify static html > escape 1`] = `
 "const { toDisplayString: _toDisplayString, normalizeClass: _normalizeClass, createElementVNode: _createElementVNode, createStaticVNode: _createStaticVNode, openBlock: _openBlock, createElementBlock: _createElementBlock } = Vue
 

--- a/packages/compiler-dom/__tests__/transforms/stringifyStatic.spec.ts
+++ b/packages/compiler-dom/__tests__/transforms/stringifyStatic.spec.ts
@@ -525,4 +525,14 @@ describe('stringify static html', () => {
 
     expect(code).toMatchSnapshot()
   })
+
+  test('eligible content + v-once node', () => {
+    const { code } = compileWithStringify(
+      `<div>
+        <div v-once>{{ msg }}</div>
+        ${repeat(`<span class="foo">foo</span>`, StringifyThresholds.ELEMENT_WITH_BINDING_COUNT)}
+      </div>`,
+    )
+    expect(code).toMatchSnapshot()
+  })
 })

--- a/packages/compiler-dom/src/transforms/stringifyStatic.ts
+++ b/packages/compiler-dom/src/transforms/stringifyStatic.ts
@@ -17,6 +17,7 @@ import {
   type TextCallNode,
   type TransformContext,
   createCallExpression,
+  findDir,
   isStaticArgOf,
 } from '@vue/compiler-core'
 import {
@@ -210,6 +211,11 @@ const isNonStringifiable = /*@__PURE__*/ makeMap(
  */
 function analyzeNode(node: StringifiableNode): [number, number] | false {
   if (node.type === NodeTypes.ELEMENT && isNonStringifiable(node.tag)) {
+    return false
+  }
+
+  // v-once nodes should not be stringified
+  if (node.type === NodeTypes.ELEMENT && findDir(node, 'once', true)) {
     return false
   }
 


### PR DESCRIPTION
This vnode with the `v-once` directive down here will be condensed into a "static vnode", so it causes a compile error.
```html
<template>
    <div v-once>{{ msg }}</div>
    <span class="foo">foo</span>
    <span class="foo">foo</span>
    <span class="foo">foo</span>
    <span class="foo">foo</span>
</template>
```

`v-once` nodes should not be stringified. This PR is to fix it.

[See live demo](https://play.vuejs.org/#eNq9kjFPwzAQhf/K4SUglXaAqUorAaoEDIAAicVLlFyCi2NbPidUivLfObtK6YA6kiGK3/vy9O6SQdw4N+87FEuRU+mVC0AYOreWRrXO+gADeKxhhNrbFjJGM2lAmtIaCtBSA6sInGf3qLWFD+t1dZZdSJMv9nmcxIeArdNFQD4BX3mleugvrSlxPQwpZhzzBasTQK4wUOqCaCVFba0Ua75zKOv/zOSLo/ZiJgLx8LVq5luyhhc3xBgpSts6pdE/u6B4OVIsITnRK3g3349JC77D2aSXn1h+/aFvaRc1KV48EvoepTh4ofANhr29eXvCHT8fzNZWnWb6hPmKZHUXO+6x285UXPuIS20f0udXpnmnzS6goWmoWDSSY+Kl4F/i7sTov3Wv5tfpPWlGMf4AVE3RGg==)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected handling of v-once within otherwise static content, preventing it from being stringified. Ensures v-once sections render once as expected and avoids potential rendering inconsistencies.

* **Tests**
  * Added test coverage for scenarios combining eligible static content with v-once to validate correct behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->