### PR TITLE
chore(reactivity): remove duplicated ReactiveEffectRunner interface

### DIFF
--- a/packages/reactivity/src/effect.ts
+++ b/packages/reactivity/src/effect.ts
@@ -470,11 +470,6 @@ function removeDep(link: Link) {
   }
 }
 
-export interface ReactiveEffectRunner<T = any> {
-  (): T
-  effect: ReactiveEffect
-}
-
 export function effect<T = any>(
   fn: () => T,
   options?: ReactiveEffectOptions,


### PR DESCRIPTION
Removed duplicated ReactiveEffectRunner interface from effect.ts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Removed a public type definition for reactive effect functions. Applications that explicitly reference this type in their code may require updates to continue functioning properly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->