### PR TITLE
fix(compiler-sfc): scoped style with state pseudo in compound selectors

### DIFF
--- a/packages/compiler-sfc/__tests__/compileStyle.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileStyle.spec.ts
@@ -109,6 +109,18 @@ color: red
     )
   })
 
+  // #13746 - state pseudo in compound selectors should have scoped attribute before it
+  test('state pseudo in compound selectors', () => {
+    // .root:hover .a -> .root[data-v-test]:hover .a[data-v-test]
+    expect(compileScoped(`.root:hover .a { color: red; }`)).toMatch(
+      `.root[data-v-test]:hover .a[data-v-test] { color: red;`,
+    )
+    // .root:focus .a -> .root[data-v-test]:focus .a[data-v-test]
+    expect(compileScoped(`.root:focus .a { color: red; }`)).toMatch(
+      `.root[data-v-test]:focus .a[data-v-test] { color: red;`,
+    )
+  })
+
   test('pseudo element', () => {
     expect(compileScoped(`::selection { display: none; }`)).toMatch(
       '[data-v-test]::selection {',

--- a/packages/compiler-sfc/src/style/pluginScoped.ts
+++ b/packages/compiler-sfc/src/style/pluginScoped.ts
@@ -12,6 +12,11 @@ const animationNameRE = /^(?:-\w+-)?animation-name$/
 const animationRE = /^(?:-\w+-)?animation$/
 const keyframesRE = /^(?:-\w+-)?keyframes$/
 
+// State pseudo-classes that need scoped attribute before them
+// e.g., .root:hover -> .root[data-v-xxx]:hover
+const statePseudoRE =
+  /^(?::(?:hover|active|focus|focus-within|visited|link|target|enabled|disabled|checked|unchecked|valid|invalid|required|optional|read-only|read-write|first-child|last-child|first-of-type|last-of-type|only-child|only-of-type|nth-child|nth-last-child|nth-of-type|nth-last-of-type|empty|blank|placeholder-shown|default|indeterminate))$/
+
 const scopedPlugin: PluginCreator<string> = (id = '') => {
   const keyframes = Object.create(null)
   const shortId = id.replace(/^data-v-/, '')
@@ -101,8 +106,29 @@ function rewriteSelector(
 ) {
   let node: selectorParser.Node | null = null
   let shouldInject = !deep
+  let prevNode: selectorParser.Node | null = null
   // find the last child node to insert attribute selector
   selector.each(n => {
+    // Handle combinator - inject scoped attribute before state pseudo classes
+    // e.g., .root:hover .a -> .root[data-v-xxx]:hover .a[data-v-xxx]
+    if (n.type === 'combinator' && prevNode && prevNode.type === 'pseudo') {
+      const pseudoValue = (prevNode as selectorParser.Pseudo).value
+      // Check if it's a state pseudo that needs attribute before it
+      if (statePseudoRE.test(pseudoValue)) {
+        const idToAdd = slotted ? id + '-s' : id
+        selector.insertBefore(
+          prevNode,
+          selectorParser.attribute({
+            attribute: idToAdd,
+            value: idToAdd,
+            raws: {},
+            quoteMark: `"`,
+          }),
+        )
+      }
+    }
+
+    prevNode = n
     // DEPRECATED ">>>" and "/deep/" combinator
     if (
       n.type === 'combinator' &&


### PR DESCRIPTION
## Summary

fix #13746

When using scoped styles with state pseudo classes in compound selectors (e.g., `.root:hover .a`), the scoped attribute was incorrectly injected after the pseudo class instead of before it.

**Before (incorrect):**
```
.root:hover .a[data-v-xxx] { color: red; }
```

**After (correct):**
```
.root[data-v-xxx]:hover .a[data-v-xxx] { color: red; }
```

This caused the scoped style to leak to external components when they had matching class names. For example, if an external component has `.root` and `:hover` classes, the style would incorrectly apply to it.

## How did you test this change?

- Added test case for state pseudo in compound selectors
- All 3511 existing tests pass

## Notes

- The fix handles common state pseudo classes: `:hover`, `:focus`, `:active`, `:focus-within`, `:visited`, `:link`, `:target`, `:enabled`, `:disabled`, `:checked`, `:valid`, `:invalid`, `:required`, `:optional`, `:read-only`, `:read-write`, `:first-child`, `:last-child`, `:first-of-type`, `:last-of-type`, `:only-child`, `:only-of-type`, `:nth-child`, `:nth-last-child`, `:nth-of-type`, `:nth-last-of-type`, `:empty`, `:blank`, `:placeholder-shown`, `:default`, `:indeterminate`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed scoped style attribute placement for state pseudo-classes (`:hover`, `:focus`) in compound selectors. The scoped attribute now correctly precedes the pseudo-class in compiled CSS output.

* **Tests**
  * Added test coverage for state pseudo-classes in compound selector combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->