### PR TITLE
fix(runtime-vapor): enable hydration capability for createSSRApp + vdomInterop

### DIFF
--- a/packages/runtime-vapor/src/dom/hydration.ts
+++ b/packages/runtime-vapor/src/dom/hydration.ts
@@ -1,4 +1,9 @@
-import { MismatchTypes, isMismatchAllowed, warn } from '@vue/runtime-dom'
+import {
+  MismatchTypes,
+  isMismatchAllowed,
+  isHydrating as isVdomHydrating,
+  warn,
+} from '@vue/runtime-dom'
 import {
   insertionIndex,
   insertionParent,
@@ -27,7 +32,7 @@ export let currentHydrationNode: Node | null = null
 
 export let isHydrating = false
 function setIsHydrating(value: boolean) {
-  if (!isHydratingEnabled) return false
+  if (!isHydratingEnabled && !isVdomHydrating) return false
   try {
     return isHydrating
   } finally {
@@ -41,17 +46,6 @@ export function runWithoutHydration(fn: () => any): any {
     return fn()
   } finally {
     setIsHydrating(prev)
-  }
-}
-
-export function runWithHydration(fn: () => any): any {
-  // temporarily enable hydration capability for createSSRApp + vdomInterop
-  const prev = isHydratingEnabled
-  setIsHydratingEnabled(true)
-  try {
-    return fn()
-  } finally {
-    setIsHydratingEnabled(prev)
   }
 }
 

--- a/packages/runtime-vapor/src/vdomInterop.ts
+++ b/packages/runtime-vapor/src/vdomInterop.ts
@@ -81,7 +81,6 @@ import {
   isComment,
   isHydrating,
   locateHydrationNode,
-  runWithHydration,
   setCurrentHydrationNode,
   hydrateNode as vaporHydrateNode,
 } from './dom/hydration'
@@ -307,11 +306,9 @@ const vaporInteropImpl: Omit<
     // In CSR (createApp/createVaporApp + vaporInteropPlugin), both are false,
     // so this logic is tree-shaken.
     if (!isHydrating && !isVdomHydrating) return node
-    runWithHydration(() => {
-      vaporHydrateNode(node, () =>
-        this.mount(vnode, container, anchor, parentComponent, parentSuspense),
-      )
-    })
+    vaporHydrateNode(node, () =>
+      this.mount(vnode, container, anchor, parentComponent, parentSuspense),
+    )
     return _next(node)
   },
 
@@ -319,17 +316,15 @@ const vaporInteropImpl: Omit<
     if (!isHydrating && !isVdomHydrating) return node
     const { slot } = vnode.vs!
     const propsRef = (vnode.vs!.ref = shallowRef(vnode.props))
-    runWithHydration(() => {
-      vaporHydrateNode(node, () => {
-        vnode.vb = slot(new Proxy(propsRef, vaporSlotPropsProxyHandler))
-        vnode.anchor = vnode.el = currentHydrationNode!
+    vaporHydrateNode(node, () => {
+      vnode.vb = slot(new Proxy(propsRef, vaporSlotPropsProxyHandler))
+      vnode.anchor = vnode.el = currentHydrationNode!
 
-        if (__DEV__ && !vnode.anchor) {
-          throw new Error(
-            `Failed to locate slot anchor. this is likely a Vue internal bug.`,
-          )
-        }
-      })
+      if (__DEV__ && !vnode.anchor) {
+        throw new Error(
+          `Failed to locate slot anchor. this is likely a Vue internal bug.`,
+        )
+      }
     })
     return vnode.anchor as Node
   },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a critical issue where nested components would be incorrectly duplicated during the hydration process when combining VDOM and Vapor components in the same application.

* **Tests**
  * Added new tests to validate that nested components hydrate correctly without unwanted duplication and do not emit hydration mismatch warnings when using VDOM and Vapor interoperability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->