### PR TITLE
test(v-model): mutating an array or set checkbox value

### DIFF
--- a/packages/runtime-dom/__tests__/directives/vModel.spec.ts
+++ b/packages/runtime-dom/__tests__/directives/vModel.spec.ts
@@ -5,6 +5,7 @@ import {
   nextTick,
   ref,
   render,
+  vModelCheckbox,
   vModelDynamic,
   withDirectives,
 } from '@vue/runtime-dom'
@@ -1444,5 +1445,52 @@ describe('vModel', () => {
     expect(data.num).toBe(1)
 
     expect(inputNum1.value).toBe('1')
+  })
+
+  it(`should support mutating an array or set value for a checkbox`, async () => {
+    const component = defineComponent({
+      data() {
+        return { value: [] }
+      },
+      render() {
+        return [
+          withDirectives(
+            h('input', {
+              type: 'checkbox',
+              class: 'foo',
+              value: 'foo',
+              'onUpdate:modelValue': setValue.bind(this),
+            }),
+            [[vModelCheckbox, this.value]],
+          ),
+        ]
+      },
+    })
+    render(h(component), root)
+
+    const foo = root.querySelector('.foo')
+    const data = root._vnode.component.data
+
+    expect(foo.checked).toEqual(false)
+
+    data.value.push('foo')
+    await nextTick()
+    expect(foo.checked).toEqual(true)
+
+    data.value[0] = 'bar'
+    await nextTick()
+    expect(foo.checked).toEqual(false)
+
+    data.value = new Set()
+    await nextTick()
+    expect(foo.checked).toEqual(false)
+
+    data.value.add('foo')
+    await nextTick()
+    expect(foo.checked).toEqual(true)
+
+    data.value.delete('foo')
+    await nextTick()
+    expect(foo.checked).toEqual(false)
   })
 })


### PR DESCRIPTION
The PRs #8639 and #13637 both attempted similar fixes that would have introduced regressions. But the existing tests didn't catch those regressions.

This PR introduces an extra test for that case.

Specifically, when an array or set is used for the `value` of an `<input type="checkbox">`, mutating the array or set should lead to the `checked` state being updated accordingly. It isn't enough to use an `===` check to compare the old and new values, as a mutated array/set won't pass that check.

This PR could also be seen as a test case for 2937530beff5c6bb57286c2556307859e37aa809, though that wasn't my initial intention.

Also note that the fix in 2937530beff5c6bb57286c2556307859e37aa809 only works when `vModelCheckbox` or `vModelSelect` are used directly, not when they're wrapped with `vModelDynamic`. The tests in `vModel.spec.ts` do generally use `vModelDynamic`, but as it's missing the `deep: true` it won't trigger rendering updates. I haven't attempted to fix that here (it isn't immediately clear to me whether it's safe to add `deep: true` to `vModelDynamic`), but I've used `vModelCheckbox` directly in my test case to dodge that problem. In practice, using `vModelCheckbox` more accurately reflects real usage anyway.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added comprehensive tests to ensure checkbox bindings stay in sync when the bound value is an array or set, covering operations like additions, index replacements, and set mutations.
  - Expanded coverage for directive-driven checkbox models to validate state synchronization across common mutation scenarios, improving reliability and reducing regression risk in reactive form behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->