### PR TITLE
fix(runtime-core): type TemplateRef as readonly Ref

### DIFF
--- a/packages-private/dts-test/ref.test-d.ts
+++ b/packages-private/dts-test/ref.test-d.ts
@@ -548,3 +548,4 @@ expectType<TemplateRef>(tRef)
 
 const tRef2 = useTemplateRef<HTMLElement>('bar')
 expectType<TemplateRef<HTMLElement>>(tRef2)
+expectType<Readonly<Ref<HTMLElement | null>>>(tRef2)

--- a/packages/runtime-core/src/helpers/useTemplateRef.ts
+++ b/packages/runtime-core/src/helpers/useTemplateRef.ts
@@ -1,11 +1,11 @@
-import { type ShallowRef, readonly, shallowRef } from '@vue/reactivity'
+import { type Ref, type ShallowRef, readonly, shallowRef } from '@vue/reactivity'
 import { type Data, getCurrentInstance } from '../component'
 import { warn } from '../warning'
 import { EMPTY_OBJ } from '@vue/shared'
 
 export const knownTemplateRefs: WeakSet<ShallowRef> = new WeakSet()
 
-export type TemplateRef<T = unknown> = Readonly<ShallowRef<T | null>>
+export type TemplateRef<T = unknown> = Readonly<Ref<T | null>>
 
 export function useTemplateRef<T = unknown, Keys extends string = string>(
   key: Keys,


### PR DESCRIPTION
Issue link
https://github.com/vuejs/core/issues/12731

Description
This PR updates TemplateRef public typing from readonly ShallowRef to readonly Ref while keeping runtime behavior unchanged.

Why
Consumers expect TemplateRef to be compatible with standard readonly Ref typing in generic utilities and TS APIs.

Changes
Updated TemplateRef exported type alias.
Added dts assertion ensuring compatibility with readonly Ref<T | null>.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated TypeScript type definitions for template references to align with reactivity API conventions, enhancing type consistency and developer experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->