### PR TITLE
docs: fix typos in comments in the code

### DIFF
--- a/packages/compiler-sfc/src/script/defineProps.ts
+++ b/packages/compiler-sfc/src/script/defineProps.ts
@@ -369,7 +369,7 @@ function genDestructuredDefaultValue(
   }
 }
 
-// non-comprehensive, best-effort type infernece for a runtime value
+// non-comprehensive, best-effort type inference for a runtime value
 // this is used to catch default value / type declaration mismatches
 // when using props destructure.
 function inferValueType(node: Node): string | undefined {

--- a/packages/compiler-sfc/src/script/utils.ts
+++ b/packages/compiler-sfc/src/script/utils.ts
@@ -109,7 +109,7 @@ function toFileNameLowerCase(x: string) {
 
 /**
  * We need `getCanonicalFileName` when creating ts module resolution cache,
- * but TS does not expose it directly. This implementation is repllicated from
+ * but TS does not expose it directly. This implementation is replicated from
  * the TS source code.
  */
 export function createGetCanonicalFileName(


### PR DESCRIPTION
### Clarification of the changes

Just fixed some typos in the comments in two files in the code. It is nothing groundbreaking, but it was nice to have these corrected.

### Files changed

- core\packages\compiler-sfc\src\script\utils.ts
- core\packages\compiler-sfc\src\script\defineProps.ts

No changes in functionality, that being said.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed typographical errors in code comments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->