### PR TITLE
fix(runtime-vapor): preserve slot-owner css vars for teleported slot content

### DIFF
--- a/packages/runtime-vapor/src/components/Teleport.ts
+++ b/packages/runtime-vapor/src/components/Teleport.ts
@@ -4,7 +4,6 @@ import {
   MoveType,
   type TeleportProps,
   type TeleportTargetElement,
-  currentInstance,
   isMismatchAllowed,
   isTeleportDeferred,
   isTeleportDisabled,
@@ -40,6 +39,7 @@ import {
   setCurrentHydrationNode,
 } from '../dom/hydration'
 import type { DefineVaporSetupFnComponent } from '../apiDefineComponent'
+import { getScopeOwner } from '../componentSlots'
 
 const VaporTeleportImpl = {
   name: 'VaporTeleport',
@@ -76,7 +76,7 @@ export class TeleportFragment extends VaporFragment {
     super([])
     this.rawProps = props
     this.rawSlots = slots
-    this.parentComponent = currentInstance
+    this.parentComponent = getScopeOwner()
     this.anchor = isHydrating
       ? undefined
       : __DEV__

--- a/packages/runtime-vapor/src/helpers/useCssVars.ts
+++ b/packages/runtime-vapor/src/helpers/useCssVars.ts
@@ -7,6 +7,7 @@ import {
 import { type VaporComponentInstance, isVaporComponent } from '../component'
 import { isArray } from '@vue/shared'
 import type { Block } from '../block'
+import { isTeleportFragment } from '../components/Teleport'
 
 export function useVaporCssVars(getter: () => Record<string, string>): void {
   if (!__BROWSER__ && !__TEST__) return
@@ -50,6 +51,10 @@ function setVarsOnBlock(block: Block, vars: Record<string, string>): void {
     block.forEach(child => setVarsOnBlock(child, vars))
   } else if (isVaporComponent(block)) {
     setVarsOnBlock(block.block!, vars)
+  } else if (isTeleportFragment(block)) {
+    // Teleport children are handled via data-v-owner + ut() to preserve
+    // lexical owner semantics for slot content.
+    return
   } else {
     setVarsOnBlock(block.nodes, vars)
   }


### PR DESCRIPTION
close #14473

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scope owner detection for teleported components, ensuring proper context preservation for slot content.
  * Enhanced CSS variable handling and propagation when using teleport fragments.

* **Tests**
  * Added comprehensive tests for CSS variable behavior across conditional branches combining teleports with slot components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->