### PR TITLE
fix(compiler-core): identifiers in switch-case should not be inferred as references

### DIFF
--- a/packages/compiler-core/__tests__/transforms/transformExpressions.spec.ts
+++ b/packages/compiler-core/__tests__/transforms/transformExpressions.spec.ts
@@ -717,7 +717,6 @@ describe('compiler: expression transform', () => {
     })
   })
 
-  // Test for switch case variable declarations bug fix
   describe('switch case variable declarations', () => {
     test('should handle const declarations in switch case without braces', () => {
       const { code } = compile(

--- a/packages/compiler-core/src/babelUtils.ts
+++ b/packages/compiler-core/src/babelUtils.ts
@@ -92,13 +92,21 @@ export function walkIdentifiers(
           )
         }
       } else if (node.type === 'CatchClause' && node.param) {
-        for (const id of extractIdentifiers(node.param)) {
-          markScopeIdentifier(node, id, knownIds)
+        if (node.scopeIds) {
+          node.scopeIds.forEach(id => markKnownIds(id, knownIds))
+        } else {
+          for (const id of extractIdentifiers(node.param)) {
+            markScopeIdentifier(node, id, knownIds)
+          }
         }
       } else if (isForStatement(node)) {
-        walkForStatement(node, false, id =>
-          markScopeIdentifier(node, id, knownIds),
-        )
+        if (node.scopeIds) {
+          node.scopeIds.forEach(id => markKnownIds(id, knownIds))
+        } else {
+          walkForStatement(node, false, id =>
+            markScopeIdentifier(node, id, knownIds),
+          )
+        }
       }
     },
     leave(node: Node & { scopeIds?: Set<string> }, parent: Node | null) {


### PR DESCRIPTION
My brother @PBK-B likes ​​to write​​ JSX in Vue. He ​​came across​​ this problem.

Variables declared under a switch-case clause are added `_ctx.` prefix when used.

```vue
<template>
  <p>{{ (() => { switch (true) { case true: let foo = 'Hello World'; return `${foo}`;} })()}}</p>
  <p>{{ (() => { switch (true) { case true: var foo = 'Hello World'; return `${foo}`;} })()}}</p>
  <p>{{ (() => { switch (true) { case true: var foo = 'Hello World'; } return `${foo}`; })()}}</p>
</template>
```

See [Playground](https://play.vuejs.org/#eNrFklFLwzAUhf/KJQhrYXQP+tR1BZWB+qCigi95WGnvus40CUnaFUL+u0nH5kQZ+ORbcs4J57uXWHItZdJ3SFKSGWwlKwzmlANkMrcWoiiGRQ4W9K4x5QYiozqM/b0sNEK4pMDQwFoIWMDkDhkT8C4UqyZzUGg6xWF1Yb3tVnMHLo5i57KZ/GNFX6h/q3A/Sr51ZLOTtZEpMboUfN3UyVYL7rdqAwYlpWhlw1A9SdMIrilJYXSCV/i63cOoBZbpQS83WH78om/1EDRKnhVqVD1ScvRMoWo0e3v5+oiDPx/NVlQd8+kz5gtqwbrAuI/ddLzy2Ce5kfa+lUKZhtdvejkY5PowVAANSTfmKfFf6/bM6F+4l8nV+I5yR9wnp9TWfg==)

Expected to show `Hello World`. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixes scoping of const declarations in switch cases so local variables are correctly recognized and emitted (including cases without braces), improving template expression handling and generated output accuracy.

* **Tests**
  * Adds tests covering switch-case variable scoping (with and without braces) and validates emitted code and control-flow behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->