### PR TITLE
fix(compiler): using guard instead of non-nullish assertion

### DIFF
--- a/packages/compiler-core/src/transforms/transformVBindShorthand.ts
+++ b/packages/compiler-core/src/transforms/transformVBindShorthand.ts
@@ -15,13 +15,12 @@ export const transformVBindShorthand: NodeTransform = (node, context) => {
       if (
         prop.type === NodeTypes.DIRECTIVE &&
         prop.name === 'bind' &&
-        !prop.exp &&
-        prop.arg &&
         (!prop.exp ||
           // #13930 :foo in in-DOM templates will be parsed into :foo="" by browser
           (__BROWSER__ &&
             prop.exp.type === NodeTypes.SIMPLE_EXPRESSION &&
-            !prop.exp.content.trim()))
+            !prop.exp.content.trim())) &&
+        prop.arg
       ) {
         const arg = prop.arg
         if (arg.type !== NodeTypes.SIMPLE_EXPRESSION || !arg.isStatic) {


### PR DESCRIPTION
## Description

https://github.com/vuejs/core/blob/079010a38cfff4c49e0a13e54ebff0c189a4d5dc/packages/compiler-core/src/transforms/transformVBindShorthand.ts#L20

This non-nullish assertion is harmful that it will be broken on language service when user has only typed `:` on an element, in that case we shouldn't treat the single `:` as a `VBindShorthand`

We got error thrown below

```
Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'type')
    at Array.yX (index-C2PqwR5h.js:108:3591)
    at bS (index-C2PqwR5h.js:91:9055)
    at iRe (index-C2PqwR5h.js:91:8941)
    at bS (index-C2PqwR5h.js:91:9320)
```

## How to reproduce

https://play.vuejs.org/#eNp9UbFOwzAQ/ZXDS5cmGWCKIiRAHWAoCDp6CcnRpCS2ZV/SoCoDCz/Awsa/8QV8AudEbTqgDrZ8997zvWfvxJUxYdugiEXiMlsaAofUmEupogiWmopSrcMwhN/vr3epkmgkMcwFYW2qlJArgOQsCODn4xNWbwYhBcfCCmEWz+AZK72F1EFKZCEIJj6sClSgDW+ZVk6zwCECFX5ZvcUc0Fo9ifKyhRgiLpLoaLyYC3J8w0u5DjdOK46z83wpMl2bskJ7b6jkCVLEMCAeSyv2dTf0yDY43/ezArPXf/ob1/meFA8WHdoWpThglNo10ggvnpbY8fkA1jpvKmafAB+R0zfe40i7blTOto94g9vb2mhL/LQrt+gIlduH8kY9sx/4UvCf3pyIPtk9Dy8GnVS96P8Ayt+tIA==





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - v-bind same-name shorthand now requires a non-empty argument, preventing accidental matches and reducing false positives.
  - Argument handling is guarded to avoid invalid processing and preserve consistent diagnostics for bad shorthand arguments.

- Developer Experience
  - More predictable template compilation and clearer, consistent error messages in edge cases involving v-bind shorthand.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->