### PR TITLE
feat(runtime-vapor): support setup fn and render fn co-usage for expose

### DIFF
--- a/packages/runtime-vapor/__tests__/component.spec.ts
+++ b/packages/runtime-vapor/__tests__/component.spec.ts
@@ -472,6 +472,29 @@ describe('component', () => {
     __DEV__ = true
   })
 
+  test('setup and render co-usage in production mode', () => {
+    __DEV__ = false
+    const { component: Child } = define({
+      setup: () => ({ foo: 'foo' }),
+      render() {
+        return template('<div> HI </div>', true)()
+      },
+    })
+
+    let exposed: Record<string, any> | null = {}
+    const { host } = define({
+      setup() {
+        let child = createComponent(Child, null, null, true)
+        exposed = child.exposed
+        return child
+      },
+    }).render()
+
+    expect(exposed.foo).toBe('foo')
+    expect(host.innerHTML).toBe('<div> HI </div>')
+    __DEV__ = true
+  })
+
   it('warn if functional vapor component not return a block', () => {
     // @ts-expect-error
     define(() => {

--- a/packages/runtime-vapor/src/component.ts
+++ b/packages/runtime-vapor/src/component.ts
@@ -1025,6 +1025,7 @@ function handleSetupResult(
       if (__DEV__ || __FEATURE_PROD_DEVTOOLS__) {
         instance.devtoolsRawSetupState = setupResult
       }
+      instance.exposed || instance.expose(setupResult)
       instance.setupState = proxyRefs(setupResult)
       if (__DEV__) {
         instance.setupState = createDevSetupStateProxy(instance)
@@ -1037,6 +1038,7 @@ function handleSetupResult(
     // - setup returning non-block state for use in render
     // support setup fn and render fn co-usage for expose
     if (!isBlock(setupResult) && component.render) {
+      instance.exposed || instance.expose(setupResult)
       instance.setupState = proxyRefs(setupResult)
       instance.block =
         callWithErrorHandling(


### PR DESCRIPTION
```tsx
const Comp = defineVaporComponent({
  setup() {
    // expose
    return {
      foo: 1
    }
  },
  render() {
    return <div />
  }
})

const comp = new Comp()
comp.exposeProxy.foo === 1
```