### PR TITLE
types(jsx): change typescript error handling (fix #14450)

### DIFF
--- a/packages/vue/jsx-runtime/index.d.ts
+++ b/packages/vue/jsx-runtime/index.d.ts
@@ -17,7 +17,7 @@ export namespace JSX {
   }
   export interface IntrinsicElements extends NativeElements {
     // allow arbitrary elements
-    // @ts-expect-error suppress ts:2374 = Duplicate string index signature.
+    // @ts-ignore suppress ts:2374 = Duplicate string index signature.
     [name: string]: any
   }
   export interface IntrinsicAttributes extends ReservedProps {}


### PR DESCRIPTION
Fixes #14450

It appears typescript 5.9.3 does not throw the expected error `ts:2374 `.  Instead of expecting it, use `ts-ignore` for forwards and backwards compatibility.