### PR TITLE
fix(compiler-vapor): allow multiple children in Transition v-if branch elements

### DIFF
--- a/packages/compiler-vapor/__tests__/transforms/TransformTransition.spec.ts
+++ b/packages/compiler-vapor/__tests__/transforms/TransformTransition.spec.ts
@@ -188,6 +188,21 @@ describe('compiler: transition', () => {
     )
   })
 
+  test('does not warn with multiple children in v-if branch', () => {
+    checkWarning(
+      `
+      <transition>
+        <h1 v-if="condition">
+          <span>True</span>
+          <span>True</span>
+        </h1>
+        <h1 v-else>False</h1>
+      </transition>
+      `,
+      false,
+    )
+  })
+
   test('inject persisted when child has v-show', () => {
     expect(
       compileWithElementTransform(`

--- a/packages/compiler-vapor/src/transforms/transformTransition.ts
+++ b/packages/compiler-vapor/src/transforms/transformTransition.ts
@@ -54,8 +54,7 @@ function hasMultipleChildren(node: ElementNode): boolean {
         // not has v-for
         !findDir(c, 'for') &&
         // if the first child has v-if, the rest should also have v-else-if/v-else
-        (index === 0 ? findDir(c, 'if') : hasElse(c)) &&
-        !hasMultipleChildren(c),
+        (index === 0 ? findDir(c, 'if') : hasElse(c)),
     )
   ) {
     return false


### PR DESCRIPTION
Fixes #14316