### PR TITLE
chore: ignore entities updates in renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -56,6 +56,9 @@
     // ESM only
     'estree-walker',
 
+    // v8 is ESM-only and breaks compiler-core's CJS path
+    'entities',
+
     // pinned
     // https://github.com/vuejs/core/issues/10300#issuecomment-1940855364
     'lru-cache',


### PR DESCRIPTION
close #14615

entities v8 is ESM-only and breaks compiler-core's CJS path

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration to exclude the `entities` package from automated version updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->