### PR TITLE
fix(runtime-vapor): preserve slot owner rendering context in resolveDynamicComponent

### DIFF
--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -688,3 +688,7 @@ export {
  * @internal
  */
 export { knownTemplateRefs, isTemplateRefKey } from './helpers/useTemplateRef'
+/**
+ * @internal
+ */
+export { setCurrentRenderingInstance } from './componentRenderContext'


### PR DESCRIPTION
close #14474

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved internal rendering context management for more reliable component instance handling and enhanced compatibility mode support.

* **Tests**
  * Added test coverage for slot resolution in dynamic components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->