### PR TITLE
perf(compiler-core): use binary-search to get the line and column.

### DIFF
--- a/packages/compiler-core/src/tokenizer.ts
+++ b/packages/compiler-core/src/tokenizer.ts
@@ -296,14 +296,30 @@ export default class Tokenizer {
   public getPos(index: number): Position {
     let line = 1
     let column = index + 1
-    for (let i = this.newlines.length - 1; i >= 0; i--) {
-      const newlineIndex = this.newlines[i]
-      if (index > newlineIndex) {
-        line = i + 2
-        column = index - newlineIndex
-        break
+    const length = this.newlines.length
+    let j = -1
+    if (length > 100) {
+      let l = -1
+      let r = length
+      while (l + 1 < r) {
+        const m = (l + r) >>> 1
+        this.newlines[m] < index ? (l = m) : (r = m)
+      }
+      j = l
+    } else {
+      for (let i = length - 1; i >= 0; i--) {
+        if (index > this.newlines[i]) {
+          j = i
+          break
+        }
       }
     }
+
+    if (j >= 0) {
+      line = j + 2
+      column = index - this.newlines[j]
+    }
+
     return {
       column,
       line,


### PR DESCRIPTION
Problem Description
- Given: `this.newlines` is a strictly increasing array.
- Direct traversal to obtain the `newLineIndex` corresponding to the critical value `index`.
- When the array length is large, the performance is significantly worse compared to `binary-search.`

Solution
- If the array length is greater than `100`, use `binary-search` to obtain the result.
- If the array length is less than or equal to `100`, obtain the result directly via traversal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized the compiler core's position calculation algorithm to improve overall system performance, particularly benefiting large files that contain numerous line breaks and require frequent position lookups during compilation
  * Enhanced the Position object data structure returned from position queries to include an additional offset field, providing developers with more granular and comprehensive position tracking information

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->