### PR TITLE
types(runtime-core): export DirectiveModifiers type

### DIFF
--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -327,6 +327,7 @@ export type {
   DirectiveHook,
   ObjectDirective,
   FunctionDirective,
+  DirectiveModifiers,
   DirectiveArguments,
 } from './directives'
 export type { SuspenseBoundary } from './components/Suspense'


### PR DESCRIPTION
The `DirectiveModifiers` type is pretty useful when implementing a custom directive

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * DirectiveModifiers type is now publicly exported, providing developers with new capabilities for custom directive implementations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->