### PR TITLE
types(runtime-vapor): infer expose type from setup in defineVaporComponent options api

### DIFF
--- a/packages-private/dts-test/vapor/defineVaporComponent.test-d.tsx
+++ b/packages-private/dts-test/vapor/defineVaporComponent.test-d.tsx
@@ -1033,17 +1033,43 @@ describe('expose typing', () => {
       { expose }: { expose: (exposed: { a: number; b: string }) => void },
     ) => {
       expose({ a: 1, b: '' })
+      return <div></div>
     },
   )
-  const foo = new Foo()
+  const foo = {} as InstanceType<typeof Foo>
   // internal should still be exposed
   foo.props
 
-  expectType<number>(foo.exposeProxy!.a)
-  expectType<string>(foo.exposeProxy!.b)
+  if (foo.exposeProxy) {
+    expectType<IsAny<typeof foo.exposeProxy.a>>(false)
+    expectType<IsAny<typeof foo.exposeProxy.b>>(false)
+    expectType<number>(foo.exposeProxy.a)
+    expectType<string>(foo.exposeProxy.b)
+  }
+
+  // options
+  const Bar = defineVaporComponent({
+    setup: (
+      props: { some?: string },
+      { expose }: { expose: (exposed: { a: number; b: string }) => void },
+    ) => {
+      expose({ a: 1, b: '' })
+      return <div></div>
+    },
+  })
+  const bar = {} as InstanceType<typeof Bar>
+  // internal should still be exposed
+  bar.props
+
+  if (bar.exposeProxy) {
+    expectType<IsAny<typeof bar.exposeProxy.a>>(false)
+    expectType<IsAny<typeof bar.exposeProxy.b>>(false)
+    expectType<number>(bar.exposeProxy.a)
+    expectType<string>(bar.exposeProxy.b)
+  }
 
   // runtime
-  const Bar = defineVaporComponent({
+  const Baz = defineVaporComponent({
     props: {
       some: String,
     },
@@ -1052,12 +1078,16 @@ describe('expose typing', () => {
     },
   })
 
-  const bar = new Bar()
+  const baz = new Baz()
   // internal should still be exposed
-  bar.props
+  baz.props
 
-  expectType<number>(bar.exposeProxy!.a)
-  expectType<string>(bar.exposeProxy!.b)
+  if (baz.exposeProxy) {
+    expectType<IsAny<typeof baz.exposeProxy.a>>(false)
+    expectType<IsAny<typeof baz.exposeProxy.b>>(false)
+    expectType<number>(baz.exposeProxy.a)
+    expectType<string>(baz.exposeProxy.b)
+  }
 })
 
 describe('Custom options', () => {

--- a/packages-private/dts-test/vapor/functionalComponent.test-d.tsx
+++ b/packages-private/dts-test/vapor/functionalComponent.test-d.tsx
@@ -1,6 +1,6 @@
-import type { FunctionalVaporComponent } from 'vue'
+import { type FunctionalVaporComponent, type Ref, ref } from 'vue'
 import { expectType } from '../utils'
-import type { Block } from 'vue'
+import type { Block, UnwrapRef } from 'vue'
 
 // simple function signature
 const VaporComp = (props: { foo: number }) => [<div>123</div>]
@@ -61,8 +61,9 @@ const Quux: FunctionalVaporComponent<
   {
     default: (props: { foo: number }) => Block
     optional?: (props: { foo: number }) => Block
-  }
-> = (props, { emit, slots }) => {
+  },
+  { foo: Ref<string> }
+> = (props, { emit, slots, expose }) => {
   expectType<{
     default: (scope: { foo: number }) => Block
     optional?: (scope: { foo: number }) => Block
@@ -77,6 +78,14 @@ const Quux: FunctionalVaporComponent<
   slots.optional?.({ foo: 'fesf' })
   // @ts-expect-error
   slots.optional({ foo: 123 })
+
+  expose({ foo: ref('foo') })
   return []
 }
 ;<Quux />
+
+// Exposed
+const quux = {} as UnwrapRef<
+  Parameters<Parameters<typeof Quux>[1]['expose']>[0]
+>
+expectType<string>(quux.foo)

--- a/packages/runtime-vapor/src/component.ts
+++ b/packages/runtime-vapor/src/component.ts
@@ -137,7 +137,7 @@ export type FunctionalVaporComponent<
     emit: EmitFn<Emits>
     slots: Slots
     attrs: Record<string, any>
-    expose: <T extends Record<string, any> = Exposed>(exposed: T) => void
+    expose: (exposed: Exposed) => void
   },
 ) => VaporRenderResult) &
   Omit<
@@ -175,9 +175,9 @@ export interface VaporComponentOptions<
       emit: EmitFn<Emits>
       slots: Slots
       attrs: Record<string, any>
-      expose: <T extends Record<string, any> = Exposed>(exposed: T) => void
+      expose: (exposed: Exposed) => void
     },
-  ) => TypeBlock | Exposed | Promise<Exposed> | void
+  ) => VaporRenderResult<TypeBlock> | Exposed | Promise<Exposed> | void
   render?(
     ctx: Exposed extends Block ? undefined : ShallowUnwrapRef<Exposed>,
     props: Readonly<InferredProps>,


### PR DESCRIPTION
Change expose to accept Exposed (remove generic) and make setup return VaporRenderResult<TypeBlock> | Exposed | Promise<Exposed> | void Update DTS tests to assert exposeProxy types and adapt functional component expose generics