### PR TITLE
fix(runtime-vapor): guard attrs proxy traps for symbol keys

### DIFF
--- a/packages/runtime-core/src/componentEmits.ts
+++ b/packages/runtime-core/src/componentEmits.ts
@@ -333,7 +333,7 @@ export function isEmitListener(
   options: ObjectEmitsOptions | null,
   key: string,
 ): boolean {
-  if (!options || !isString(key) || !isOn(key)) {
+  if (!options || !isOn(key)) {
     return false
   }
 

--- a/packages/runtime-vapor/src/componentProps.ts
+++ b/packages/runtime-vapor/src/componentProps.ts
@@ -1,7 +1,6 @@
 import {
   EMPTY_ARR,
   NO,
-  YES,
   camelize,
   hasOwn,
   isArray,
@@ -98,9 +97,12 @@ export function getPropsProxyHandlers(
       : NO
   ) as (key: string | symbol) => key is string
   const isAttr = propsOptions
-    ? (key: string) =>
-        key !== '$' && !isProp(key) && !isEmitListener(emitsOptions, key)
-    : YES
+    ? (key: string | symbol) =>
+        isString(key) &&
+        key !== '$' &&
+        !isProp(key) &&
+        !isEmitListener(emitsOptions, key)
+    : (key: string | symbol) => isString(key)
 
   const getProp = (instance: VaporComponentInstance, key: string | symbol) => {
     // this enables direct watching of props and prevents `Invalid watch source` DEV warnings.
@@ -200,13 +202,13 @@ export function getPropsProxyHandlers(
     })
   }
 
-  const getAttr = (target: RawProps, key: string) => {
-    if (!isProp(key) && !isEmitListener(emitsOptions, key)) {
+  const getAttr = (target: RawProps, key: string | symbol) => {
+    if (isString(key) && !isProp(key) && !isEmitListener(emitsOptions, key)) {
       return getAttrFromRawProps(target, key)
     }
   }
 
-  const hasAttr = (target: RawProps, key: string) => {
+  const hasAttr = (target: RawProps, key: string | symbol) => {
     if (isAttr(key)) {
       return hasAttrFromRawProps(target, key)
     } else {
@@ -215,15 +217,15 @@ export function getPropsProxyHandlers(
   }
 
   const getOnceAttr = withOnceCache((instance, key) =>
-    getAttr(instance.rawProps, key as string),
+    getAttr(instance.rawProps, key),
   )
   const attrsHandlers = {
-    get: (target, key: string) =>
+    get: (target, key: string | symbol) =>
       once ? getOnceAttr(target, key) : getAttr(target.rawProps, key),
-    has: (target, key: string) => hasAttr(target.rawProps, key),
+    has: (target, key: string | symbol) => hasAttr(target.rawProps, key),
     ownKeys: target => getKeysFromRawProps(target.rawProps).filter(isAttr),
-    getOwnPropertyDescriptor(target, key: string) {
-      if (hasAttr(target.rawProps, key)) {
+    getOwnPropertyDescriptor(target, key: string | symbol) {
+      if (isString(key) && hasAttr(target.rawProps, key)) {
         return {
           configurable: true,
           enumerable: true,


### PR DESCRIPTION
### Problem Description
The Vapor component cannot display the "attrs" attribute on the page

### Version
v3.6.0-beta.5

### Steps to reproduce
Click repl with this PR
Console print: `key.charCodeAt is not a function`

### Link to minimal reproduction

[Playground](https://play.vuejs.org/#eNp9kcFOwzAMhl8lijgMaXRIAw5TQQK0AxxgAm4EodJ6I6NNotgtlaq+O067lh2mJZfY3x/nj93IW+eiqgS5kDGmXjsSCFQ6USXO+htlUmuQBBSaxLXIYK0NLDnAyfvH6UCdt26kKw5w0rRMw45nfVkuxQFB4fKEgCPBK850tTuG1TTiJCHyKNp2J5j1ini2d1NOJSG/vNabaIvWsPcmyJVMbeF0Dv7ZkWZnSi5ERwJL8tz+PnY58iVMh3z6DenPgfwW65BTcuUBwVeg5Mgo8RugHi9fn6Dm8wgLm5U5q4/AF0Cbl8FjL7srTca293Sd24eCZ0DabN5wWRMYHD4VjAZl2+mV5AHeH/n6v915dNHdU6blLn5W4ENNbuA8uorOz76AkuhStn9YDq9n)