### PR TITLE
refactor(shared): clarify normalizeCssVarValue control flow and intent

### DIFF
--- a/packages/shared/src/cssVars.ts
+++ b/packages/shared/src/cssVars.ts
@@ -3,21 +3,30 @@
  * See https://github.com/vuejs/core/pull/12461#issuecomment-2495804664
  */
 export function normalizeCssVarValue(value: unknown): string {
+  // null / undefined → reset CSS variable
   if (value == null) {
     return 'initial'
   }
 
+  // strings are mostly passed through
   if (typeof value === 'string') {
+    // empty string is not a valid CSS var value
     return value === '' ? ' ' : value
   }
 
-  if (typeof value !== 'number' || !Number.isFinite(value)) {
-    if (__DEV__) {
-      console.warn(
-        '[Vue warn] Invalid value used for CSS binding. Expected a string or a finite number but received:',
-        value,
-      )
+  // numbers must be finite
+  if (typeof value === 'number') {
+    if (Number.isFinite(value)) {
+      return String(value)
     }
+  }
+
+  // everything else is invalid but tolerated
+  if (__DEV__) {
+    console.warn(
+      '[Vue warn] Invalid value used for CSS binding. Expected a string or a finite number but received:',
+      value,
+    )
   }
 
   return String(value)


### PR DESCRIPTION
The behavior is intentionally unchanged. The goal is to make the function’s intent and decision tree a bit clearer by:

- making the control flow more explicit (separating string / number / fallback cases)
- adding comments to document why certain edge cases exist (e.g. empty strings for CSS variables)
- keeping all existing runtime behavior and dev warnings exactly the same

This function sits at the boundary between JS values and CSS custom properties, so I’ve been careful not to change any semantics - especially around invalid values being tolerated and only warned about in dev.

This is my first “real” PR proposing a code change to Vue core, so I’m very much open to feedback and suggestions on style, structure, or whether this refactor is useful at all. Thanks for taking a look! 😄

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CSS variable value handling to properly manage edge cases, including empty strings and numeric values, ensuring more consistent rendering and appropriate warnings for invalid inputs during development.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->