### PR TITLE
fix(runtime-dom): widen VOnModifiers key typings

### DIFF
--- a/packages-private/dts-test/h.test-d.ts
+++ b/packages-private/dts-test/h.test-d.ts
@@ -10,6 +10,7 @@ import {
   h,
   ref,
   resolveComponent,
+  withModifiers,
 } from 'vue'
 import { describe, expectAssignable, expectType } from './utils'
 
@@ -45,6 +46,10 @@ describe('h inference w/ element', () => {
       expectType<FocusEvent>(e)
     },
   })
+})
+
+describe('withModifiers typing', () => {
+  withModifiers((e: Event) => e.type, ['enter', 'tab'])
 })
 
 describe('h inference w/ Fragment', () => {

--- a/packages/runtime-dom/src/directives/vOn.ts
+++ b/packages/runtime-dom/src/directives/vOn.ts
@@ -11,8 +11,13 @@ import { hyphenate, isArray } from '@vue/shared'
 const systemModifiers = ['ctrl', 'shift', 'alt', 'meta'] as const
 type SystemModifiers = (typeof systemModifiers)[number]
 type CompatModifiers = keyof typeof keyNames
+type KeyModifiers = string & {}
 
-export type VOnModifiers = SystemModifiers | ModifierGuards | CompatModifiers
+export type VOnModifiers =
+  | SystemModifiers
+  | ModifierGuards
+  | CompatModifiers
+  | KeyModifiers
 type KeyedEvent = KeyboardEvent | MouseEvent | TouchEvent
 
 type ModifierGuards =


### PR DESCRIPTION
Issue link
https://github.com/vuejs/core/issues/13336

Description
This PR widens VOnModifiers typing so key modifiers such as enter/tab are accepted in withModifiers typing scenarios.

Why
Current type union was too narrow for practical key-modifier usage.

Changes
Expanded VOnModifiers type to include string key modifier cases.
Added dts regression coverage using withModifiers and keyboard-style modifiers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced TypeScript type definitions for event modifiers, delivering improved IDE autocomplete and type checking when handling keyboard and system event interactions.

* **Tests**
  * Added type definition tests to validate event modifier typing behavior and ensure robust TypeScript support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->