### PR TITLE
fix(runtime-core): prevent merging model listener when value is null or undefined

### DIFF
--- a/packages/runtime-core/__tests__/vnode.spec.ts
+++ b/packages/runtime-core/__tests__/vnode.spec.ts
@@ -477,6 +477,12 @@ describe('vnode', () => {
       expect(mergeProps({ onClick: null })).toMatchObject({
         onClick: null,
       })
+      expect(
+        mergeProps({ 'onUpdate:modelValue': undefined }),
+      ).not.toHaveProperty('onUpdate:modelValue')
+      expect(mergeProps({ 'onUpdate:modelValue': null })).not.toHaveProperty(
+        'onUpdate:modelValue',
+      )
     })
 
     test('default', () => {

--- a/packages/runtime-core/src/vnode.ts
+++ b/packages/runtime-core/src/vnode.ts
@@ -6,6 +6,7 @@ import {
   extend,
   isArray,
   isFunction,
+  isModelListener,
   isObject,
   isOn,
   isString,
@@ -891,7 +892,13 @@ export function mergeProps(...args: (Data & VNodeProps)[]): Data {
           ret[key] = existing
             ? [].concat(existing as any, incoming as any)
             : incoming
-        } else if (incoming == null && existing == null) {
+        } else if (
+          incoming == null &&
+          existing == null &&
+          // mergeProps({ 'onUpdate:modelValue': undefined }) should not retain
+          // the model listener.
+          !isModelListener(key)
+        ) {
           ret[key] = incoming
         }
       } else if (key !== '') {


### PR DESCRIPTION
fix https://github.com/vuejs/ecosystem-ci/actions/runs/23529115737/job/68488818862

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed model listener property handling in prop merging: null or undefined model listener properties are now correctly omitted from the merged result instead of being preserved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->