### PR TITLE
chore(lint): replace deprecated `tseslint.config` and `prefer-ts-expect-error`

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -61,7 +61,10 @@ export default defineConfig(
       ],
       // This rule enforces the preference for using '@ts-expect-error' comments in TypeScript
       // code to indicate intentional type errors, improving code clarity and maintainability.
-      '@typescript-eslint/prefer-ts-expect-error': 'error',
+      '@typescript-eslint/ban-ts-comment': [
+        'error',
+        { minimumDescriptionLength: 0 },
+      ],
       // Enforce the use of 'import type' for importing types
       '@typescript-eslint/consistent-type-imports': [
         'error',

--- a/packages/vue/jsx-runtime/index.d.ts
+++ b/packages/vue/jsx-runtime/index.d.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/prefer-ts-expect-error */
+/* eslint-disable @typescript-eslint/ban-ts-comment */
 import type { NativeElements, ReservedProps, VNode } from '@vue/runtime-dom'
 
 /**

--- a/packages/vue/jsx.d.ts
+++ b/packages/vue/jsx.d.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/prefer-ts-expect-error */
+/* eslint-disable @typescript-eslint/ban-ts-comment */
 // global JSX namespace registration
 // somehow we have to copy=pase the jsx-runtime types here to make TypeScript happy
 import type { NativeElements, ReservedProps, VNode } from '@vue/runtime-dom'


### PR DESCRIPTION
1. Replaced `tseslint.config` with `defineConfig` from `eslint/config`, since `tseslint.config` was deprecated in [`typescript-eslint@8.42.0`](https://github.com/typescript-eslint/typescript-eslint/releases/tag/v8.42.0).

2. Replaced [`@typescript-eslint/prefer-ts-expect-error`](https://typescript-eslint.io/rules/prefer-ts-expect-error/) with [`@typescript-eslint/ban-ts-comment`](https://typescript-eslint.io/rules/ban-ts-comment/), as the former has been deprecated and the latter provides a more powerful and configurable alternative.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - No user-facing changes.

- Chores
  - Updated ESLint setup to use a new configuration wrapper and replaced a TypeScript lint rule for comment handling. No impact on runtime behavior or public APIs.

- Style
  - Adjusted ESLint disable directives in TypeScript declaration files to align with the updated lint rule. No changes to typings or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->