### PR TITLE
Revert "fix(compiler-core): remove types for expressions"

### DIFF
--- a/packages/compiler-core/__tests__/transforms/__snapshots__/transformExpressions.spec.ts.snap
+++ b/packages/compiler-core/__tests__/transforms/__snapshots__/transformExpressions.spec.ts.snap
@@ -14,16 +14,6 @@ return function render(_ctx, _cache, $props, $setup, $data, $options) {
 }"
 `;
 
-exports[`compiler: expression transform > expression with type 1`] = `
-"const { openBlock: _openBlock, createElementBlock: _createElementBlock } = Vue
-
-return function render(_ctx, _cache) {
-  return (_openBlock(), _createElementBlock("div", {
-    onClick: _ctx.handleClick
-  }, null, 8 /* PROPS */, ["onClick"]))
-}"
-`;
-
 exports[`compiler: expression transform > should allow leak of var declarations in for loop 1`] = `
 "const { openBlock: _openBlock, createElementBlock: _createElementBlock } = Vue
 

--- a/packages/compiler-core/__tests__/transforms/transformExpressions.spec.ts
+++ b/packages/compiler-core/__tests__/transforms/transformExpressions.spec.ts
@@ -754,12 +754,4 @@ describe('compiler: expression transform', () => {
       expect(code).toMatch(`_ctx.bar`)
     })
   })
-
-  test('expression with type', () => {
-    const { code } = compile(
-      `<div @click="(<number>handleClick as any)"></div>`,
-    )
-    expect(code).toMatch(`onClick: _ctx.handleClick`)
-    expect(code).toMatchSnapshot()
-  })
 })

--- a/packages/compiler-core/src/transforms/transformExpression.ts
+++ b/packages/compiler-core/src/transforms/transformExpression.ts
@@ -18,7 +18,6 @@ import {
   createSimpleExpression,
 } from '../ast'
 import {
-  TS_NODE_TYPES,
   isInDestructureAssignment,
   isInNewExpression,
   isStaticProperty,
@@ -348,18 +347,15 @@ export function processExpression(
   // an ExpressionNode has the `.children` property, it will be used instead of
   // `.content`.
   const children: CompoundExpressionNode['children'] = []
-  const isTSNode = TS_NODE_TYPES.includes(ast.type)
   ids.sort((a, b) => a.start - b.start)
   ids.forEach((id, i) => {
     // range is offset by -1 due to the wrapping parens when parsed
     const start = id.start - 1
     const end = id.end - 1
     const last = ids[i - 1]
-    if (!(isTSNode && i === 0)) {
-      const leadingText = rawExp.slice(last ? last.end - 1 : 0, start)
-      if (leadingText.length || id.prefix) {
-        children.push(leadingText + (id.prefix || ``))
-      }
+    const leadingText = rawExp.slice(last ? last.end - 1 : 0, start)
+    if (leadingText.length || id.prefix) {
+      children.push(leadingText + (id.prefix || ``))
     }
     const source = rawExp.slice(start, end)
     children.push(
@@ -376,7 +372,7 @@ export function processExpression(
           : ConstantTypes.NOT_CONSTANT,
       ),
     )
-    if (i === ids.length - 1 && end < rawExp.length && !isTSNode) {
+    if (i === ids.length - 1 && end < rawExp.length) {
       children.push(rawExp.slice(end))
     }
   })


### PR DESCRIPTION
Reverts vuejs/core#13397
Close #14060

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Removed test case for expression type casting

* **Chores**
  * Refactored internal expression transformation logic to streamline identifier text processing while maintaining existing functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->