### PR TITLE
fix(runtime-vapor): prevent v-for crash on looping through null or undefined array

### DIFF
--- a/packages/runtime-vapor/__tests__/componentSlots.spec.ts
+++ b/packages/runtime-vapor/__tests__/componentSlots.spec.ts
@@ -2201,7 +2201,7 @@ describe('component: slots', () => {
           return createComponent(Child, null, {
             $: [
               () =>
-                createForSlots(loop.value, (item, i) => ({
+                createForSlots(loop.value as any, (item, i) => ({
                   name: item,
                   fn: () => template(item + i)(),
                 })),

--- a/packages/runtime-vapor/__tests__/for.spec.ts
+++ b/packages/runtime-vapor/__tests__/for.spec.ts
@@ -696,7 +696,7 @@ describe('createFor', () => {
 
     const { host } = define(() => {
       const n1 = createFor(
-        () => list.value,
+        () => list.value as any,
         (item, key, index) => {
           const span = document.createElement('li')
           renderEffect(() => {

--- a/packages/runtime-vapor/src/apiCreateFor.ts
+++ b/packages/runtime-vapor/src/apiCreateFor.ts
@@ -73,14 +73,7 @@ class ForBlock extends VaporFragment {
   }
 }
 
-type Source =
-  | any[]
-  | Record<any, any>
-  | number
-  | Set<any>
-  | Map<any, any>
-  | null
-  | undefined
+type Source = any[] | Record<any, any> | number | Set<any> | Map<any, any>
 
 type ResolvedSource = {
   values: any[]
@@ -137,7 +130,7 @@ export const createFor = (
 
   const renderList = () => {
     const source = normalizeSource(src())
-    const newLength = source.values?.length ?? 0
+    const newLength = source.values.length
     const oldLength = oldBlocks.length
     newBlocks = new Array(newLength)
     let isFallback = false
@@ -579,7 +572,7 @@ export function createForSlots(
   getSlot: (item: any, key: any, index?: number) => DynamicSlot,
 ): DynamicSlot[] {
   const source = normalizeSource(rawSource)
-  const sourceLength = source.values?.length ?? 0
+  const sourceLength = source.values.length
   const slots = new Array<DynamicSlot>(sourceLength)
   for (let i = 0; i < sourceLength; i++) {
     slots[i] = getSlot(...getItem(source, i))
@@ -616,6 +609,8 @@ function normalizeSource(source: any): ResolvedSource {
         values[i] = source[keys[i]]
       }
     }
+  } else {
+    values = []
   }
   return {
     values,


### PR DESCRIPTION
When porting my project to vapor, I noticed component crash. After digging into it I find out that v-for crashes with undefined/null input which was not the case for vdom. This PR aims to fix that issue.

repl (not working):
[vapor](https://play.vuejs.org/#eNqNU8FOwzAM/RUrF0AaHayIwzQmAeIAB0DAjSBUOncE0qRK0jJU9d9xsrVssE071X7PeX6N45qdF0VUlciGbGRTIwoHFl1ZQJUU2oy5Ejl9HdRgMIMGMqNz2KMDex11qfNigUd9n3g9orlKtbIOEmOO4cyf31ellAdL+GCBl2qCmVA4WSbjBfl83IPBCzGj/twhuaLEYV7IxCFlAKOJqEKwEi4S33U46v/FoTrMtDnjTIBQwSVn47oWTfO/dtw53EVosEWI6OR7F5F4nchK/E+bBMBK7ewfeT+ULgtIe3nbuq5c8Lz5ktBvizZaOcF6zFkaZSam0YfVit5X7Ys5S0lDSDR3hRM0as6GEBjPJVLqr5uAOVNir8XTd0w/1+AfduYxzu4NWjQVctZxLjFTdHP66vEWZxR3ZK4npaTqLeQDWi1L73FedkFPgGwv1QW312EJhJo+2auZQ2Xbn/JGfWUT6jmjpfDXt+nXf+3G0Uk4x1VDt9gu1IYF3XEn/KuA/tZxvVZovHlqFEen0dHhG7okilnzA1t2VJ8=)

repl (working):
[vdom](https://play.vuejs.org/#eNqNU01PwzAM/StRLgNp69iKOEzbJEA7wAEQcCMIlc4dGWlSJWkZqvrfcbK1+2TazX7PeX6J45JeZ1lQ5EAHdGhizTNLDNg8GzPJ00xpS0qiISEVSbRKSQtLWw11q9JshQddlzglpJmMlTSWRFr3yMidP5O5EOcbeH+F53IKCZcw3STDFfnWa5P+OzLD7tIbusLEQpqJyAJmhAynvPDBVrhKXNfBsLuLk6KTKD1ilBMuvUtGx2XJq2q/dtw4PEWof0QI6ej3FJHwkMhWvKeNAsQIZc2OvBtKk3mkfrxjXbceeNl8Q2jdoo62TtA2tQZHmfBZMDdK4s8qXTGjMWpwAfoxsxxHzeiAeMZxkRDq595jVufQrvH4C+LvA/jcLBzG6JMGA7oARhvORnoGdklPXh5ggXFDpmqaC6w+Qj6DUSJ3HpdlN/gF0PZGnXd755eAy9mrmSwsSFNfyhl1lZWvZxSXwj3ff1df2w2DS3+OyQpfsV6ovdU8cRvcfyDdo4P6KEA729giDK6Ci84n2CgIafUH6BpQDw==)

repl (working):
[vapor this PR](https://deploy-preview-14328--vue-sfc-playground.netlify.app/#eNqNU01PwzAM/StWLgNpbNrGadomAdoBDoCAG+FQde7ISJMqSctQ1f+Ok63d97RT7fecl1c7LtldlnWKHNmQjWxsRObAosszKKJMmwlXIqWvgxIMJlBBYnQKLTrQaqgHnWZrvNP1idcjmqtYK+sgMqYHY3/+SuVSXm/h/TWeqxkmQuFsmxysyc9eG/pfxIy6K4fkihKHaSYjh5QBjGaiCMFOuE78rcNRdx+H4ibRZsyZAKGCS84mZSmq6rB20ji8RKh/Rojo6O8SkcExkZ34QJsEwErt7J68H0qTBaRu3rlbdxq8unxLaHNFHe2cYG3mLI0yEfPOwmpF76v0xZzFpCEkmpfMCRo1Z0MIjOciKfXvU8CcybFd4/E3xj9H8IVdeoyzV4MWTYGcNZyLzBzdip6+P+OS4oZM9SyXVH2GfEOrZe49rsru6QmQ7a264PYxLIFQ8w87XTpUtv4pb9RXVqGeM1oK375Tv76xO+jchnNcVdTFeqFOLOiFO+FfBXTPjKv6Bx84TS0=)