### PR TITLE
fix(reactivity): add generic watch overloads

### DIFF
--- a/packages/reactivity/__tests__/watch.spec.ts
+++ b/packages/reactivity/__tests__/watch.spec.ts
@@ -60,6 +60,19 @@ describe('watch', () => {
     expect(dummy).toBe(1)
   })
 
+  // #13807
+  test('with explicit generic type argument', () => {
+    const source = ref(0)
+    let seen: number | undefined
+
+    watch<number>(source, value => {
+      seen = value
+    })
+
+    source.value++
+    expect(seen).toBe(1)
+  })
+
   test('call option with error handling', () => {
     const onError = vi.fn()
     const call: WatchOptions['call'] = function call(fn, type, args) {

--- a/packages/reactivity/src/watch.ts
+++ b/packages/reactivity/src/watch.ts
@@ -74,6 +74,18 @@ export interface WatchHandle extends WatchStopHandle {
   stop: () => void
 }
 
+type MaybeUndefined<T, I> = I extends true ? T | undefined : T
+
+type MultiWatchSources = (WatchSource<unknown> | object)[]
+
+type MapSources<T, Immediate> = {
+  [K in keyof T]: T[K] extends WatchSource<infer V>
+    ? MaybeUndefined<V, Immediate>
+    : T[K] extends object
+      ? MaybeUndefined<T[K], Immediate>
+      : never
+}
+
 // initial value for watchers to trigger on undefined initial values
 const INITIAL_WATCHER_VALUE = {}
 
@@ -117,10 +129,45 @@ export function onWatcherCleanup(
   }
 }
 
-export function watch(
-  source: WatchSource | WatchSource[] | WatchEffect | object,
+export function watch(effect: WatchEffect, options?: WatchOptions): WatchHandle
+
+export function watch<T, Immediate extends Readonly<boolean> = false>(
+  source: WatchSource<T>,
+  cb: WatchCallback<T, MaybeUndefined<T, Immediate>>,
+  options?: WatchOptions<Immediate>,
+): WatchHandle
+
+export function watch<
+  T extends Readonly<MultiWatchSources>,
+  Immediate extends Readonly<boolean> = false,
+>(
+  sources: readonly [...T] | T,
+  cb: WatchCallback<MapSources<T, false>, MapSources<T, Immediate>>,
+  options?: WatchOptions<Immediate>,
+): WatchHandle
+
+export function watch<
+  T extends MultiWatchSources,
+  Immediate extends Readonly<boolean> = false,
+>(
+  sources: [...T],
+  cb: WatchCallback<MapSources<T, false>, MapSources<T, Immediate>>,
+  options?: WatchOptions<Immediate>,
+): WatchHandle
+
+export function watch<
+  T extends object,
+  Immediate extends Readonly<boolean> = false,
+>(
+  source: T,
+  cb: WatchCallback<T, MaybeUndefined<T, Immediate>>,
+  options?: WatchOptions<Immediate>,
+): WatchHandle
+
+export function watch<T = any, Immediate extends Readonly<boolean> = false>(
+  source: WatchSource<T> | WatchSource<T>[] | WatchEffect | T,
   cb?: WatchCallback | null,
-  options: WatchOptions = EMPTY_OBJ,
+  options: WatchOptions<Immediate> = EMPTY_OBJ,
 ): WatchHandle {
   const { immediate, deep, once, scheduler, augmentJob, call } = options
 


### PR DESCRIPTION
Issue link
https://github.com/vuejs/core/issues/13807

Description
This PR adds explicit generic overloads for watch in @vue/reactivity so calls like watch<number>(...) preserve typed callback parameters.

Why
Current typing made generic usage awkward and could degrade callback types in generic-heavy usage.

Changes
Added overload signatures for watch, including single source, array sources, and object sources with generic support.
Added a regression test in reactivity watch tests for explicit generic usage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced TypeScript type inference for watch callbacks. The watch function now provides stronger type checking and more accurate IDE autocomplete suggestions when watching single sources, multiple sources, or object sources. Callback types are now precisely inferred based on source configuration.

* **Tests**
  * Added test coverage for explicit generic type arguments in watch functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->