### PR TITLE
fix(compiler-vapor): avoid delegating same-event handlers when sibling uses `stop` modifiers

### DIFF
--- a/packages/compiler-vapor/__tests__/transforms/__snapshots__/vOn.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/transforms/__snapshots__/vOn.spec.ts.snap
@@ -300,14 +300,25 @@ export function render(_ctx) {
 `;
 
 exports[`v-on > should not delegate .stop when have multiple events of same name 1`] = `
-"import { createInvoker as _createInvoker, withModifiers as _withModifiers, on as _on, delegateEvents as _delegateEvents, template as _template } from 'vue';
+"import { createInvoker as _createInvoker, on as _on, withModifiers as _withModifiers, template as _template } from 'vue';
 const t0 = _template("<div>", true)
-_delegateEvents("click")
 
 export function render(_ctx) {
   const n0 = t0()
-  n0.$evtclick = _createInvoker(e => _ctx.test(e))
+  _on(n0, "click", _createInvoker(e => _ctx.test(e)))
   _on(n0, "click", _createInvoker(_withModifiers(e => _ctx.test(e), ["stop"])))
+  return n0
+}"
+`;
+
+exports[`v-on > should not delegate normalized static event when sibling uses .stop 1`] = `
+"import { createInvoker as _createInvoker, withModifiers as _withModifiers, on as _on, template as _template } from 'vue';
+const t0 = _template("<div>", true)
+
+export function render(_ctx) {
+  const n0 = t0()
+  _on(n0, "contextmenu", _createInvoker(_withModifiers(e => _ctx.test(e), ["right"])))
+  _on(n0, "contextmenu", _createInvoker(_withModifiers(e => _ctx.test(e), ["stop"])))
   return n0
 }"
 `;

--- a/packages/compiler-vapor/__tests__/transforms/vOn.spec.ts
+++ b/packages/compiler-vapor/__tests__/transforms/vOn.spec.ts
@@ -694,10 +694,27 @@ describe('v-on', () => {
       `<div @click="test" @click.stop="test" />`,
     )
     expect(helpers).not.contains('delegate')
+    expect(helpers).not.contains('delegateEvents')
     expect(code).toMatchSnapshot()
-    expect(code).contains('n0.$evtclick = _createInvoker(e => _ctx.test(e))')
+    expect(code).contains('_on(n0, "click", _createInvoker(e => _ctx.test(e)))')
     expect(code).contains(
       '_on(n0, "click", _createInvoker(_withModifiers(e => _ctx.test(e), ["stop"])))',
+    )
+  })
+
+  test('should not delegate normalized static event when sibling uses .stop', () => {
+    const { code, helpers } = compileWithVOn(
+      `<div @click.right="test" @contextmenu.stop="test" />`,
+    )
+
+    expect(helpers).not.contains('delegate')
+    expect(helpers).not.contains('delegateEvents')
+    expect(code).toMatchSnapshot()
+    expect(code).contains(
+      '_on(n0, "contextmenu", _createInvoker(_withModifiers(e => _ctx.test(e), ["right"])))',
+    )
+    expect(code).contains(
+      '_on(n0, "contextmenu", _createInvoker(_withModifiers(e => _ctx.test(e), ["stop"])))',
     )
   })
 

--- a/packages/compiler-vapor/src/transforms/vOn.ts
+++ b/packages/compiler-vapor/src/transforms/vOn.ts
@@ -1,13 +1,16 @@
 import {
+  type ElementNode,
   ElementTypes,
   ErrorCodes,
+  NodeTypes,
+  type SimpleExpressionNode,
   createCompilerError,
   isKeyboardEvent,
   isStaticExp,
+  resolveModifiers,
 } from '@vue/compiler-dom'
 import type { DirectiveTransform } from '../transform'
 import { IRNodeTypes, type KeyOverride, type SetEventIRNode } from '../ir'
-import { resolveModifiers } from '@vue/compiler-dom'
 import { extend, makeMap } from '@vue/shared'
 import { resolveExpression } from '../utils'
 import { EMPTY_EXPRESSION } from './utils'
@@ -47,19 +50,16 @@ export const transformVOn: DirectiveTransform = (dir, node, context) => {
     if (keyOverride) {
       // TODO error here
     }
-    if (isStaticClick) {
-      arg = extend({}, arg, { content: 'mouseup' })
-    } else if (!arg.isStatic) {
+    if (!isStaticClick && !arg.isStatic) {
       keyOverride = ['click', 'mouseup']
     }
   }
   if (nonKeyModifiers.includes('right')) {
-    if (isStaticClick) {
-      arg = extend({}, arg, { content: 'contextmenu' })
-    } else if (!arg.isStatic) {
+    if (!isStaticClick && !arg.isStatic) {
       keyOverride = ['click', 'contextmenu']
     }
   }
+  arg = normalizeStaticEventArg(arg, nonKeyModifiers)
 
   // don't gen keys guard for non-keyboard events
   // if event name is dynamic, always wrap with keys guard
@@ -88,12 +88,12 @@ export const transformVOn: DirectiveTransform = (dir, node, context) => {
   // Only delegate if:
   // - no dynamic event name
   // - no event option modifiers (passive, capture, once)
-  // - no propagation modifiers that depend on running before ancestor listeners
+  // - no handlers for the same static event on this element that use .stop
   // - is a delegatable event
   const delegate =
     arg.isStatic &&
     !eventOptionModifiers.length &&
-    !nonKeyModifiers.includes('stop') &&
+    !hasStopHandlerForStaticEvent(node, arg.content) &&
     delegatedEvents(arg.content)
 
   const operation: SetEventIRNode = {
@@ -112,4 +112,51 @@ export const transformVOn: DirectiveTransform = (dir, node, context) => {
   }
 
   context.registerEffect([arg], operation)
+}
+
+function normalizeStaticEventArg(
+  arg: SimpleExpressionNode,
+  nonKeyModifiers: string[],
+): SimpleExpressionNode {
+  if (!arg.isStatic) return arg
+
+  let normalized = arg
+  const isStaticClick = arg.content.toLowerCase() === 'click'
+
+  if (nonKeyModifiers.includes('middle') && isStaticClick) {
+    normalized = extend({}, normalized, { content: 'mouseup' })
+  }
+  if (nonKeyModifiers.includes('right') && isStaticClick) {
+    normalized = extend({}, normalized, { content: 'contextmenu' })
+  }
+
+  return normalized
+}
+
+function hasStopHandlerForStaticEvent(node: ElementNode, eventName: string) {
+  return node.props.some(prop => {
+    if (
+      prop.type !== NodeTypes.DIRECTIVE ||
+      prop.name !== 'on' ||
+      !prop.arg ||
+      prop.arg.type !== NodeTypes.SIMPLE_EXPRESSION
+    ) {
+      return false
+    }
+
+    const arg = resolveExpression(prop.arg)
+    if (!arg.isStatic) return false
+
+    const { nonKeyModifiers } = resolveModifiers(
+      `on${arg.content}`,
+      prop.modifiers,
+      null,
+      prop.loc,
+    )
+
+    return (
+      nonKeyModifiers.includes('stop') &&
+      normalizeStaticEventArg(arg, nonKeyModifiers).content === eventName
+    )
+  })
 }


### PR DESCRIPTION
close #14609

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved event delegation behavior for v-on handlers with multiple events and stop modifiers
  * Fixed event normalization for click modifiers (.right, .middle) to correctly map to underlying event types
  * Enhanced compilation of event handlers to prevent incorrect delegation in complex modifier combinations
<!-- end of auto-generated comment: release notes by coderabbit.ai -->