### PR TITLE
test(types): add regression for toRef(MaybeRef) assignment

### DIFF
--- a/packages-private/dts-test/ref.test-d.ts
+++ b/packages-private/dts-test/ref.test-d.ts
@@ -538,6 +538,12 @@ declare const unref2:
   | WritableComputedRef<string>
 expectType<string>(unref(unref2))
 
+// #12986
+function toRefFromMaybeRef(v: MaybeRef<number>) {
+  const r = toRef(v)
+  r.value = 1
+}
+
 // toValue
 expectType<number>(toValue(unref1))
 expectType<string>(toValue(unref2))


### PR DESCRIPTION
Issue link
https://github.com/vuejs/core/issues/12986

Description
This PR adds a regression type test for assigning through toRef(MaybeRef<number>).

Why
The issue reports incorrect writable behavior around MaybeRef -> toRef conversion; this test protects current intended typing and prevents regressions.

Changes
Added dts test case ensuring assignment through toRef(MaybeRef<number>) type-checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added type-checking test to verify correct handling of ref conversion with union type inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->