### PR TITLE
chore(reactivity): remove redundant IS_SHALLOW default in RefImpl

### DIFF
--- a/packages/reactivity/src/ref.ts
+++ b/packages/reactivity/src/ref.ts
@@ -114,7 +114,7 @@ class RefImpl<T = any> {
   dep: Dep = new Dep()
 
   public readonly [ReactiveFlags.IS_REF] = true
-  public readonly [ReactiveFlags.IS_SHALLOW]: boolean = false
+  public readonly [ReactiveFlags.IS_SHALLOW]: boolean
 
   constructor(value: T, isShallow: boolean) {
     this._rawValue = isShallow ? value : toRaw(value)


### PR DESCRIPTION
`[ReactiveFlags.IS_SHALLOW]` is declared with a default value of `false`, but the constructor always overwrites it based on the `isShallow` parameter, making the default dead code.

Removing it cleans up the code and avoids the misleading impression that `[ReactiveFlags.IS_SHALLOW]` default to `false`.

First time contributing to this project, thanks for reviewing, any feedback welcome!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code structure improvements to the reactivity system with no end-user visible changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->