### PR TITLE
fix(reactivity): avoid duplicate raw/proxy entries in Set.add

### DIFF
--- a/packages/reactivity/__tests__/collections/Set.spec.ts
+++ b/packages/reactivity/__tests__/collections/Set.spec.ts
@@ -1,4 +1,11 @@
-import { effect, isReactive, reactive, toRaw } from '../../src'
+import {
+  effect,
+  isReactive,
+  reactive,
+  readonly,
+  shallowReactive,
+  toRaw,
+} from '../../src'
 
 describe('reactivity/collections', () => {
   function coverCollectionFn(collection: Set<any>, fnName: string) {
@@ -401,6 +408,34 @@ describe('reactivity/collections', () => {
 
       set.delete(entry)
       expect(dummy).toBe(false)
+    })
+
+    it('should not add readonly versions of existing raw values', () => {
+      const rawValue = {}
+      const wrappedValue = readonly(rawValue)
+      const set = reactive(new Set([rawValue]))
+
+      expect(set.has(wrappedValue)).toBe(true)
+
+      set.add(wrappedValue)
+
+      expect(set.size).toBe(1)
+      expect(toRaw(set).has(rawValue)).toBe(true)
+      expect(toRaw(set).has(wrappedValue)).toBe(false)
+    })
+
+    it('should not add proxy versions of existing raw values to shallow sets', () => {
+      const rawValue = {}
+      const wrappedValue = reactive(rawValue)
+      const set = shallowReactive(new Set([rawValue]))
+
+      expect(set.has(wrappedValue)).toBe(true)
+
+      set.add(wrappedValue)
+
+      expect(set.size).toBe(1)
+      expect(toRaw(set).has(rawValue)).toBe(true)
+      expect(toRaw(set).has(wrappedValue)).toBe(false)
     })
 
     it('should warn when set contains both raw and reactive versions of the same object', () => {

--- a/packages/reactivity/src/collectionHandlers.ts
+++ b/packages/reactivity/src/collectionHandlers.ts
@@ -169,13 +169,17 @@ function createInstrumentations(
           add(this: SetTypes, value: unknown) {
             const target = toRaw(this)
             const proto = getProto(target)
+            const rawValue = toRaw(value)
             const valueToAdd =
               !shallow && !isShallow(value) && !isReadonly(value)
-                ? toRaw(value)
+                ? rawValue
                 : value
             const hadKey =
               proto.has.call(target, valueToAdd) ||
-              (value !== valueToAdd && proto.has.call(target, value))
+              (hasChanged(value, valueToAdd) &&
+                proto.has.call(target, value)) ||
+              (hasChanged(rawValue, valueToAdd) &&
+                proto.has.call(target, rawValue))
             if (!hadKey) {
               target.add(valueToAdd)
               trigger(target, TriggerOpTypes.ADD, valueToAdd, valueToAdd)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added comprehensive tests for Set behavior when working with readonly and shallow reactive values, ensuring duplicate prevention and accurate raw value tracking.

* **Bug Fixes**
  * Improved Set and WeakSet value addition logic to properly handle raw values and prevent duplicates when mixing reactive and readonly wrappers with set operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->