### PR TITLE
fix(runtime-dom): handle null/undefined handler in withModifiers

### DIFF
--- a/packages/runtime-dom/__tests__/directives/vOn.spec.ts
+++ b/packages/runtime-dom/__tests__/directives/vOn.spec.ts
@@ -163,4 +163,16 @@ describe('runtime-dom: v-on directive', () => {
     triggerEvent(el2, 'click', e => (e.shiftKey = true))
     expect(fn).toBeCalledTimes(2)
   })
+
+  it('withModifiers should handle null or undefined handler', () => {
+    expect(() => {
+      const handler1 = withModifiers(null as any, ['ctrl'])
+      expect(handler1).toBe(null)
+    }).not.toThrow()
+
+    expect(() => {
+      const handler2 = withModifiers(undefined as any, ['shift'])
+      expect(handler2).toBe(undefined)
+    }).not.toThrow()
+  })
 })

--- a/packages/runtime-dom/src/directives/vOn.ts
+++ b/packages/runtime-dom/src/directives/vOn.ts
@@ -55,6 +55,7 @@ export const withModifiers = <
   fn: T & { _withMods?: { [key: string]: T } },
   modifiers: VOnModifiers[],
 ): T => {
+  if (!fn) return fn
   const cache = fn._withMods || (fn._withMods = {})
   const cacheKey = modifiers.join('.')
   return (


### PR DESCRIPTION
close #14361

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability of event handler modifiers by gracefully handling null or undefined values, preventing errors and ensuring consistent behavior in edge cases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->