### PR TITLE
fix(compiler-vapor): normalize default dynamic slot names in transform

### DIFF
--- a/packages/compiler-vapor/__tests__/transforms/__snapshots__/vSlot.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/transforms/__snapshots__/vSlot.spec.ts.snap
@@ -1,5 +1,48 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`compiler: transform slot > default slot with v-for directive 1`] = `
+"import { resolveComponent as _resolveComponent, toDisplayString as _toDisplayString, setText as _setText, renderEffect as _renderEffect, createForSlots as _createForSlots, createComponentWithFallback as _createComponentWithFallback, template as _template } from 'vue';
+const t0 = _template(" ")
+
+export function render(_ctx) {
+  const _component_Comp = _resolveComponent("Comp")
+  const n2 = _createComponentWithFallback(_component_Comp, null, {
+    $: [
+      () => (_createForSlots(_ctx.list, (item) => ({
+        name: "default",
+        fn: () => {
+          const n0 = t0()
+          _renderEffect(() => _setText(n0, _toDisplayString(item)))
+          return n0
+        }
+      })))
+    ]
+  }, true)
+  return n2
+}"
+`;
+
+exports[`compiler: transform slot > default slot with v-if directive 1`] = `
+"import { resolveComponent as _resolveComponent, createComponentWithFallback as _createComponentWithFallback } from 'vue';
+
+export function render(_ctx) {
+  const _component_Comp = _resolveComponent("Comp")
+  const n1 = _createComponentWithFallback(_component_Comp, null, {
+    $: [
+      () => (_ctx.show
+        ? {
+          name: "default",
+          fn: () => {
+            return null
+          }
+        }
+        : void 0)
+    ]
+  }, true)
+  return n1
+}"
+`;
+
 exports[`compiler: transform slot > dynamic slots name 1`] = `
 "import { resolveComponent as _resolveComponent, createComponentWithFallback as _createComponentWithFallback, template as _template } from 'vue';
 const t0 = _template("foo")
@@ -200,27 +243,6 @@ export function render(_ctx) {
       const n0 = t0()
       return n0
     }
-  }, true)
-  return n1
-}"
-`;
-
-exports[`compiler: transform slot > named default slot with v-if directive 1`] = `
-"import { resolveComponent as _resolveComponent, createComponentWithFallback as _createComponentWithFallback } from 'vue';
-
-export function render(_ctx) {
-  const _component_Comp = _resolveComponent("Comp")
-  const n1 = _createComponentWithFallback(_component_Comp, null, {
-    $: [
-      () => (_ctx.show
-        ? {
-          name: "default",
-          fn: () => {
-            return null
-          }
-        }
-        : void 0)
-    ]
   }, true)
   return n1
 }"

--- a/packages/compiler-vapor/__tests__/transforms/vSlot.spec.ts
+++ b/packages/compiler-vapor/__tests__/transforms/vSlot.spec.ts
@@ -63,7 +63,7 @@ describe('compiler: transform slot', () => {
     })
   })
 
-  test('named default slot with v-if directive', () => {
+  test('default slot with v-if directive', () => {
     const { ir, code } = compileWithSlots(
       `<Comp><template # v-if="show"></template></Comp>`,
     )
@@ -84,7 +84,42 @@ describe('compiler: transform slot', () => {
     expect(ir.block.dynamic).toMatchObject({
       children: [{ id: 1 }],
     })
-    expect(code).contain(`name: "default",`)
+    expect(code).contains(`name: "default",`)
+  })
+
+  test('default slot with v-for directive', () => {
+    const { ir, code } = compileWithSlots(
+      `<Comp><template # v-for="item in list">{{ item }}</template></Comp>`,
+    )
+    expect(code).toMatchSnapshot()
+
+    expect(ir.block.dynamic.children[0].operation).toMatchObject({
+      type: IRNodeTypes.CREATE_COMPONENT_NODE,
+      id: 2,
+      tag: 'Comp',
+      props: [[]],
+      slots: [
+        {
+          slotType: IRSlotType.LOOP,
+          name: {
+            type: NodeTypes.SIMPLE_EXPRESSION,
+            content: 'default',
+            isStatic: true,
+          },
+          fn: { type: IRNodeTypes.BLOCK },
+          loop: {
+            source: { content: 'list' },
+            value: { content: 'item' },
+            index: undefined,
+          },
+        },
+      ],
+    })
+    expect(ir.block.returns).toEqual([2])
+    expect(ir.block.dynamic).toMatchObject({
+      children: [{ id: 2 }],
+    })
+    expect(code).contains(`name: "default",`)
   })
 
   test('on-component default slot', () => {

--- a/packages/compiler-vapor/src/generators/component.ts
+++ b/packages/compiler-vapor/src/generators/component.ts
@@ -498,7 +498,7 @@ function genBasicDynamicSlot(
   const { name, fn } = slot
   return genMulti(
     DELIMITERS_OBJECT_NEWLINE,
-    ['name: ', ...(name ? genExpression(name, context) : ['"default"'])],
+    ['name: ', ...genExpression(name, context)],
     ['fn: ', ...genSlotBlockWithProps(fn, context)],
   )
 }

--- a/packages/compiler-vapor/src/transforms/vSlot.ts
+++ b/packages/compiler-vapor/src/transforms/vSlot.ts
@@ -6,6 +6,7 @@ import {
   type SimpleExpressionNode,
   type TemplateChildNode,
   createCompilerError,
+  createSimpleExpression,
   isTemplateNode,
 } from '@vue/compiler-dom'
 import type { NodeTransform, TransformContext } from '../transform'
@@ -134,7 +135,9 @@ function transformTemplateSlot(
 ) {
   context.dynamic.flags |= DynamicFlag.NON_TEMPLATE
 
-  const arg = dir.arg && resolveExpression(dir.arg)
+  const resolvedArg = dir.arg && resolveExpression(dir.arg)
+  let arg = resolvedArg
+  if (!arg) arg = createSimpleExpression('default', true)
   const vFor = findDir(node, 'for')
   const vIf = findDir(node, 'if')
   const vElse = findDir(node, /^else(-if)?$/, true /* allowEmpty */)
@@ -142,7 +145,9 @@ function transformTemplateSlot(
   const [block, onExit] = createSlotBlock(node, dir, context)
 
   if (!vFor && !vIf && !vElse) {
-    const slotName = arg ? arg.isStatic && arg.content : 'default'
+    const slotName = resolvedArg
+      ? resolvedArg.isStatic && resolvedArg.content
+      : 'default'
     if (slotName && hasStaticSlot(slots, slotName)) {
       context.options.onError(
         createCompilerError(ErrorCodes.X_V_SLOT_DUPLICATE_SLOT_NAMES, dir.loc),


### PR DESCRIPTION
### Problem Description
Unable to correctly compile dynamic default named slots with v-if directives

Compilation failed. Console output: `Cannot destructure property 'content' of 'node' as it is undefined.`

### Vue Version
3.6.0-beta.8

### Link to minimal reproduction
[Playground](https://play.vuejs.org/#eNp9Ut1OwjAUfpVaL9BENxONMTqJP+FCL9Qol03MGGej0LVLezZICO/uaTcQjHDV9vs5/U5Pl/yxqqKmBn7LE5dZWSFzgHXFmrQyti+0LGlFtmQWcrZiuTUl65Ght6GeTVl1eBT7g6/XuxM6M9pRuYmZs3tvP8lT5eBU6CRur6LydEAoK5Ui0ImxZFQjGs0eMiWz2b3gnf3Ir4L3h6YoFCRxKwsFyORvDXbar8ux5lzmXQHB2XHHk2Ismz7CApPY7zpbvBsjNELbHZyfcXTUVS6LaOqMpkdberXgGamlAvteoaSuBb9lgfFcqpSZvwYMbQ1nazybQDb7B5+6hccE/7DgwDYg+IbD1BaALT34eqMmtsjSjGtF6gPkJzijap+xlT3Vekyxt3Qh7UuYrNTF0A0WCNqtm/JBvXIV9ILTpP1D7Wv9N+5ldBV8Qq/oFde/ZM+vO/Q/tkbmlEEWd/Nq8b/j+m7A+vB00WV0HV2cjwDT6IavfgATXPtD)



