### PR TITLE
fix(runtime-dom): preserve nullish values for custom element properties

### DIFF
--- a/packages/runtime-dom/__tests__/patchProps.spec.ts
+++ b/packages/runtime-dom/__tests__/patchProps.spec.ts
@@ -65,13 +65,56 @@ describe('runtime-dom: props patching', () => {
     expect(el.value).toBe('foo')
     expect(el.setterCalled).toBe(1)
     patchProp(el, 'value', null, null)
-    expect(el.value).toBe('')
+    // #14209: custom elements should preserve nullish values as-is
+    expect(el.value).toBe(null)
     expect(el.setterCalled).toBe(2)
     expect(el.getAttribute('value')).toBe(null)
     const obj = {}
     patchProp(el, 'value', null, obj)
     expect(el.value).toBe(obj)
     expect(el.setterCalled).toBe(3)
+  })
+
+  // #14209
+  test('nullish value handling for custom element props', () => {
+    class TestElement extends HTMLElement {
+      myNumber = 1
+      myBool = true
+      myString = 'hello'
+    }
+    window.customElements.define('ce-nullish-test', TestElement)
+    const el = document.createElement('ce-nullish-test') as TestElement
+
+    // null: should preserve null, not coerce based on existing type
+    patchProp(el, '.myNumber', null, null)
+    expect(el.myNumber).toBe(null)
+    expect(el.getAttribute('myNumber')).toBe(null)
+
+    patchProp(el, '.myBool', null, null)
+    expect(el.myBool).toBe(null)
+
+    patchProp(el, '.myString', null, null)
+    expect(el.myString).toBe(null)
+
+    // undefined: should preserve undefined, not coerce based on existing type
+    el.myNumber = 1
+    el.myBool = true
+    el.myString = 'hello'
+
+    patchProp(el, '.myNumber', null, undefined)
+    expect(el.myNumber).toBe(undefined)
+    expect(el.getAttribute('myNumber')).toBe(null)
+
+    patchProp(el, '.myBool', null, undefined)
+    expect(el.myBool).toBe(undefined)
+
+    patchProp(el, '.myString', null, undefined)
+    expect(el.myString).toBe(undefined)
+
+    // '': should preserve empty string, not coerce to true for boolean
+    el.myBool = true
+    patchProp(el, '.myBool', null, '')
+    expect(el.myBool).toBe('')
   })
 
   // For <input type="text">, setting el.value won't create a `value` attribute

--- a/packages/runtime-dom/src/modules/props.ts
+++ b/packages/runtime-dom/src/modules/props.ts
@@ -56,18 +56,25 @@ export function patchDOMProp(
 
   let needRemove = false
   if (value === '' || value == null) {
-    const type = typeof el[key]
-    if (type === 'boolean') {
-      // e.g. <select multiple> compiles to { multiple: '' }
-      value = includeBooleanAttr(value)
-    } else if (value == null && type === 'string') {
-      // e.g. <div :id="null">
-      value = ''
-      needRemove = true
-    } else if (type === 'number') {
-      // e.g. <img :width="null">
-      value = 0
-      needRemove = true
+    if (tag.includes('-')) {
+      // #14209 custom element properties may accept multiple types
+      // so we avoid coercing the value based on the existing property type
+      // and preserve the value as-is
+      needRemove = value == null
+    } else {
+      const type = typeof el[key]
+      if (type === 'boolean') {
+        // e.g. <select multiple> compiles to { multiple: '' }
+        value = includeBooleanAttr(value)
+      } else if (value == null && type === 'string') {
+        // e.g. <div :id="null">
+        value = ''
+        needRemove = true
+      } else if (type === 'number') {
+        // e.g. <img :width="null">
+        value = 0
+        needRemove = true
+      }
     }
   } else {
     if (


### PR DESCRIPTION
## Summary

Fixes #14209

Custom element properties may accept multiple types, so when a nullish value (`null`/`undefined`) or empty string is passed, Vue should not coerce it based on the existing property type.

Previously in `patchDOMProp`, the nullish/empty value coercion logic (lines 58-71) would check `typeof el[key]` and coerce accordingly — even for custom elements:
- `null` → `0` for number properties
- `null` → `''` for string properties  
- `''` → `true` for boolean properties

This is correct for native HTML elements (which have fixed property types), but wrong for custom elements whose properties can intentionally accept `null`/`undefined` or change types.

The fix skips this type-based coercion for custom elements (`tag.includes('-')`) and preserves the value as-is, while still removing the attribute when the value is nullish.

## Test plan

- [x] Updated existing "value for custom elements" test to expect `null` instead of coerced `''`
- [x] Added new test covering all three coercion cases: number, boolean, and string props on custom elements
- [x] All 220 runtime-dom tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Custom elements now preserve null and other nullish property values as-is instead of coercing them to default primitives; standard HTML elements retain prior coercion behavior.

* **Tests**
  * Added tests confirming nullish handling and attribute reflection for custom element properties, including empty-string and null preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->