### PR TITLE
refactor(runtime-core): unify lifecycle hook triggering via enum

### DIFF
--- a/packages/runtime-core/src/apiLifecycle.ts
+++ b/packages/runtime-core/src/apiLifecycle.ts
@@ -7,7 +7,7 @@ import {
 import type { ComponentPublicInstance } from './componentPublicInstance'
 import { ErrorTypeStrings, callWithAsyncErrorHandling } from './errorHandling'
 import { warn } from './warning'
-import { toHandlerKey } from '@vue/shared'
+import { invokeArrayFns, toHandlerKey } from '@vue/shared'
 import {
   type DebuggerEvent,
   pauseTracking,
@@ -61,6 +61,14 @@ export function injectHook(
           : ``),
     )
   }
+}
+
+export const triggerHooks = (
+  instance: ComponentInternalInstance,
+  type: LifecycleHooks,
+): void => {
+  const hooks = instance[type]
+  if (hooks) invokeArrayFns(hooks)
 }
 
 const createHook =

--- a/packages/runtime-core/src/compat/global.ts
+++ b/packages/runtime-core/src/compat/global.ts
@@ -9,7 +9,6 @@ import {
 import {
   NOOP,
   extend,
-  invokeArrayFns,
   isArray,
   isFunction,
   isObject,
@@ -58,6 +57,8 @@ import {
   warnDeprecation,
 } from './compatConfig'
 import type { LegacyPublicInstance } from './instance'
+import { triggerHooks } from '../apiLifecycle'
+import { LifecycleHooks } from '../enums'
 
 /**
  * @deprecated the default `Vue` export has been removed in Vue 3. The type for
@@ -577,11 +578,8 @@ function installCompatMount(
         }
         delete app._container.__vue_app__
       } else {
-        const { bum, scope, um } = instance
-        // beforeDestroy hooks
-        if (bum) {
-          invokeArrayFns(bum)
-        }
+        const { scope } = instance
+        triggerHooks(instance, LifecycleHooks.BEFORE_UNMOUNT)
         if (isCompatEnabled(DeprecationTypes.INSTANCE_EVENT_HOOKS, instance)) {
           instance.emit('hook:beforeDestroy')
         }
@@ -589,10 +587,7 @@ function installCompatMount(
         if (scope) {
           scope.stop()
         }
-        // unmounted hook
-        if (um) {
-          invokeArrayFns(um)
-        }
+        triggerHooks(instance, LifecycleHooks.UNMOUNTED)
         if (isCompatEnabled(DeprecationTypes.INSTANCE_EVENT_HOOKS, instance)) {
           instance.emit('hook:destroyed')
         }

--- a/packages/runtime-core/src/components/KeepAlive.ts
+++ b/packages/runtime-core/src/components/KeepAlive.ts
@@ -23,15 +23,9 @@ import {
   onMounted,
   onUnmounted,
   onUpdated,
+  triggerHooks,
 } from '../apiLifecycle'
-import {
-  ShapeFlags,
-  invokeArrayFns,
-  isArray,
-  isRegExp,
-  isString,
-  remove,
-} from '@vue/shared'
+import { ShapeFlags, isArray, isRegExp, isString, remove } from '@vue/shared'
 import { watch } from '../apiWatch'
 import {
   type ElementNamespace,
@@ -151,9 +145,7 @@ const KeepAliveImpl: ComponentOptions = {
       )
       queuePostRenderEffect(() => {
         instance.isDeactivated = false
-        if (instance.a) {
-          invokeArrayFns(instance.a)
-        }
+        triggerHooks(instance, LifecycleHooks.ACTIVATED)
         const vnodeHook = vnode.props && vnode.props.onVnodeMounted
         if (vnodeHook) {
           invokeVNodeHook(vnodeHook, instance.parent, vnode)
@@ -173,9 +165,7 @@ const KeepAliveImpl: ComponentOptions = {
 
       move(vnode, storageContainer, null, MoveType.LEAVE, parentSuspense)
       queuePostRenderEffect(() => {
-        if (instance.da) {
-          invokeArrayFns(instance.da)
-        }
+        triggerHooks(instance, LifecycleHooks.DEACTIVATED)
         const vnodeHook = vnode.props && vnode.props.onVnodeUnmounted
         if (vnodeHook) {
           invokeVNodeHook(vnodeHook, instance.parent, vnode)

--- a/packages/runtime-core/src/renderer.ts
+++ b/packages/runtime-core/src/renderer.ts
@@ -87,6 +87,8 @@ import { isCompatEnabled } from './compat/compatConfig'
 import { DeprecationTypes } from './compat/compatConfig'
 import { type TransitionHooks, leaveCbKey } from './components/BaseTransition'
 import type { VueElement } from '@vue/runtime-dom'
+import { triggerHooks } from './apiLifecycle'
+import { LifecycleHooks } from './enums'
 
 export interface Renderer<HostElement = RendererElement> {
   render: RootRenderFunction<HostElement>
@@ -1323,14 +1325,11 @@ function baseCreateRenderer(
       if (!instance.isMounted) {
         let vnodeHook: VNodeHook | null | undefined
         const { el, props } = initialVNode
-        const { bm, m, parent, root, type } = instance
+        const { m, parent, root, type } = instance
         const isAsyncWrapperVNode = isAsyncWrapper(initialVNode)
 
         toggleRecurse(instance, false)
-        // beforeMount hook
-        if (bm) {
-          invokeArrayFns(bm)
-        }
+        triggerHooks(instance, LifecycleHooks.BEFORE_MOUNT)
         // onVnodeBeforeMount
         if (
           !isAsyncWrapperVNode &&
@@ -2316,14 +2315,11 @@ function baseCreateRenderer(
       unregisterHMR(instance)
     }
 
-    const { bum, scope, job, subTree, um, m, a } = instance
+    const { scope, job, subTree, um, m, a } = instance
     invalidateMount(m)
     invalidateMount(a)
 
-    // beforeUnmount hook
-    if (bum) {
-      invokeArrayFns(bum)
-    }
+    triggerHooks(instance, LifecycleHooks.BEFORE_UNMOUNT)
 
     if (
       __COMPAT__ &&


### PR DESCRIPTION
This PR refactors internal lifecycle hook invocation by introducing
`triggerHooks`, which triggers hooks based on the existing `LifecycleHooks` enum.

The lifecycle being triggered is now explicit in the function call, while the
execution order remains unchanged.


Before:
- `// beforeMount hook`

- `if (bm) invokeArrayFns(bm)`

After:

- `triggerHooks(instance, LifecycleHooks.BEFORE_MOUNT)`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal improvements to lifecycle hook management system to consolidate hook invocation logic across core components.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->