### PR TITLE
docs(runtime-core): clarify useTemplateRef slot owner behavior

### DIFF
--- a/packages/runtime-core/src/helpers/useTemplateRef.ts
+++ b/packages/runtime-core/src/helpers/useTemplateRef.ts
@@ -7,6 +7,15 @@ export const knownTemplateRefs: WeakSet<ShallowRef> = new WeakSet()
 
 export type TemplateRef<T = unknown> = Readonly<ShallowRef<T | null>>
 
+/**
+ * Create a read-only template ref by key.
+ *
+ * When the same ref key is used multiple times in the owner template
+ * (for example under `v-for`), the collected value is an array.
+ *
+ * For slotted content rendered in another component's scope, ref collection
+ * follows the slot render owner semantics.
+ */
 export function useTemplateRef<T = unknown, Keys extends string = string>(
   key: Keys,
 ): TemplateRef<T> {


### PR DESCRIPTION
Issue link
https://github.com/vuejs/core/issues/12489

Description
This PR improves useTemplateRef documentation comments to clarify ref collection behavior for repeated refs and slotted content ownership.

Why
Users can misinterpret array-collection expectations when refs appear in slot-rendered content controlled by another owner scope.

Changes
Added explanatory notes for:
repeated ref keys under v-for producing array collection semantics
slot owner semantics affecting where refs are collected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced documentation for template reference functionality, clarifying behavior when the same reference key is used multiple times and how ref collection works with slotted content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->