### PR TITLE
fix(compiler-vapor): fix circular reference in repeated call expression cache

### DIFF
--- a/packages/compiler-vapor/__tests__/transforms/__snapshots__/expression.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/transforms/__snapshots__/expression.spec.ts.snap
@@ -217,6 +217,35 @@ export function render(_ctx) {
 }"
 `;
 
+exports[`compiler: expression > cache expressions > repeated simple function calls 1`] = `
+"import { setProp as _setProp, renderEffect as _renderEffect, template as _template } from 'vue';
+const t0 = _template("<div>")
+
+export function render(_ctx) {
+  const n0 = t0()
+  const n1 = t0()
+  _renderEffect(() => {
+    const _foo = _ctx.foo()
+    _setProp(n0, "id", _foo)
+    _setProp(n1, "id", _foo)
+  })
+  return [n0, n1]
+}"
+`;
+
+exports[`compiler: expression > cache expressions > repeated simple function calls with setup-const binding 1`] = `
+"
+  const n0 = t0()
+  const n1 = t0()
+  _renderEffect(() => {
+    const _foo = foo()
+    _setProp(n0, "id", _foo)
+    _setProp(n1, "id", _foo)
+  })
+  return [n0, n1]
+"
+`;
+
 exports[`compiler: expression > cache expressions > repeated variable in expressions 1`] = `
 "import { setProp as _setProp, renderEffect as _renderEffect, template as _template } from 'vue';
 const t0 = _template("<div>")

--- a/packages/compiler-vapor/__tests__/transforms/expression.spec.ts
+++ b/packages/compiler-vapor/__tests__/transforms/expression.spec.ts
@@ -115,6 +115,27 @@ describe('compiler: expression', () => {
       expect(code).contains('_setProp(n2, "id", _foo + _foo_bar)')
     })
 
+    test('repeated simple function calls', () => {
+      const { code } = compileWithExpression(`
+        <div :id="foo()"></div>
+        <div :id="foo()"></div>
+      `)
+      expect(code).matchSnapshot()
+      expect(code).contains('const _foo = _ctx.foo()')
+    })
+
+    test('repeated simple function calls with setup-const binding', () => {
+      const { code } = compileWithExpression(
+        `
+        <div :id="foo()"></div>
+        <div :id="foo()"></div>
+      `,
+        { bindingMetadata: { foo: BindingTypes.SETUP_CONST }, inline: true },
+      )
+      expect(code).matchSnapshot()
+      expect(code).contains('const _foo = foo()')
+    })
+
     test('function calls with arguments', () => {
       const { code } = compileWithExpression(`
         <div :id="foo[bar(baz)]"></div>

--- a/packages/compiler-vapor/src/generators/expression.ts
+++ b/packages/compiler-vapor/src/generators/expression.ts
@@ -638,7 +638,7 @@ function genDeclarations(
   // process expressions
   declarations.forEach(({ name, isIdentifier, value }) => {
     if (!isIdentifier) {
-      const varName = (ids[name] = `_${name}`)
+      const varName = `_${name}`
       varNames.add(varName)
       if (shouldDeclare) {
         push(`const `)
@@ -648,6 +648,7 @@ function genDeclarations(
         ...context.withId(() => genExpression(value, context), ids),
         NEWLINE,
       )
+      ids[name] = varName
     }
   })
 


### PR DESCRIPTION

When the same function call (e.g. `msg()`) appears more than once in a template, it is not handled correctly.

repro
https://play.vuejs.org/#eNp9kU9Lw0AQxb/KMieFulEqCiUUVHrQg4p6XJC4nSapm91l/8RAyHd3NrG1B+1t5703y29merixlrcRYQG5l662gXkM0bK2sMYthd5ELUNtNGt8eXLKeqEZc5RwmgmoUCkjQOhB6Dyb+qmHioCNVUVAqhjLq4tl3//8MAx5RvX/ep4dNMMMgpdGb+qSb73RxDkiCJCmsbVC92QTnhewmOCSVxDW18OoBRdxttNlhfLzD33ru6QJeHbo0bUoYO+FwpUYJnv1+ogdvfdmY9ZRUfqI+YLeqJgYp9ht1GvCPsiNtPcN7TvUunzzqy6g9ruhEmhKDmNeAB3r7sjov7hzfjn20XVoi+8tuvQnLXDOr/j52QeGgl/D8A3es6h0

fixed
https://deploy-preview-14567--vue-sfc-playground.netlify.app/#eNp9kTtPwzAQx7+KdRNIVSIEUxVVAtQBBkDA6CVyr0mKc7b8CJGifHfOCX0MbTff/2H97Bvg0dqsiwhLKLxyjQ3CY4hWdKU1biVpG0mFxpBofXVzKwZJQjhOOBISatTaSJA0Siryuc8dHgK2VpcBeRKiqO9Ww/B/wzgWOc+X9SI/KcMCgleGtk2V7bwh5pwQJCjT2kaje7cJz0tYznDJKxnr93XSgou42OuqRvVzRt/5PmkSPhx6dB1KOHihdBWG2V5/vWHP54PZmk3UnL5ifqI3OibGOfYUacPYJ7mJ9qXl/w4NVd9+3Qckv39UAk3JccpL4GU9X3n6Efc+e5h6vB0Y/wAet6D+