### PR TITLE
fix(runtime-core): prevent currentInstance leak into sibling render during async setup re-entry

### DIFF
--- a/packages/runtime-core/__tests__/apiSetupHelpers.spec.ts
+++ b/packages/runtime-core/__tests__/apiSetupHelpers.spec.ts
@@ -330,6 +330,70 @@ describe('SFC <script setup> helpers', () => {
       expect(seenUid.two).toBeNull()
     })
 
+    test('should not leak currentInstance to sibling slot render', async () => {
+      let done!: () => void
+      const ready = new Promise<void>(r => {
+        done = r
+      })
+      let innerUid: number | null = null
+      let innerRenderUid: number | null = null
+
+      const Inner = defineComponent({
+        setup(_, { slots }) {
+          innerUid = getCurrentInstance()!.uid
+          return () => {
+            innerRenderUid = getCurrentInstance()!.uid
+            done()
+            return h('div', slots.default?.())
+          }
+        },
+      })
+
+      const Outer = defineComponent({
+        setup(_, { slots }) {
+          return () => h(Inner, null, () => [slots.default?.()])
+        },
+      })
+
+      const AsyncA = defineComponent({
+        async setup() {
+          let __temp: any, __restore: any
+          ;[__temp, __restore] = withAsyncContext(() =>
+            Promise.resolve()
+              .then(() => {})
+              .then(() => {}),
+          )
+          __temp = await __temp
+          __restore()
+          return () => h('div', 'A')
+        },
+      })
+
+      const AsyncB = defineComponent({
+        async setup() {
+          let __temp: any, __restore: any
+          ;[__temp, __restore] = withAsyncContext(() => Promise.resolve())
+          __temp = await __temp
+          __restore()
+          return () => h(Outer, null, () => 'B')
+        },
+      })
+
+      const root = nodeOps.createElement('div')
+      render(
+        h(() => h(Suspense, () => h('div', [h(AsyncA), h(AsyncB)]))),
+        root,
+      )
+
+      await ready
+      expect(
+        'Slot "default" invoked outside of the render function',
+      ).not.toHaveBeenWarned()
+      expect(innerRenderUid).toBe(innerUid)
+      await Promise.resolve()
+      expect(serializeInner(root)).toBe(`<div><div>A</div><div>B</div></div>`)
+    })
+
     test('error handling', async () => {
       const spy = vi.fn()
 

--- a/packages/runtime-core/__tests__/components/Suspense.spec.ts
+++ b/packages/runtime-core/__tests__/components/Suspense.spec.ts
@@ -36,14 +36,12 @@ import {
   createApp,
   defineAsyncComponent as defineAsyncComp,
   defineComponent,
-  getCurrentInstance,
   inject,
   provide,
 } from 'vue'
 import type { RawSlots } from 'packages/runtime-core/src/componentSlots'
 import { resetSuspenseId } from '../../src/components/Suspense'
 import { PatchFlags } from '@vue/shared'
-import { withAsyncContext } from '../../src/apiSetupHelpers'
 
 describe('Suspense', () => {
   const deps: Promise<any>[] = []
@@ -2625,50 +2623,6 @@ describe('Suspense', () => {
     // wait for new B to resolve
     await Promise.all(deps)
     expect(serializeInner(root)).toBe(`<div>B</div>`)
-  })
-
-  // #14667
-  test('no currentInstance leak when async setups resolve concurrently', async () => {
-    let selfInstance: any = null
-    let renderInstance: any = null
-
-    const AsyncA = defineComponent({
-      async setup() {
-        let __temp: any, __restore: any
-        ;[__temp, __restore] = withAsyncContext(() =>
-          Promise.resolve()
-            .then(() => {})
-            .then(() => {}),
-        )
-        __temp = await __temp
-        __restore()
-        return () => h('div', 'A')
-      },
-    })
-
-    const AsyncB = defineComponent({
-      async setup() {
-        let __temp: any, __restore: any
-        ;[__temp, __restore] = withAsyncContext(() => Promise.resolve())
-        __temp = await __temp
-        __restore()
-        selfInstance = getCurrentInstance()
-        return () => {
-          renderInstance = getCurrentInstance()
-          return h('div', 'B')
-        }
-      },
-    })
-
-    const root = nodeOps.createElement('div')
-    render(
-      h(() => h(Suspense, () => h('div', [h(AsyncA), h(AsyncB)]))),
-      root,
-    )
-
-    await new Promise(r => setTimeout(r))
-    expect(serializeInner(root)).toBe(`<div><div>A</div><div>B</div></div>`)
-    expect(renderInstance).toBe(selfInstance)
   })
 
   describe('warnings', () => {

--- a/packages/runtime-core/src/components/Suspense.ts
+++ b/packages/runtime-core/src/components/Suspense.ts
@@ -13,7 +13,6 @@ import {
 import { ShapeFlags, isArray, isFunction, toNumber } from '@vue/shared'
 import {
   type ComponentInternalInstance,
-  getCurrentInstance,
   handleSetupResult,
   unsetCurrentInstance,
 } from '../component'
@@ -727,10 +726,10 @@ function createSuspenseBoundary(
           ) {
             return
           }
-          // clear any currentInstance that may have leaked from a concurrent
-          // async setup continuation (withAsyncContext defers its cleanup to
-          // the next microtask, which may run after this handler).
-          if (getCurrentInstance()) unsetCurrentInstance()
+          // withAsyncContext defers cleanup to a later microtask, so currentInstance may
+          // still be set when Suspense re-enters another component's render path.
+          // Clear it first.
+          unsetCurrentInstance()
           // retry from this component
           instance.asyncResolved = true
           const { vnode } = instance


### PR DESCRIPTION
fix https://github.com/vuejs/core/issues/14667

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed instance context leakage in Suspense boundaries when rendering async sibling components, ensuring correct component identity during async setup and rendering.
* **Tests**
  * Added tests to verify async setup/render context preservation and correct DOM ordering under Suspense.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->