### PR TITLE
types(jsx): correct the naming of the enterKeyHint property in InputHTMLAttributes

### DIFF
--- a/packages/runtime-dom/src/jsx.ts
+++ b/packages/runtime-dom/src/jsx.ts
@@ -547,7 +547,7 @@ export interface InputHTMLAttributes extends HTMLAttributes {
   checked?: Booleanish | any[] | Set<any> | undefined // for IDE v-model multi-checkbox support
   crossorigin?: string | undefined
   disabled?: Booleanish | undefined
-  enterKeyHint?:
+  enterkeyhint?:
     | 'enter'
     | 'done'
     | 'go'
@@ -556,6 +556,10 @@ export interface InputHTMLAttributes extends HTMLAttributes {
     | 'search'
     | 'send'
     | undefined
+  /**
+   * @deprecated Use `enterkeyhint` instead.
+   */
+  enterKeyHint?: InputHTMLAttributes['enterkeyhint']
   form?: string | undefined
   formaction?: string | undefined
   formenctype?: string | undefined


### PR DESCRIPTION
Close #14088 

Correct the naming of the `enterKeyHint` property in `InputHTMLAttributes`

Change the enterKeyHint property to the lowercase form enterkeyhint to comply with HTML standard specifications, and add a deprecation flag to prompt for migration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated HTML input enter key hint attribute naming and expanded supported values to include 'next' and 'previous'. Previous property name remains available as a deprecated alias.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->