### PR TITLE
fix(runtime-vapor): allow renderEffect to self re-queue on sync state mutation

### DIFF
--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -538,7 +538,7 @@ export { baseEmit, isEmitListener } from './componentEmits'
 /**
  * @internal
  */
-export { queueJob, flushOnAppMount } from './scheduler'
+export { queueJob, flushOnAppMount, SchedulerJobFlags } from './scheduler'
 /**
  * @internal
  */

--- a/packages/runtime-vapor/__tests__/componentEmits.spec.ts
+++ b/packages/runtime-vapor/__tests__/componentEmits.spec.ts
@@ -7,9 +7,15 @@ import {
   isEmitListener,
   nextTick,
   onBeforeUnmount,
+  ref,
   toHandlers,
 } from '@vue/runtime-dom'
-import { createComponent, defineVaporComponent } from '../src'
+import {
+  createComponent,
+  createIf,
+  defineVaporComponent,
+  template,
+} from '../src'
 import { makeRender } from './_utils'
 
 const define = makeRender()
@@ -443,5 +449,40 @@ describe('component: emit', () => {
     render(props as any)
 
     expect(handler).toHaveBeenCalledTimes(1)
+  })
+
+  test('should re-queue when child emit mutates parent state during update', async () => {
+    const show = ref(false)
+    const calls: string[] = []
+
+    const { component: Child } = define({
+      emits: ['change'],
+      setup(_: any, { emit }: any) {
+        emit('change')
+        return template('<p>child</p>')()
+      },
+    })
+
+    const { host } = define({
+      setup() {
+        const onChange = () => {
+          calls.push(`change:${show.value}`)
+          show.value = false
+        }
+        return createIf(
+          () => show.value,
+          () =>
+            createComponent(Child, {
+              onChange: () => onChange,
+            }),
+        )
+      },
+    }).render()
+
+    show.value = true
+    await nextTick()
+
+    expect(calls).toEqual(['change:true'])
+    expect(host.innerHTML).toBe('<!--if-->')
   })
 })

--- a/packages/runtime-vapor/src/renderEffect.ts
+++ b/packages/runtime-vapor/src/renderEffect.ts
@@ -1,6 +1,7 @@
 import { EffectFlags, type EffectScope, ReactiveEffect } from '@vue/reactivity'
 import {
   type SchedulerJob,
+  SchedulerJobFlags,
   currentInstance,
   queueJob,
   queuePostFlushCb,
@@ -53,6 +54,12 @@ export class RenderEffect extends ReactiveEffect {
 
     this.job = job
     this.i = instance
+
+    // Allow self re-queue when render/hook logic mutates reactive state.
+    // Safe in Vapor because updates are always async via queueJob(), and
+    // isUpdating prevents duplicate bu/u hooks on re-entry.
+    this.flags |= EffectFlags.ALLOW_RECURSE
+    this.job.flags! |= SchedulerJobFlags.ALLOW_RECURSE
   }
 
   fn(): void {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Render effects now support self-re-queueing when reactive state changes occur during their execution, ensuring proper state synchronization.
  * SchedulerJobFlags now available in the public API for advanced scheduler control.

* **Tests**
  * Added test coverage for render effect re-queueing behavior, including scenarios with state mutations during effect execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->