### PR TITLE
chore(compiler-ssr): move `defaultProps` initialization into `input` tag branch

### DIFF
--- a/packages/compiler-ssr/src/transforms/ssrVModel.ts
+++ b/packages/compiler-ssr/src/transforms/ssrVModel.ts
@@ -83,11 +83,11 @@ export const ssrTransformModel: DirectiveTransform = (dir, node, context) => {
 
   if (node.tagType === ElementTypes.ELEMENT) {
     const res: DirectiveTransformResult = { props: [] }
-    const defaultProps = [
-      // default value binding for text type inputs
-      createObjectProperty(`value`, model),
-    ]
     if (node.tag === 'input') {
+      const defaultProps = [
+        // default value binding for text type inputs
+        createObjectProperty(`value`, model),
+      ]
       const type = findProp(node, 'type')
       if (type) {
         const value = findValueBinding(node)


### PR DESCRIPTION
`defaultProps` is only used when the tag is `input`, so there is no need to initialize it outside the conditional.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code organization improvements with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->