### PR TITLE
fix(reactivity): cleanup unsubscribed computed deps and release stale ref oldValue

### DIFF
--- a/packages/reactivity/__tests__/gc.spec.ts
+++ b/packages/reactivity/__tests__/gc.spec.ts
@@ -20,7 +20,7 @@ describe.skipIf(!global.gc)('reactivity/gc', () => {
   }
 
   // #9233
-  it.todo('should release computed cache', async () => {
+  it('should release computed cache', async () => {
     const src = ref<{} | undefined>({})
     // @ts-expect-error ES2021 API
     const srcRef = new WeakRef(src.value!)
@@ -35,7 +35,7 @@ describe.skipIf(!global.gc)('reactivity/gc', () => {
     expect(srcRef.deref()).toBeUndefined()
   })
 
-  it.todo('should release reactive property dep', async () => {
+  it('should release reactive property dep', async () => {
     const src = reactive({ foo: 1 })
 
     let c: ComputedRef | undefined = computed(() => src.foo)

--- a/packages/reactivity/src/ref.ts
+++ b/packages/reactivity/src/ref.ts
@@ -202,6 +202,11 @@ class RefImpl<T = any> implements ReactiveNode {
     this.flags &= ~_ReactiveFlags.Dirty
     return hasChanged(this._oldValue, (this._oldValue = this._rawValue))
   }
+
+  // Release stale old-value references when nothing depends on this ref.
+  cleanup(): void {
+    this._oldValue = this._rawValue
+  }
 }
 
 /**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic garbage collection for computed properties and refs—unused computed values and reactive references now properly clean up memory when they have no active subscribers.

* **Tests**
  * Enabled garbage collection verification tests to ensure computed properties and refs properly release memory when unsubscribed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->