### PR TITLE
fix(runtime-vapor): correctly check slot existence in ownKeys

### DIFF
--- a/packages/runtime-vapor/src/componentSlots.ts
+++ b/packages/runtime-vapor/src/componentSlots.ts
@@ -75,10 +75,12 @@ export const dynamicSlotsProxyHandlers: ProxyHandler<RawSlots> = {
       for (const source of dynamicSources) {
         if (isFunction(source)) {
           const slot = resolveFunctionSource(source)
-          if (isArray(slot)) {
-            for (const s of slot) keys.push(String(s.name))
-          } else {
-            keys.push(String(slot.name))
+          if (slot) {
+            if (isArray(slot)) {
+              for (const s of slot) keys.push(String(s.name))
+            } else {
+              keys.push(String(slot.name))
+            }
           }
         } else {
           keys.push(...Object.keys(source))


### PR DESCRIPTION
## Description

Fixes a bug in the `ownKeys` trap of the slots proxy where accessing `slot.name` would throw an error when a dynamic slot returns `undefined` (e.g., when using `v-if` with a `false` condition).

Reproduction: [playground](https://play.vuejs.org/#eNq1VW1v0zAQ/iu3gNRMatPCEB+6boihSYAEQ9v4RBByk0vrLbEj2+laVf3vnO0mTdptSAg+tIrv9bnHd+d18L4so0WFwTiY6ETx0sCClVKBRlOV57HgBZ0MfJBFCZmSBfSioT1Yp16jXoPCrA9SfJGVMJjCZmvsrWKRSKENcH0zlw8fkaWo4Mz6hEZVeGwtGt8wPIazc1jHAiyKW16grExbCp1A0YLlFVK4jOUarX7Th9ej0YjCbug3GfrCqBg6GCzKnBmkE8Ak5Qv3AUA8WL39bEnpYIttTnSuA8CLua9jMeDZWRy0IcVBywNga0gcGBSmFWvYQeNFrXyTYY2k/up4BP3AaAqa8Vl0p6WgO3T0xEFCMXiO6qo0nIiPg3FNXBywPJcPn53Mct+v5ckck/tH5Hd6aWVx8E2hRrXAOGh0hqkZGq++vPmKS/pulIVMq5ysn1Feo5Z5ZTF6s4tKpAS7ZefQfnJNxsXsVl8uiUJdF2WB+gv3dVO3WfqeKn0H9yR64/yoQ4jFup9bQ+DafzsKORMzumBDwXYDsYZK400uje7TxRZlRZ1rB+ACM6nwe5nSHfWpw1li+MJ/pVLkq/3ByCpBFlLYcNdbaxeW+t0B95OjrYh6vE4aUmPXujqJU7ix8ufJNRWhxO2qxImhP5k17ufn4drOBsAuv4PcSQ0wHAIXWxroyhDMHBXS+AETgEqR+IGbOVxN7zAx0T2udOigutg1QIJTsbyGJ/ABbtCEhz4dp6kj8jmnTt21c8stqgQVFrayH0ekvGTJPKQArXUC0A0GzBa4Ov5BZj8pu4PnDt7eU0fdA13arKDbAmFL79TK3UnTDntFUD/utmXrzvc6Y7dPL4vSrJqFWjfidlkeuQiRXz9/3oSgzSpH6vSUa9KsxpDluDx1/4OUKyKe+BxTlrwqxGmz5JzvdgsedSDFwd/G3G5h2gdUmC9gtw2d2tYGghU2uDegbMODzblXWkErgIuBkeWY3ohyaTOu110e30GPqDGrem/bTD0YQ69kWtPb1hZvNnWqR5LNkc/mZgyvKA9MWXI/U/TEpQMqVqoxTHMSnYKH5OHAiADZIg6Zfdm+zH9KLCRm+R/JPeogP2CXkj/FcKPasfz0U/hrgco+DLTET6K30WgwRcOiV8HmN80B/ks=)

## Problem

When using dynamic slots with conditional rendering (via `v-if`), the `ownKeys` trap in `dynamicSlotsProxyHandlers` would attempt to access `slot.name` without first checking if `slot` is `undefined`. This caused a `TypeError: Cannot read properties of undefined (reading 'name')` when calling `Object.keys(slots)` or `Reflect.ownKeys(slots)` on a component instance with conditionally rendered slots.

## Solution

Added a null check before accessing `slot.name` in the `ownKeys` trap handler. This ensures that when a dynamic slot source function returns `undefined`, it is properly skipped rather than causing an error.

## Testing

- Added a test case `slots proxy ownKeys trap correctly reflects dynamic slot presence` that verifies `Reflect.ownKeys(instance.slots)` correctly reflects the presence/absence of dynamic slots when toggled with `v-if`