### PR TITLE
fix(reactivity): allow async watchEffect callbacks

### DIFF
--- a/packages-private/dts-test/watch.test-d.ts
+++ b/packages-private/dts-test/watch.test-d.ts
@@ -9,6 +9,7 @@ import {
   ref,
   shallowRef,
   watch,
+  watchEffect,
 } from 'vue'
 import { expectType } from './utils'
 
@@ -211,3 +212,9 @@ defineComponent({
     expectType<string>(value)
   })
 }
+
+// #14249
+watchEffect(async onCleanup => {
+  onCleanup(() => {})
+})
+

--- a/packages/reactivity/src/watch.ts
+++ b/packages/reactivity/src/watch.ts
@@ -34,7 +34,7 @@ export enum WatchErrorCodes {
   WATCH_CLEANUP,
 }
 
-export type WatchEffect = (onCleanup: OnCleanup) => void
+export type WatchEffect = (onCleanup: OnCleanup) => void | Promise<void>
 
 export type WatchSource<T = any> = Ref<T, any> | ComputedRef<T> | (() => T)
 


### PR DESCRIPTION
Issue link
[https://github.com/vuejs/core/issues/14249

Description
This PR updates WatchEffect typing to allow async callbacks by accepting Promise<void> in addition to void.

Why
watchEffect is documented and commonly used with async functions, but the previous type signature rejected this pattern and caused lint/type friction.

Changes
Updated WatchEffect type to support async callbacks.
Added dts regression coverage to ensure async watchEffect callbacks are accepted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `watchEffect` now supports async callbacks in addition to synchronous ones.

* **Tests**
  * Added type test coverage for async `watchEffect` callbacks with cleanup support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->