### PR TITLE
fix(server-renderer): use ssrRenderClass helper for className attribute

### DIFF
--- a/packages/server-renderer/__tests__/ssrRenderAttrs.spec.ts
+++ b/packages/server-renderer/__tests__/ssrRenderAttrs.spec.ts
@@ -154,7 +154,7 @@ describe('ssr: renderClass', () => {
       ssrRenderAttrs({
         className: ['foo', 'bar'],
       }),
-    ).toBe(` class="foo,bar"`)
+    ).toBe(` class="foo bar"`)
   })
 })
 

--- a/packages/server-renderer/src/helpers/ssrRenderAttrs.ts
+++ b/packages/server-renderer/src/helpers/ssrRenderAttrs.ts
@@ -38,12 +38,10 @@ export function ssrRenderAttrs(
       continue
     }
     const value = props[key]
-    if (key === 'class') {
+    if (key === 'class' || key === 'className') {
       ret += ` class="${ssrRenderClass(value)}"`
     } else if (key === 'style') {
       ret += ` style="${ssrRenderStyle(value)}"`
-    } else if (key === 'className') {
-      ret += ` class="${String(value)}"`
     } else {
       ret += ssrRenderDynamicAttr(key, value, tag)
     }


### PR DESCRIPTION
fix https://github.com/vuejs/core/security/advisories/GHSA-5c3j-59mh-x5gj

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Server-side rendering now treats class and className consistently and normalizes values for correct HTML output.
  * Array class values are rendered with space-separated tokens (e.g., class="foo bar" instead of class="foo,bar"), avoiding malformed class attributes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->