### PR TITLE
fix(runtime-core): preserve nullish event handlers in mergeProps

### DIFF
--- a/packages/runtime-core/__tests__/vnode.spec.ts
+++ b/packages/runtime-core/__tests__/vnode.spec.ts
@@ -472,6 +472,8 @@ describe('vnode', () => {
       expect(mergeProps(props1, props3)).toMatchObject({
         onClick: clickHandler1,
       })
+      const props4: Data = { onClick: undefined }
+      expect(mergeProps(props4)).toHaveProperty('onClick', undefined)
       expect(mergeProps({ onClick: null })).toMatchObject({
         onClick: null,
       })

--- a/packages/runtime-core/src/vnode.ts
+++ b/packages/runtime-core/src/vnode.ts
@@ -891,7 +891,7 @@ export function mergeProps(...args: (Data & VNodeProps)[]): Data {
           ret[key] = existing
             ? [].concat(existing as any, incoming as any)
             : incoming
-        } else if (!incoming && !existing) {
+        } else if (incoming == null && existing == null) {
           ret[key] = incoming
         }
       } else if (key !== '') {


### PR DESCRIPTION
Ensure event listeners that are explicitly null or undefined are preserved during prop merging instead of being dropped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prop and event handler merging now preserves explicitly set null values instead of omitting them, preventing unexpected removal of null-assigned handlers or props.

* **Tests**
  * Added test coverage validating null value handling in prop/event merging scenarios to ensure consistent behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->