### PR TITLE
fix(runtime-core): relax function ref callback variance

### DIFF
--- a/packages-private/dts-test/h.test-d.ts
+++ b/packages-private/dts-test/h.test-d.ts
@@ -25,6 +25,8 @@ describe('h inference w/ element', () => {
   h('div', { ref: 'foo' })
   h('div', { ref: ref(null) })
   h('div', { ref: _el => {} })
+  h('form', { ref: (_el: HTMLFormElement | null) => {} })
+  h('div', { ref: (_el: HTMLDivElement | null) => {} })
   //  @ts-expect-error
   h('div', { ref: [] })
   //  @ts-expect-error

--- a/packages/runtime-core/src/vnode.ts
+++ b/packages/runtime-core/src/vnode.ts
@@ -87,10 +87,14 @@ export type VNodeTypes =
 export type VNodeRef =
   | string
   | Ref
-  | ((
-      ref: Element | ComponentPublicInstance | null,
-      refs: Record<string, any>,
-    ) => void)
+  | {
+      // Bivariant callback param allows assigning more specific element types,
+      // e.g. (el: HTMLFormElement | null) => void for <form ref="...">.
+      bivarianceHack(
+        ref: Element | ComponentPublicInstance | null,
+        refs: Record<string, any>,
+      ): void
+    }['bivarianceHack']
 
 export type VNodeNormalizedRefAtom = {
   /**


### PR DESCRIPTION
Issue link
https://github.com/vuejs/core/issues/13969

Description
This PR adjusts function-ref typing so callbacks with narrower HTMLElement parameter types are accepted (for example HTMLFormElement on form refs).

Why
Template/function refs should allow element-specific callback parameter typing, but current type variance rejected valid narrower element types.

Changes
Updated VNode function ref callback typing to be bivariant.
Added dts regression cases for HTMLFormElement/HTMLDivElement function refs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Extended TypeScript test coverage for element reference callback type validation, improving type inference accuracy and IDE support for developers using element refs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->