### PR TITLE
 fix(compiler-core): reject v-for with unmatched parentheses

### DIFF
--- a/packages/compiler-core/__tests__/transforms/vFor.spec.ts
+++ b/packages/compiler-core/__tests__/transforms/vFor.spec.ts
@@ -293,6 +293,30 @@ describe('compiler: v-for', () => {
       )
     })
 
+    test('unmatched closing parenthesis', () => {
+      const onError = vi.fn()
+      parseWithForTransform('<span v-for="i) in items" />', { onError })
+
+      expect(onError).toHaveBeenCalledTimes(1)
+      expect(onError).toHaveBeenCalledWith(
+        expect.objectContaining({
+          code: ErrorCodes.X_V_FOR_MALFORMED_EXPRESSION,
+        }),
+      )
+    })
+
+    test('unmatched opening parenthesis', () => {
+      const onError = vi.fn()
+      parseWithForTransform('<span v-for="(i in items" />', { onError })
+
+      expect(onError).toHaveBeenCalledTimes(1)
+      expect(onError).toHaveBeenCalledWith(
+        expect.objectContaining({
+          code: ErrorCodes.X_V_FOR_MALFORMED_EXPRESSION,
+        }),
+      )
+    })
+
     test('<template v-for> key placement', () => {
       const onError = vi.fn()
       parseWithForTransform(

--- a/packages/compiler-core/src/parser.ts
+++ b/packages/compiler-core/src/parser.ts
@@ -490,7 +490,6 @@ const tokenizer = new Tokenizer(stack, {
 // This regex doesn't cover the case if key or index aliases have destructuring,
 // but those do not make sense in the first place, so this works in practice.
 const forIteratorRE = /,([^,\}\]]*)(?:,([^,\}\]]*))?$/
-const stripParensRE = /^\(|\)$/g
 
 function parseForExpression(
   input: SimpleExpressionNode,
@@ -526,7 +525,16 @@ function parseForExpression(
     finalized: false,
   }
 
-  let valueContent = LHS.trim().replace(stripParensRE, '').trim()
+  let valueContent = LHS.trim()
+  const hasLeadingParen = valueContent.startsWith('(')
+  const hasTrailingParen = valueContent.endsWith(')')
+
+  if (hasLeadingParen && hasTrailingParen) {
+    valueContent = valueContent.slice(1, -1).trim()
+  } else if (hasLeadingParen || hasTrailingParen) {
+    return
+  }
+
   const trimmedOffset = LHS.indexOf(valueContent)
 
   const iteratorMatch = valueContent.match(forIteratorRE)


### PR DESCRIPTION
 ### What kind of change does this PR introduce?

  Bug fix

  ### Does this PR introduce a breaking change?

  No

  ### What problem does this PR solve?

  Fixes #14227

  Previously, the v-for parser incorrectly accepted malformed expressions with unmatched parentheses. For example, `v-for="i) in items"` would compile without error.

  The root cause was the regex `/^\(|\)$/g` on line 493 in `parser.ts`, which strips opening parentheses at the start OR closing parentheses at the end independently, without validating they form matching pairs.

  ### What is the new behavior?

  The parser now checks that parentheses exist at both the start AND end before stripping them:
  - If both `(` and `)` are present, they are stripped as before (e.g., `(item)` → `item`)
  - If only one parenthesis is present, `parseForExpression` returns `undefined`, triggering an `X_V_FOR_MALFORMED_EXPRESSION` error

  **Examples:**
  - ✅ `v-for="(item) in items"` - valid, works as before
  - ✅ `v-for="item in items"` - valid, works as before
  - ❌ `v-for="item) in items"` - now correctly throws error
  - ❌ `v-for="(item in items"` - now correctly throws error

  ### Additional context

  - Removed unused `stripParensRE` regex constant
  - Added two unit tests to verify the fix
  - All 646 existing compiler-core tests pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for v-for expressions by enhancing parenthesis matching detection. The compiler now properly identifies and reports errors when encountering mismatched, unmatched, or incomplete parentheses in for-loop syntax. This provides clearer error messages to help developers quickly identify and correct syntax issues in their templates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->