### PR TITLE
fix(runtime-core): queue mounted hooks added during mount

### DIFF
--- a/packages/runtime-core/src/renderer.ts
+++ b/packages/runtime-core/src/renderer.ts
@@ -1549,7 +1549,8 @@ function baseCreateRenderer(
           }
           initialVNode.el = subTree.el
         }
-        // mounted hook
+        // Mounted hooks may be added to `instance.m` while mounting.
+        // Reading `instance.m` here ensures those hooks are still scheduled.
         if (instance.m) {
           queuePostRenderEffect(instance.m, undefined, parentSuspense)
         }


### PR DESCRIPTION
Ensure mounted hooks registered during render (e.g., slots calling onMounted) are still scheduled by reading instance.m after patch instead of relying on a destructured snapshot.

### Problem Description
The mounted hook is lost after the virtual dom mounts the vapor slot

### Root Cause
After the mounted hook is deconstructed, the reference is lost due to modification

### Validation
1. Enter text in the input box.
2. Click the "Change" button

Under normal circumstances, the text should be brought out.

### Playground
- × [play](https://play.vuejs.org/#eNqNU01P3DAQ/StTXwISJCVb9bANqB/i0B7aqu3RUhXCJGtwbMsfYaXV/nfGNpsFBCtO8cx78zzzPNmwL8aUU0C2ZI3rrDAeHPpgYGqNthdciZG+HjZgsYct9FaPUFBBMUPf9GjOHoCySlFULD49YdRPGPWOwVWnlaNLV/oOzuMlR94GPN7lRzc8pIuCklz1QXVeaAWdFN3t0TFsuIJUXk6tDEjsd/uIqy1XTZUno2ko8Dga2XqkCKC5Ct6T2Oekds5Z+nJ20a1aNWBTZTxz86DTqeiJGO8gXgQIEsoET9Cor1ESSm1zBlWuy57sNWoionS5gzcV13RuqkedsxPmHTnUi6G8cVrR8yUfaACiC4n2l4kuOc6W2aGItVLqux8pF00+2eW7FXa3L+Rv3DrmOPtt0aGdkLMZ860d0Gf48u9PXNN5BmmSIIl9APyDTssQe8y0r0FdU9uPeKnb72mDhBr+ucu1R+V2Q8VGI3Ob+JzRPkWnXht93+6i/JDqaDXIxXldX/kBDuwOQPT6bAmNk9qn93r+RvOqP1c/pBtV60Oq/ye00QcSXZQfy/enV+jbcsG29x0uQ8g=)
- √ [play](https://play.vuejs.org/#eNqNU8tu2zAQ/BWWFzlAIjVy0YMrG30ghxboA22PBApFXslMKJLgQzFg6N+7JGPZDmqjB0HkznA5O9zd0Q9a54MHuqCVbQzXjlhwXpOh1sqsmOQ9/h3ZEQMtGUlrVE8yPJBN0CfV69tnIC/iLmTM3p0wyhNGuWcw2Shp8dKNeiLLcMnMGQ9X+3hvu+dwlmGQydbLxnElSSN48zi7IjsmSTyeD7XwgOxXhx2TI5NVkSrDanDjoNeidoA7Qqp77xwmex+zLRmNf0ZXzaaWHVRFwhM3FTrc8BaJ4Q7kBQAhLrV3CPVqDQJRlM0oKdK55MkhR4lEEDYp+K/DJa6r4kg5vabOokMt7/IHqyQ+X/QBC0A6F2C+6+CSZXSRHApYLYR6+hJjweTrfbzZQPP4j/iD3YYYoz8MWDADMDphrjYduATf/foGW1xPIFbiBbIvgD/BKuGDxkT76OUaZR/xotrPsYO47H7bu60DafdFBaGBOUY+o9hPwalzpR/kzvM38Ry2Bro4teuZAbjQO4QEr28XpLJCufheL99oavWX2Y8HS8mvyksH65PxwtmYgBm2+XKVigljoQTkQnWzLHXTxAsTMuJ3QXSQXC5iZ51V/WcAE3xG0fP8bf765h5cnc/p+Bd76mUH)