### PR TITLE
fix(hydration): keep lazy hydration on the async wrapper path

### DIFF
--- a/packages/runtime-vapor/__tests__/hydration.spec.ts
+++ b/packages/runtime-vapor/__tests__/hydration.spec.ts
@@ -9826,6 +9826,68 @@ describe('VDOM interop', () => {
     )
   })
 
+  test('hydrate multi-root Vapor component should cleanup extra SSR text within allow-mismatch wrapper', async () => {
+    const data = ref({
+      msg: 'Hello',
+      extra: 'Tail',
+      after: 'After',
+    })
+
+    const childCode = `<script setup>
+        const data = _data
+      </script>
+      <template>
+        <span>{{ data.msg }}</span>{{ data.extra }}
+      </template>`
+
+    const appCode = `<script setup>
+        const components = _components
+        const data = _data
+      </script>
+      <template>
+        <div data-allow-mismatch="text">
+          <components.Child />
+          <span>{{ data.after }}</span>
+        </div>
+      </template>`
+
+    const SSRChild = compileVaporComponent(childCode, data, undefined, true)
+    const SSRApp = compileVaporComponent(
+      appCode,
+      data,
+      { Child: SSRChild },
+      true,
+    )
+    const html = await VueServerRenderer.renderToString(
+      runtimeDom.createSSRApp(SSRApp),
+    )
+
+    data.value.extra = ''
+
+    const ClientChild = compileVaporComponent(childCode, data)
+    const ClientApp = compileVaporComponent(appCode, data, {
+      Child: ClientChild,
+    })
+
+    const container = document.createElement('div')
+    container.innerHTML = html
+    document.body.appendChild(container)
+    createVaporSSRApp(ClientApp).mount(container)
+
+    expect(`Hydration text mismatch`).not.toHaveBeenWarned()
+    expect(container.innerHTML).toBe(
+      '<div data-allow-mismatch="text"><!--[--><span>Hello</span><!--]--><span>After</span></div>',
+    )
+
+    data.value.extra = 'Updated'
+    data.value.after = 'After updated'
+    await nextTick()
+
+    expect(container.innerHTML).toBe(
+      '<div data-allow-mismatch="text"><!--[--><span>Hello</span>Updated<!--]--><span>After updated</span></div>',
+    )
+  })
+
   test('hydrate multi-root VDOM via mountVNode as non-first child', async () => {
     const MultiRootVDOM = {
       setup() {

--- a/packages/runtime-vapor/__tests__/hydration.spec.ts
+++ b/packages/runtime-vapor/__tests__/hydration.spec.ts
@@ -5806,38 +5806,51 @@ describe('mismatch handling', () => {
     expect(container.innerHTML).toBe('<span>foo</span><!--dynamic-component-->')
     expect(`Hydration node mismatch`).toHaveBeenWarned()
   })
-  // test('fragment mismatch removal', () => {
-  //   const { container } = mountWithHydration(
-  //     `<div><!--[--><div>foo</div><div>bar</div><!--]--></div>`,
-  //     () => h('div', [h('span', 'replaced')]),
-  //   )
-  //   expect(container.innerHTML).toBe('<div><span>replaced</span></div>')
-  //   expect(`Hydration node mismatch`).toHaveBeenWarned()
-  // })
-  // test('fragment not enough children', () => {
-  //   const { container } = mountWithHydration(
-  //     `<div><!--[--><div>foo</div><!--]--><div>baz</div></div>`,
-  //     () => h('div', [[h('div', 'foo'), h('div', 'bar')], h('div', 'baz')]),
-  //   )
-  //   expect(container.innerHTML).toBe(
-  //     '<div><!--[--><div>foo</div><div>bar</div><!--]--><div>baz</div></div>',
-  //   )
-  //   expect(`Hydration node mismatch`).toHaveBeenWarned()
-  // })
-  // test('fragment too many children', () => {
-  //   const { container } = mountWithHydration(
-  //     `<div><!--[--><div>foo</div><div>bar</div><!--]--><div>baz</div></div>`,
-  //     () => h('div', [[h('div', 'foo')], h('div', 'baz')]),
-  //   )
-  //   expect(container.innerHTML).toBe(
-  //     '<div><!--[--><div>foo</div><!--]--><div>baz</div></div>',
-  //   )
-  //   // fragment ends early and attempts to hydrate the extra <div>bar</div>
-  //   // as 2nd fragment child.
-  //   expect(`Hydration text content mismatch`).toHaveBeenWarned()
-  //   // excessive children removal
-  //   expect(`Hydration children mismatch`).toHaveBeenWarned()
-  // })
+  test('fragment mismatch removal', async () => {
+    const data = ref({ items: [] as string[] })
+    const { container } = await mountWithHydration(
+      `<div><!--[--><div>foo</div><div>bar</div><!--]--><div>baz</div></div>`,
+      `<div>
+        <div v-for="item in data.items" :key="item">foo</div>
+        <div>baz</div>
+      </div>`,
+      data,
+    )
+    expect(container.innerHTML).toBe(
+      '<div><!--[--><!--]--><div>baz</div></div>',
+    )
+    expect(`Hydration children mismatch`).toHaveBeenWarned()
+  })
+  test('fragment not enough children', async () => {
+    const data = ref({ items: ['a', 'b'] })
+    const { container } = await mountWithHydration(
+      `<div><!--[--><div>foo</div><!--]--><div>baz</div></div>`,
+      `<div>
+        <div v-for="item in data.items" :key="item">foo</div>
+        <div>baz</div>
+      </div>`,
+      data,
+    )
+    expect(container.innerHTML).toBe(
+      '<div><!--[--><div>foo</div><div>foo</div><!--]--><div>baz</div></div>',
+    )
+    expect(`Hydration node mismatch`).toHaveBeenWarned()
+  })
+  test('fragment too many children', async () => {
+    const data = ref({ items: ['a'] })
+    const { container } = await mountWithHydration(
+      `<div><!--[--><div>foo</div><div>foo</div><!--]--><div>baz</div></div>`,
+      `<div>
+        <div v-for="item in data.items" :key="item">foo</div>
+        <div>baz</div>
+      </div>`,
+      data,
+    )
+    expect(container.innerHTML).toBe(
+      '<div><!--[--><div>foo</div><!--]--><div>baz</div></div>',
+    )
+    expect(`Hydration children mismatch`).toHaveBeenWarned()
+  })
   // test('Teleport target has empty children', () => {
   //   const teleportContainer = document.createElement('div')
   //   teleportContainer.id = 'teleport'
@@ -6296,40 +6309,51 @@ describe('data-allow-mismatch', () => {
     )
     expect(`Hydration node mismatch`).not.toHaveBeenWarned()
   })
-  // test('fragment mismatch removal', () => {
-  //   const { container } = mountWithHydration(
-  //     `<div data-allow-mismatch="children"><!--[--><div>foo</div><div>bar</div><!--]--></div>`,
-  //     () => h('div', [h('span', 'replaced')]),
-  //   )
-  //   expect(container.innerHTML).toBe(
-  //     '<div data-allow-mismatch="children"><span>replaced</span></div>',
-  //   )
-  //   expect(`Hydration node mismatch`).not.toHaveBeenWarned()
-  // })
-  // test('fragment not enough children', () => {
-  //   const { container } = mountWithHydration(
-  //     `<div data-allow-mismatch="children"><!--[--><div>foo</div><!--]--><div>baz</div></div>`,
-  //     () => h('div', [[h('div', 'foo'), h('div', 'bar')], h('div', 'baz')]),
-  //   )
-  //   expect(container.innerHTML).toBe(
-  //     '<div data-allow-mismatch="children"><!--[--><div>foo</div><div>bar</div><!--]--><div>baz</div></div>',
-  //   )
-  //   expect(`Hydration node mismatch`).not.toHaveBeenWarned()
-  // })
-  // test('fragment too many children', () => {
-  //   const { container } = mountWithHydration(
-  //     `<div data-allow-mismatch="children"><!--[--><div>foo</div><div>bar</div><!--]--><div>baz</div></div>`,
-  //     () => h('div', [[h('div', 'foo')], h('div', 'baz')]),
-  //   )
-  //   expect(container.innerHTML).toBe(
-  //     '<div data-allow-mismatch="children"><!--[--><div>foo</div><!--]--><div>baz</div></div>',
-  //   )
-  //   // fragment ends early and attempts to hydrate the extra <div>bar</div>
-  //   // as 2nd fragment child.
-  //   expect(`Hydration text content mismatch`).not.toHaveBeenWarned()
-  //   // excessive children removal
-  //   expect(`Hydration children mismatch`).not.toHaveBeenWarned()
-  // })
+  test('fragment mismatch removal', async () => {
+    const data = ref({ items: [] as string[] })
+    const { container } = await mountWithHydration(
+      `<div data-allow-mismatch="children"><!--[--><div>foo</div><div>bar</div><!--]--><div>baz</div></div>`,
+      `<div data-allow-mismatch="children">
+        <div v-for="item in data.items" :key="item">foo</div>
+        <div>baz</div>
+      </div>`,
+      data,
+    )
+    expect(container.innerHTML).toBe(
+      '<div data-allow-mismatch="children"><!--[--><!--]--><div>baz</div></div>',
+    )
+    expect(`Hydration children mismatch`).not.toHaveBeenWarned()
+  })
+  test('fragment not enough children', async () => {
+    const data = ref({ items: ['a', 'b'] })
+    const { container } = await mountWithHydration(
+      `<div data-allow-mismatch="children"><!--[--><div>foo</div><!--]--><div>baz</div></div>`,
+      `<div data-allow-mismatch="children">
+        <div v-for="item in data.items" :key="item">foo</div>
+        <div>baz</div>
+      </div>`,
+      data,
+    )
+    expect(container.innerHTML).toBe(
+      '<div data-allow-mismatch="children"><!--[--><div>foo</div><div>foo</div><!--]--><div>baz</div></div>',
+    )
+    expect(`Hydration node mismatch`).not.toHaveBeenWarned()
+  })
+  test('fragment too many children', async () => {
+    const data = ref({ items: ['a'] })
+    const { container } = await mountWithHydration(
+      `<div data-allow-mismatch="children"><!--[--><div>foo</div><div>foo</div><!--]--><div>baz</div></div>`,
+      `<div data-allow-mismatch="children">
+        <div v-for="item in data.items" :key="item">foo</div>
+        <div>baz</div>
+      </div>`,
+      data,
+    )
+    expect(container.innerHTML).toBe(
+      '<div data-allow-mismatch="children"><!--[--><div>foo</div><!--]--><div>baz</div></div>',
+    )
+    expect(`Hydration children mismatch`).not.toHaveBeenWarned()
+  })
   // test('comment mismatch (element)', () => {
   //   const { container } = mountWithHydration(
   //     `<div data-allow-mismatch="children"><span></span></div>`,
@@ -7340,6 +7364,174 @@ describe('VDOM interop', () => {
     await nextTick()
     expect(container.innerHTML).toBe(
       '<!--[--><!--dynamic-component--><span>tail-updated</span><!--]-->',
+    )
+  })
+
+  test('hydrate createDynamicComponent to null branch at end of container', async () => {
+    const data = ref({
+      show: true,
+      msg: 'late',
+    })
+    const code = `<script setup>
+        const data = _data
+      </script>
+      <template>
+        <component :is="data.show ? 'div' : null">{{ data.msg }}</component>
+      </template>`
+
+    const serverComp = compile(code, data, {}, { vapor: true, ssr: true })
+    const html = await VueServerRenderer.renderToString(
+      runtimeDom.createSSRApp(serverComp),
+    )
+
+    data.value.show = false
+
+    const container = document.createElement('div')
+    container.innerHTML = html
+    document.body.appendChild(container)
+
+    const clientComp = compile(code, data, {}, { vapor: true, ssr: false })
+    createVaporSSRApp(clientComp).mount(container)
+
+    expect(`Hydration node mismatch`).not.toHaveBeenWarned()
+    expect(`Hydration children mismatch`).toHaveBeenWarned()
+    expect(container.innerHTML).toBe('<!--dynamic-component-->')
+
+    data.value.show = true
+    await nextTick()
+    expect(container.innerHTML).toBe('<div>late</div><!--dynamic-component-->')
+
+    data.value.msg = 'late-updated'
+    await nextTick()
+    expect(container.innerHTML).toBe(
+      '<div>late-updated</div><!--dynamic-component-->',
+    )
+  })
+
+  test('hydrate createDynamicComponent to null branch at end of allowed-mismatch container', async () => {
+    const data = ref({
+      show: true,
+      msg: 'late',
+    })
+    const code = `<script setup>
+        const data = _data
+      </script>
+      <template>
+        <div data-allow-mismatch="children">
+          <component :is="data.show ? 'div' : null">{{ data.msg }}</component>
+        </div>
+      </template>`
+
+    const serverComp = compile(code, data, {}, { vapor: true, ssr: true })
+    const html = await VueServerRenderer.renderToString(
+      runtimeDom.createSSRApp(serverComp),
+    )
+
+    data.value.show = false
+
+    const container = document.createElement('div')
+    container.innerHTML = html
+    document.body.appendChild(container)
+
+    const clientComp = compile(code, data, {}, { vapor: true, ssr: false })
+    createVaporSSRApp(clientComp).mount(container)
+
+    expect(`Hydration node mismatch`).not.toHaveBeenWarned()
+    expect(`Hydration children mismatch`).not.toHaveBeenWarned()
+    expect(container.innerHTML).toBe(
+      '<div data-allow-mismatch="children"><!--dynamic-component--></div>',
+    )
+  })
+
+  test('hydrate Fragment dynamic component to null branch at end of container', async () => {
+    const data = ref({
+      showMulti: true,
+    })
+    const code = `<script setup>
+        import { Fragment, computed, h } from 'vue'
+        const data = _data
+        const vnode = computed(() =>
+          data.value.showMulti
+            ? h(Fragment, null, [
+                h('div', null, 'first fragment'),
+                h('div', null, 'second fragment'),
+              ])
+            : null
+        )
+      </script>
+      <template>
+        <component :is="vnode" />
+      </template>`
+
+    const serverComp = compile(code, data, {}, { vapor: true, ssr: true })
+    const html = await VueServerRenderer.renderToString(
+      runtimeDom.createSSRApp(serverComp),
+    )
+
+    data.value.showMulti = false
+
+    const container = document.createElement('div')
+    container.innerHTML = html
+    document.body.appendChild(container)
+
+    const clientComp = compile(code, data, {}, { vapor: true, ssr: false })
+    const app = createVaporSSRApp(clientComp)
+    app.use(runtimeVapor.vaporInteropPlugin)
+    app.mount(container)
+
+    expect(`Hydration node mismatch`).not.toHaveBeenWarned()
+    expect(`Hydration children mismatch`).toHaveBeenWarned()
+    expect(container.innerHTML).toBe('<!--dynamic-component-->')
+
+    data.value.showMulti = true
+    await nextTick()
+    expect(formatHtml(container.innerHTML)).toMatchInlineSnapshot(`
+      "<div>first fragment</div><div>second fragment</div><!--dynamic-component-->"
+    `)
+  })
+
+  test('hydrate Fragment dynamic component to null branch at end of allowed-mismatch container', async () => {
+    const data = ref({
+      showMulti: true,
+    })
+    const code = `<script setup>
+        import { Fragment, computed, h } from 'vue'
+        const data = _data
+        const vnode = computed(() =>
+          data.value.showMulti
+            ? h(Fragment, null, [
+                h('div', null, 'first fragment'),
+                h('div', null, 'second fragment'),
+              ])
+            : null
+        )
+      </script>
+      <template>
+        <div data-allow-mismatch="children">
+          <component :is="vnode" />
+        </div>
+      </template>`
+
+    const serverComp = compile(code, data, {}, { vapor: true, ssr: true })
+    const html = await VueServerRenderer.renderToString(
+      runtimeDom.createSSRApp(serverComp),
+    )
+
+    data.value.showMulti = false
+
+    const container = document.createElement('div')
+    container.innerHTML = html
+    document.body.appendChild(container)
+
+    const clientComp = compile(code, data, {}, { vapor: true, ssr: false })
+    const app = createVaporSSRApp(clientComp)
+    app.use(runtimeVapor.vaporInteropPlugin)
+    app.mount(container)
+
+    expect(`Hydration node mismatch`).not.toHaveBeenWarned()
+    expect(`Hydration children mismatch`).not.toHaveBeenWarned()
+    expect(container.innerHTML).toBe(
+      '<div data-allow-mismatch="children"><!--dynamic-component--></div>',
     )
   })
 

--- a/packages/runtime-vapor/__tests__/hydration.spec.ts
+++ b/packages/runtime-vapor/__tests__/hydration.spec.ts
@@ -4841,7 +4841,7 @@ describe('Vapor Mode hydration', () => {
       `)
     })
 
-    test.todo('update async component slot structure after parent mount before async component resolve', async () => {
+    test('update async component slot structure after parent mount before async component resolve', async () => {
       const data = ref({
         show: false,
         msg: 'bar',
@@ -4901,6 +4901,71 @@ describe('Vapor Mode hydration', () => {
       expect(formatHtml(container.innerHTML)).toMatchInlineSnapshot(`
       	"<div>
       	<!--[--><span>bar</span><!--if--><!--]-->
+      	</div><!--async component-->"
+      `)
+    })
+
+    test('update async component slot single-root if with trailing sibling after parent mount before async component resolve', async () => {
+      const data = ref({
+        show: false,
+        msg: 'bar',
+        tail: 'tail',
+      })
+      const compCode = `<div><slot/></div>`
+      const SSRComp = compileVaporComponent(
+        compCode,
+        undefined,
+        undefined,
+        true,
+      )
+      let serverResolve: any
+      let AsyncComp = defineAsyncComponent(
+        () =>
+          new Promise(r => {
+            serverResolve = r
+          }),
+      )
+      const appCode = `<components.AsyncComp><span v-if="data.show">{{data.msg}}</span><i>{{data.tail}}</i></components.AsyncComp>`
+      const SSRApp = compileVaporComponent(appCode, data, { AsyncComp }, true)
+
+      const htmlPromise = VueServerRenderer.renderToString(
+        runtimeDom.createSSRApp(SSRApp),
+      )
+      serverResolve(SSRComp)
+      const html = await htmlPromise
+      expect(formatHtml(html)).toMatchInlineSnapshot(`
+      	"<div>
+      	<!--[--><!----><i>tail</i><!--]-->
+      	</div>"
+      `)
+
+      let clientResolve: any
+      AsyncComp = defineVaporAsyncComponent(
+        () =>
+          new Promise(r => {
+            clientResolve = r
+          }),
+      ) as any
+
+      const Comp = compileVaporComponent(compCode)
+      const App = compileVaporComponent(appCode, data, { AsyncComp })
+
+      const container = document.createElement('div')
+      container.innerHTML = html
+      document.body.appendChild(container)
+      createVaporSSRApp(App).mount(container)
+
+      data.value.show = true
+      await nextTick()
+
+      clientResolve(Comp)
+      await new Promise(r => setTimeout(r))
+
+      expect(`Hydration node mismatch`).toHaveBeenWarned()
+      expect(`Hydration text mismatch`).toHaveBeenWarned()
+      expect(formatHtml(container.innerHTML)).toMatchInlineSnapshot(`
+      	"<div>
+      	<!--[--><span>bar</span><!--if--><i>tail</i><!--]-->
       	</div><!--async component-->"
       `)
     })

--- a/packages/runtime-vapor/__tests__/hydration.spec.ts
+++ b/packages/runtime-vapor/__tests__/hydration.spec.ts
@@ -7231,6 +7231,87 @@ describe('VDOM interop', () => {
     `)
   })
 
+  test('hydrate empty createDynamicComponent should fill before trailing sibling', async () => {
+    const data = ref({
+      show: false,
+      msg: 'late',
+      tail: 'tail',
+    })
+    const { container } = await mountWithHydration(
+      '<!--[--><!--dynamic-component--><span>tail</span><!--]-->',
+      `<script setup>
+        const data = _data
+      </script>
+      <template>
+        <component :is="data.show ? 'div' : null">{{ data.msg }}</component>
+        <span>{{ data.tail }}</span>
+      </template>`,
+      data,
+    )
+
+    expect(`Hydration node mismatch`).not.toHaveBeenWarned()
+    expect(container.innerHTML).toBe(
+      '<!--[--><!--dynamic-component--><span>tail</span><!--]-->',
+    )
+
+    data.value.show = true
+    await nextTick()
+    expect(container.innerHTML).toBe(
+      '<!--[--><div>late</div><!--dynamic-component--><span>tail</span><!--]-->',
+    )
+
+    data.value.msg = 'late-updated'
+    data.value.tail = 'tail-updated'
+    await nextTick()
+
+    expect(container.innerHTML).toBe(
+      '<!--[--><div>late-updated</div><!--dynamic-component--><span>tail-updated</span><!--]-->',
+    )
+  })
+
+  test('hydrate empty createDynamicComponent under keyed Transition should fill before trailing sibling', async () => {
+    const data = ref({
+      show: false,
+      key: 'empty',
+      msg: 'late',
+      tail: 'tail',
+    })
+    const { container } = await mountWithHydration(
+      '<!--[--><!----><span>tail</span><!--]-->',
+      `<script setup>
+        const data = _data
+      </script>
+      <template>
+        <Transition :css="false">
+          <component :is="data.show ? 'div' : null" :key="data.key">
+            {{ data.msg }}
+          </component>
+        </Transition>
+        <span>{{ data.tail }}</span>
+      </template>`,
+      data,
+    )
+
+    expect(`Hydration node mismatch`).not.toHaveBeenWarned()
+    expect(container.innerHTML).toBe(
+      '<!--[--><!----><!--keyed--><span>tail</span><!--]-->',
+    )
+
+    data.value.show = true
+    data.value.key = 'filled'
+    await nextTick()
+    expect(container.innerHTML).toBe(
+      '<!--[--><div>late</div><!--dynamic-component--><!--keyed--><span>tail</span><!--]-->',
+    )
+
+    data.value.msg = 'late-updated'
+    data.value.tail = 'tail-updated'
+    await nextTick()
+    expect(container.innerHTML).toBe(
+      '<!--[--><div>late-updated</div><!--dynamic-component--><!--keyed--><span>tail-updated</span><!--]-->',
+    )
+  })
+
   test('hydrate vapor slot in vdom component with empty slot and sibling nodes', async () => {
     const msg = ref('Hello World!')
     const { container } = await testWithVaporApp(

--- a/packages/runtime-vapor/__tests__/hydration.spec.ts
+++ b/packages/runtime-vapor/__tests__/hydration.spec.ts
@@ -7312,6 +7312,37 @@ describe('VDOM interop', () => {
     )
   })
 
+  test('hydrate createDynamicComponent to null branch should remove stale branch before trailing sibling', async () => {
+    const data = ref({
+      show: false,
+      msg: 'late',
+      tail: 'tail',
+    })
+    const { container } = await mountWithHydration(
+      '<!--[--><div>late</div><!--dynamic-component--><span>tail</span><!--]-->',
+      `<script setup>
+        const data = _data
+      </script>
+      <template>
+        <component :is="data.show ? 'div' : null">{{ data.msg }}</component>
+        <span>{{ data.tail }}</span>
+      </template>`,
+      data,
+    )
+
+    expect(`Hydration node mismatch`).not.toHaveBeenWarned()
+    expect(`Hydration children mismatch`).toHaveBeenWarned()
+    expect(container.innerHTML).toBe(
+      '<!--[--><!--dynamic-component--><span>tail</span><!--]-->',
+    )
+
+    data.value.tail = 'tail-updated'
+    await nextTick()
+    expect(container.innerHTML).toBe(
+      '<!--[--><!--dynamic-component--><span>tail-updated</span><!--]-->',
+    )
+  })
+
   test('hydrate vapor slot in vdom component with empty slot and sibling nodes', async () => {
     const msg = ref('Hello World!')
     const { container } = await testWithVaporApp(

--- a/packages/runtime-vapor/__tests__/hydration.spec.ts
+++ b/packages/runtime-vapor/__tests__/hydration.spec.ts
@@ -5851,16 +5851,17 @@ describe('mismatch handling', () => {
     )
     expect(`Hydration children mismatch`).toHaveBeenWarned()
   })
-  // test('Teleport target has empty children', () => {
-  //   const teleportContainer = document.createElement('div')
-  //   teleportContainer.id = 'teleport'
-  //   document.body.appendChild(teleportContainer)
-  //   mountWithHydration('<!--teleport start--><!--teleport end-->', () =>
-  //     h(Teleport, { to: '#teleport' }, [h('span', 'value')]),
-  //   )
-  //   expect(teleportContainer.innerHTML).toBe(`<span>value</span>`)
-  //   expect(`Hydration children mismatch`).toHaveBeenWarned()
-  // })
+  test('Teleport target has empty children', async () => {
+    const teleportContainer = document.createElement('div')
+    teleportContainer.id = 'teleport'
+    document.body.appendChild(teleportContainer)
+    await mountWithHydration(
+      '<!--teleport start--><!--teleport end-->',
+      `<teleport to="#teleport"><span>value</span></teleport>`,
+    )
+    expect(teleportContainer.innerHTML).toBe(`<span>value</span>`)
+    expect(`Hydration children mismatch`).toHaveBeenWarned()
+  })
   // test('comment mismatch (element)', () => {
   //   const { container } = mountWithHydration(`<div><span></span></div>`, () =>
   //     h('div', [createCommentVNode('hi')]),
@@ -7535,6 +7536,100 @@ describe('VDOM interop', () => {
     )
   })
 
+  test('hydrate Teleport VNode dynamic component to null branch at end of container', async () => {
+    const data = ref({
+      showTeleport: true,
+    })
+    const code = `<script setup>
+        import { Teleport, computed, h } from 'vue'
+        const data = _data
+        const vnode = computed(() =>
+          data.value.showTeleport
+            ? h(Teleport, { to: '#target', disabled: true }, [
+                h('div', null, 'teleported'),
+              ])
+            : null
+        )
+      </script>
+      <template>
+        <component :is="vnode" />
+      </template>`
+
+    const serverComp = compile(code, data, {}, { vapor: true, ssr: true })
+    const html = await VueServerRenderer.renderToString(
+      runtimeDom.createSSRApp(serverComp),
+    )
+
+    data.value.showTeleport = false
+
+    const container = document.createElement('div')
+    container.innerHTML = html
+    document.body.appendChild(container)
+
+    const clientComp = compile(code, data, {}, { vapor: true, ssr: false })
+    const app = createVaporSSRApp(clientComp)
+    app.use(runtimeVapor.vaporInteropPlugin)
+    app.mount(container)
+
+    expect(`Hydration node mismatch`).not.toHaveBeenWarned()
+    expect(`Hydration children mismatch`).toHaveBeenWarned()
+    expect(container.innerHTML).toBe('<!--dynamic-component-->')
+
+    data.value.showTeleport = true
+    await nextTick()
+    expect(formatHtml(container.innerHTML)).toMatchInlineSnapshot(`
+      "
+      <!--teleport start-->
+      <div>teleported</div>
+      <!--teleport end-->
+      <!--dynamic-component-->"
+    `)
+  })
+
+  test('hydrate Teleport VNode dynamic component to null branch at end of allowed-mismatch container', async () => {
+    const data = ref({
+      showTeleport: true,
+    })
+    const code = `<script setup>
+        import { Teleport, computed, h } from 'vue'
+        const data = _data
+        const vnode = computed(() =>
+          data.value.showTeleport
+            ? h(Teleport, { to: '#target', disabled: true }, [
+                h('div', null, 'teleported'),
+              ])
+            : null
+        )
+      </script>
+      <template>
+        <div data-allow-mismatch="children">
+          <component :is="vnode" />
+        </div>
+      </template>`
+
+    const serverComp = compile(code, data, {}, { vapor: true, ssr: true })
+    const html = await VueServerRenderer.renderToString(
+      runtimeDom.createSSRApp(serverComp),
+    )
+
+    data.value.showTeleport = false
+
+    const container = document.createElement('div')
+    container.innerHTML = html
+    document.body.appendChild(container)
+
+    const clientComp = compile(code, data, {}, { vapor: true, ssr: false })
+    const app = createVaporSSRApp(clientComp)
+    app.use(runtimeVapor.vaporInteropPlugin)
+    app.mount(container)
+
+    expect(`Hydration node mismatch`).not.toHaveBeenWarned()
+    expect(`Hydration children mismatch`).not.toHaveBeenWarned()
+    expect(container.innerHTML).toBe(
+      '<div data-allow-mismatch="children"><!--dynamic-component--></div>',
+    )
+  })
+
   test('hydrate vapor slot in vdom component with empty slot and sibling nodes', async () => {
     const msg = ref('Hello World!')
     const { container } = await testWithVaporApp(
@@ -7718,6 +7813,57 @@ describe('VDOM interop', () => {
       <div>teleported</div>
       <!--teleport end-->
       <!--dynamic-component--><span>tail-updated</span><!--]-->
+      "
+    `)
+  })
+
+  test('hydrate Teleport dynamic component to null branch should remove teleport range and preserve trailing sibling', async () => {
+    const data = ref({
+      showTeleport: true,
+      tail: 'tail',
+    })
+
+    const code = `<script setup>
+        import { Teleport } from 'vue'
+        const data = _data
+      </script>
+      <template>
+        <component
+          :is="data.showTeleport ? Teleport : null"
+          to="#target"
+          :disabled="true"
+        >
+          <div>teleported</div>
+        </component>
+        <span>{{ data.tail }}</span>
+      </template>`
+
+    const serverComp = compile(code, data, {}, { vapor: true, ssr: true })
+    const html = await VueServerRenderer.renderToString(
+      runtimeDom.createSSRApp(serverComp),
+    )
+
+    data.value.showTeleport = false
+
+    const container = document.createElement('div')
+    container.innerHTML = html
+    document.body.appendChild(container)
+
+    const clientComp = compile(code, data, {}, { vapor: true, ssr: false })
+    createVaporSSRApp(clientComp).mount(container)
+
+    expect(`Hydration children mismatch`).toHaveBeenWarned()
+    expect(formatHtml(container.innerHTML)).toMatchInlineSnapshot(`
+      "
+      <!--[--><!--dynamic-component--><span>tail</span><!--]-->
+      "
+    `)
+
+    data.value.tail = 'tail-updated'
+    await nextTick()
+    expect(formatHtml(container.innerHTML)).toMatchInlineSnapshot(`
+      "
+      <!--[--><!--dynamic-component--><span>tail-updated</span><!--]-->
       "
     `)
   })

--- a/packages/runtime-vapor/__tests__/hydration.spec.ts
+++ b/packages/runtime-vapor/__tests__/hydration.spec.ts
@@ -9693,6 +9693,139 @@ describe('VDOM interop', () => {
     )
   })
 
+  test('hydrate multi-root Vapor component should preserve close marker when client renders extra child', async () => {
+    const data = ref({
+      msg: 'Hello',
+      extra: '',
+    })
+
+    const childCode = `<script setup>
+        const data = _data
+      </script>
+      <template>
+        <span>{{ data.msg }}</span>{{ data.extra }}
+      </template>`
+
+    const appCode = `<script setup>
+        const components = _components
+      </script>
+      <template>
+        <div>Before</div>
+        <components.Child />
+        <div>After</div>
+      </template>`
+
+    const SSRChild = compileVaporComponent(childCode, data, undefined, true)
+    const SSRApp = compileVaporComponent(
+      appCode,
+      data,
+      { Child: SSRChild },
+      true,
+    )
+    const html = await VueServerRenderer.renderToString(
+      runtimeDom.createSSRApp(SSRApp),
+    )
+
+    data.value.extra = 'Tail'
+
+    const ClientChild = compileVaporComponent(childCode, data)
+    const ClientApp = compileVaporComponent(appCode, data, {
+      Child: ClientChild,
+    })
+
+    const container = document.createElement('div')
+    container.innerHTML = html
+    document.body.appendChild(container)
+    createVaporSSRApp(ClientApp).mount(container)
+
+    expect(`Hydration node mismatch`).toHaveBeenWarned()
+    expect(`Hydration text mismatch`).toHaveBeenWarned()
+    expect(formatHtml(container.innerHTML)).toMatchInlineSnapshot(
+      `
+      "
+      <!--[--><div>Before</div>
+      <!--[--><span>Hello</span>Tail<!--]-->
+      <div>After</div><!--]-->
+      "
+    `,
+    )
+
+    data.value.extra = 'Tail updated'
+    await nextTick()
+
+    expect(formatHtml(container.innerHTML)).toMatchInlineSnapshot(
+      `
+      "
+      <!--[--><div>Before</div>
+      <!--[--><span>Hello</span>Tail updated<!--]-->
+      <div>After</div><!--]-->
+      "
+    `,
+    )
+  })
+
+  test('hydrate multi-root Vapor component should cleanup extra SSR text without crossing trailing sibling', async () => {
+    const data = ref({
+      msg: 'Hello',
+      extra: 'Tail',
+      after: 'After',
+    })
+
+    const childCode = `<script setup>
+        const data = _data
+      </script>
+      <template>
+        <span>{{ data.msg }}</span>{{ data.extra }}
+      </template>`
+
+    const appCode = `<script setup>
+        const components = _components
+        const data = _data
+      </script>
+      <template>
+        <div data-test="wrapper">
+          <components.Child />
+          <span>{{ data.after }}</span>
+        </div>
+      </template>`
+
+    const SSRChild = compileVaporComponent(childCode, data, undefined, true)
+    const SSRApp = compileVaporComponent(
+      appCode,
+      data,
+      { Child: SSRChild },
+      true,
+    )
+    const html = await VueServerRenderer.renderToString(
+      runtimeDom.createSSRApp(SSRApp),
+    )
+
+    data.value.extra = ''
+
+    const ClientChild = compileVaporComponent(childCode, data)
+    const ClientApp = compileVaporComponent(appCode, data, {
+      Child: ClientChild,
+    })
+
+    const container = document.createElement('div')
+    container.innerHTML = html
+    document.body.appendChild(container)
+    createVaporSSRApp(ClientApp).mount(container)
+
+    expect(`Hydration text mismatch`).toHaveBeenWarned()
+    expect(container.innerHTML).toBe(
+      '<div data-test="wrapper"><!--[--><span>Hello</span><!--]--><span>After</span></div>',
+    )
+
+    data.value.extra = 'Updated'
+    data.value.after = 'After updated'
+    await nextTick()
+
+    expect(container.innerHTML).toBe(
+      '<div data-test="wrapper"><!--[--><span>Hello</span>Updated<!--]--><span>After updated</span></div>',
+    )
+  })
+
   test('hydrate multi-root VDOM via mountVNode as non-first child', async () => {
     const MultiRootVDOM = {
       setup() {

--- a/packages/runtime-vapor/__tests__/hydration.spec.ts
+++ b/packages/runtime-vapor/__tests__/hydration.spec.ts
@@ -9201,6 +9201,60 @@ describe('VDOM interop', () => {
     )
   })
 
+  test('hydrate forwarded slot fallback with nested component before parent close marker', async () => {
+    const data = ref('foo')
+    const { container } = await testWithVaporApp(
+      `<script setup>
+        const components = _components
+      </script>
+      <template>
+        <components.Child>
+          <template #foo><slot name="foo" /></template>
+        </components.Child>
+      </template>`,
+      {
+        Child: {
+          code: `<script setup>
+              const components = _components
+              const data = _data
+            </script>
+            <template>
+              <div>
+                <slot name="foo">
+                  <components.GrandChild
+                    v-if="data"
+                    :text="data"
+                  />
+                </slot>
+              </div>
+            </template>`,
+          vapor: true,
+        },
+        GrandChild: {
+          code: `<script setup>
+              defineProps(['text'])
+            </script>
+            <template>
+              <template v-if="text">
+                <span v-if="text">{{ text }}</span>
+              </template>
+            </template>`,
+          vapor: true,
+        },
+      },
+      data,
+    )
+
+    expect(`Hydration node mismatch`).not.toHaveBeenWarned()
+    expect(formatHtml(container.innerHTML)).toMatchInlineSnapshot(`
+      "<div>
+      <!--[-->
+      <!--[--><span>foo</span><!--if--><!--if--><!--if--><!--]-->
+      <!--slot--><!--]-->
+      </div>"
+    `)
+  })
+
   test('hydrate VDOM component returning Fragment', async () => {
     const data = ref('foo')
     const { container } = await testWithVaporApp(

--- a/packages/runtime-vapor/__tests__/hydration.spec.ts
+++ b/packages/runtime-vapor/__tests__/hydration.spec.ts
@@ -4611,9 +4611,9 @@ describe('Vapor Mode hydration', () => {
       clientResolve(Comp)
       await new Promise(r => setTimeout(r))
 
-      // prevent lazy hydration since the component has been patched
-      expect('Skipping lazy hydration for component').toHaveBeenWarned()
-      expect(`Hydration node mismatch`).not.toHaveBeenWarned()
+      // vapor lazy hydration always proceeds; drift is corrected by the
+      // mismatch handling path.
+      expect(`Hydration text mismatch`).toHaveBeenWarned()
       expect(container.innerHTML).toMatchInlineSnapshot(
         `"<h1>Updated async component</h1><!--async component-->"`,
       )
@@ -4684,12 +4684,196 @@ describe('Vapor Mode hydration', () => {
       clientResolve(Comp)
       await new Promise(r => setTimeout(r))
 
-      // prevent lazy hydration since the component has been patched
-      expect('Skipping lazy hydration for component').toHaveBeenWarned()
-      expect(`Hydration node mismatch`).not.toHaveBeenWarned()
+      // vapor lazy hydration always proceeds; drift is corrected by the
+      // mismatch handling path.
+      expect(`Hydration text mismatch`).toHaveBeenWarned()
       expect(container.innerHTML).toMatchInlineSnapshot(
-        `"<!--[--><h1>Updated async component</h1><h2>fragment root</h2><!--async component--><!--]-->"`,
+        `"<!--[--><h1>Updated async component</h1><h2>fragment root</h2><!--]--><!--async component-->"`,
       )
+    })
+
+    test('update async component fallthrough attrs after parent mount before async component resolve', async () => {
+      const data = ref({
+        cls: 'foo',
+      })
+      const compCode = `<div>Async component</div>`
+      const SSRComp = compileVaporComponent(
+        compCode,
+        undefined,
+        undefined,
+        true,
+      )
+      let serverResolve: any
+      let AsyncComp = defineAsyncComponent(
+        () =>
+          new Promise(r => {
+            serverResolve = r
+          }),
+      )
+      const appCode = `<components.AsyncComp :class="data.cls"/>`
+      const SSRApp = compileVaporComponent(appCode, data, { AsyncComp }, true)
+
+      const htmlPromise = VueServerRenderer.renderToString(
+        runtimeDom.createSSRApp(SSRApp),
+      )
+      serverResolve(SSRComp)
+      const html = await htmlPromise
+      expect(html).toMatchInlineSnapshot(
+        `"<div class=\"foo\">Async component</div>"`,
+      )
+
+      let clientResolve: any
+      AsyncComp = defineVaporAsyncComponent(
+        () =>
+          new Promise(r => {
+            clientResolve = r
+          }),
+      ) as any
+
+      const Comp = compileVaporComponent(compCode)
+      const App = compileVaporComponent(appCode, data, { AsyncComp })
+
+      const container = document.createElement('div')
+      container.innerHTML = html
+      document.body.appendChild(container)
+      createVaporSSRApp(App).mount(container)
+
+      data.value.cls = 'bar'
+      await nextTick()
+
+      clientResolve(Comp)
+      await new Promise(r => setTimeout(r))
+
+      expect(`Hydration class mismatch`).toHaveBeenWarned()
+      expect(container.innerHTML).toMatchInlineSnapshot(
+        `"<div class="foo bar">Async component</div><!--async component-->"`,
+      )
+    })
+
+    test('update async component slot content after parent mount before async component resolve', async () => {
+      const data = ref({
+        msg: 'foo',
+      })
+      const compCode = `<div><slot/></div>`
+      const SSRComp = compileVaporComponent(
+        compCode,
+        undefined,
+        undefined,
+        true,
+      )
+      let serverResolve: any
+      let AsyncComp = defineAsyncComponent(
+        () =>
+          new Promise(r => {
+            serverResolve = r
+          }),
+      )
+      const appCode = `<components.AsyncComp><span>{{data.msg}}</span></components.AsyncComp>`
+      const SSRApp = compileVaporComponent(appCode, data, { AsyncComp }, true)
+
+      const htmlPromise = VueServerRenderer.renderToString(
+        runtimeDom.createSSRApp(SSRApp),
+      )
+      serverResolve(SSRComp)
+      const html = await htmlPromise
+      expect(formatHtml(html)).toMatchInlineSnapshot(`
+      	"<div>
+      	<!--[--><span>foo</span><!--]-->
+      	</div>"
+      `)
+
+      let clientResolve: any
+      AsyncComp = defineVaporAsyncComponent(
+        () =>
+          new Promise(r => {
+            clientResolve = r
+          }),
+      ) as any
+
+      const Comp = compileVaporComponent(compCode)
+      const App = compileVaporComponent(appCode, data, { AsyncComp })
+
+      const container = document.createElement('div')
+      container.innerHTML = html
+      document.body.appendChild(container)
+      createVaporSSRApp(App).mount(container)
+
+      data.value.msg = 'bar'
+      await nextTick()
+
+      clientResolve(Comp)
+      await new Promise(r => setTimeout(r))
+
+      expect(`Hydration text mismatch`).toHaveBeenWarned()
+      expect(formatHtml(container.innerHTML)).toMatchInlineSnapshot(`
+      	"<div>
+      	<!--[--><span>bar</span><!--]-->
+      	</div><!--async component-->"
+      `)
+    })
+
+    test.todo('update async component slot structure after parent mount before async component resolve', async () => {
+      const data = ref({
+        show: false,
+        msg: 'bar',
+      })
+      const compCode = `<div><slot/></div>`
+      const SSRComp = compileVaporComponent(
+        compCode,
+        undefined,
+        undefined,
+        true,
+      )
+      let serverResolve: any
+      let AsyncComp = defineAsyncComponent(
+        () =>
+          new Promise(r => {
+            serverResolve = r
+          }),
+      )
+      const appCode = `<components.AsyncComp><span v-if="data.show">{{data.msg}}</span></components.AsyncComp>`
+      const SSRApp = compileVaporComponent(appCode, data, { AsyncComp }, true)
+
+      const htmlPromise = VueServerRenderer.renderToString(
+        runtimeDom.createSSRApp(SSRApp),
+      )
+      serverResolve(SSRComp)
+      const html = await htmlPromise
+      expect(formatHtml(html)).toMatchInlineSnapshot(`
+      	"<div>
+      	<!--[--><!--]-->
+      	</div>"
+      `)
+
+      let clientResolve: any
+      AsyncComp = defineVaporAsyncComponent(
+        () =>
+          new Promise(r => {
+            clientResolve = r
+          }),
+      ) as any
+
+      const Comp = compileVaporComponent(compCode)
+      const App = compileVaporComponent(appCode, data, { AsyncComp })
+
+      const container = document.createElement('div')
+      container.innerHTML = html
+      document.body.appendChild(container)
+      createVaporSSRApp(App).mount(container)
+
+      data.value.show = true
+      await nextTick()
+
+      clientResolve(Comp)
+      await new Promise(r => setTimeout(r))
+
+      expect(`Hydration node mismatch`).toHaveBeenWarned()
+      expect(`Hydration text mismatch`).toHaveBeenWarned()
+      expect(formatHtml(container.innerHTML)).toMatchInlineSnapshot(`
+      	"<div>
+      	<!--[--><span>bar</span><!--if--><!--]-->
+      	</div><!--async component-->"
+      `)
     })
 
     describe('suspense', () => {

--- a/packages/runtime-vapor/__tests__/hydration.spec.ts
+++ b/packages/runtime-vapor/__tests__/hydration.spec.ts
@@ -3157,6 +3157,35 @@ describe('Vapor Mode hydration', () => {
       )
     })
 
+    test('hydrate non-empty v-for over empty SSR range with trailing sibling', async () => {
+      const ssrData = ref({
+        items: [] as string[],
+        tail: 'tail',
+      })
+      const clientData = ref({
+        items: ['foo', 'bar'],
+        tail: 'tail',
+      })
+      const code = `
+        <div>
+          <span v-for="item in data.items" :key="item">{{ item }}</span>
+          <i>{{ data.tail }}</i>
+        </div>
+      `
+      const SSRComp = compileVaporComponent(code, ssrData, undefined, true)
+      const html = await VueServerRenderer.renderToString(
+        runtimeDom.createSSRApp(SSRComp),
+      )
+
+      const { container } = await mountWithHydration(html, code, clientData)
+
+      expect(`Hydration node mismatch`).toHaveBeenWarned()
+      expect(`Hydration text mismatch`).toHaveBeenWarned()
+      expect(formatHtml(container.innerHTML)).toMatchInlineSnapshot(
+        `"<div>\n<!--[--><span>foo</span><span>bar</span><!--]-->\n<i>tail</i></div>"`,
+      )
+    })
+
     test('slot fallback from invalid v-for branch', async () => {
       const data = reactive({
         items: [{ text: 'bar', show: false }],

--- a/packages/runtime-vapor/__tests__/hydration.spec.ts
+++ b/packages/runtime-vapor/__tests__/hydration.spec.ts
@@ -4413,6 +4413,85 @@ describe('Vapor Mode hydration', () => {
       expect('Failed to locate Teleport target').toHaveBeenWarned()
     })
 
+    test('disabled teleport with null target should preserve trailing sibling when re-enabled without target', async () => {
+      const data = ref({
+        disabled: true,
+        target: undefined as string | undefined,
+        tail: 'tail',
+      })
+
+      const { container } = await mountWithHydration(
+        '<!--[--><!--teleport start--><div>content</div><!--teleport end--><span>tail</span><!--]-->',
+        `<teleport :to="data.target" :disabled="data.disabled">
+          <div>content</div>
+        </teleport>
+        <span>{{data.tail}}</span>`,
+        data,
+      )
+
+      expect(container.innerHTML).toBe(
+        '<!--[--><!--teleport start--><div>content</div><!--teleport end--><span>tail</span><!--]-->',
+      )
+      expect(`Hydration text mismatch`).not.toHaveBeenWarned()
+
+      data.value.tail = 'tail-updated'
+      await nextTick()
+      expect(container.innerHTML).toBe(
+        '<!--[--><!--teleport start--><div>content</div><!--teleport end--><span>tail-updated</span><!--]-->',
+      )
+      expect('Invalid Teleport target').not.toHaveBeenWarned()
+
+      data.value.disabled = false
+      await nextTick()
+      expect('Invalid Teleport target').toHaveBeenWarned()
+      expect(container.innerHTML).toBe(
+        '<!--[--><!--teleport start--><!--teleport end--><span>tail-updated</span><!--]-->',
+      )
+    })
+
+    test('enabled teleport with null target should preserve trailing sibling when toggling disabled', async () => {
+      const data = ref({
+        disabled: false,
+        target: '#non-existent-target-hydrate-sibling' as string | undefined,
+        tail: 'tail',
+      })
+
+      const { container } = await mountWithHydration(
+        '<!--[--><!--teleport start--><!--teleport end--><span>tail</span><!--]-->',
+        `<teleport :to="data.target" :disabled="data.disabled">
+          <div>content</div>
+        </teleport>
+        <span>{{data.tail}}</span>`,
+        data,
+      )
+
+      expect(container.innerHTML).toBe(
+        '<!--[--><!--teleport start--><!--teleport end--><span>tail</span><!--]-->',
+      )
+      expect('Failed to locate Teleport target').toHaveBeenWarned()
+
+      data.value.tail = 'tail-updated'
+      await nextTick()
+      expect(container.innerHTML).toBe(
+        '<!--[--><!--teleport start--><!--teleport end--><span>tail-updated</span><!--]-->',
+      )
+
+      data.value.disabled = true
+      data.value.target = undefined
+      await nextTick()
+      expect(container.innerHTML).toBe(
+        '<!--[--><!--teleport start--><div>content</div><!--teleport end--><span>tail-updated</span><!--]-->',
+      )
+
+      data.value.disabled = false
+      data.value.target = '#non-existent-target-hydrate-sibling'
+      await nextTick()
+      expect('Invalid Teleport target on mount').toHaveBeenWarned()
+      expect(container.innerHTML).toBe(
+        '<!--[--><!--teleport start--><!--teleport end--><span>tail-updated</span><!--]-->',
+      )
+    })
+
     test('enabled teleport with null target should delay child setup until target becomes available', async () => {
       const version = ref('one')
       const target = ref<any>('#non-existent-target-hydrate-late')

--- a/packages/runtime-vapor/__tests__/hydration.spec.ts
+++ b/packages/runtime-vapor/__tests__/hydration.spec.ts
@@ -4398,6 +4398,63 @@ describe('Vapor Mode hydration', () => {
       expect(teleport.targetAnchor).toBeNull()
     })
 
+    test('enabled teleport hydration should preserve existing target end anchor when target is empty', async () => {
+      const data = ref({ msg: 'foo' })
+
+      const teleportContainer = document.createElement('div')
+      teleportContainer.id = 'teleport-empty-anchors'
+      teleportContainer.innerHTML =
+        `<!--teleport start anchor-->` + `<!--teleport anchor-->`
+      document.body.appendChild(teleportContainer)
+
+      const { container } = await mountWithHydration(
+        '<!--teleport start--><!--teleport end-->',
+        `<teleport to="#teleport-empty-anchors">
+          <span>{{data.msg}}</span>
+        </teleport>`,
+        data,
+      )
+
+      expect(container.innerHTML).toBe(
+        `<!--teleport start--><!--teleport end-->`,
+      )
+      expect(`Hydration node mismatch`).toHaveBeenWarned()
+      expect(`Hydration text mismatch`).toHaveBeenWarned()
+      expect(teleportContainer.innerHTML).toBe(
+        `<!--teleport start anchor--><span>foo</span><!--teleport anchor-->`,
+      )
+
+      data.value.msg = 'bar'
+      await nextTick()
+      expect(teleportContainer.innerHTML).toBe(
+        `<!--teleport start anchor--><span>bar</span><!--teleport anchor-->`,
+      )
+    })
+
+    test('disabled teleport hydration over empty main-view range should preserve teleport end anchor', async () => {
+      const data = ref({ msg: 'foo' })
+
+      const { container } = await mountWithHydration(
+        '<!--teleport start--><!--teleport end-->',
+        `<teleport :to="undefined" :disabled="true">
+          <span>{{data.msg}}</span>
+        </teleport>`,
+        data,
+      )
+
+      expect(`Hydration node mismatch`).toHaveBeenWarned()
+      expect(`Hydration text mismatch`).toHaveBeenWarned()
+      expect(container.innerHTML).toBe(
+        `<!--teleport start--><span>foo</span><!--teleport end-->`,
+      )
+
+      data.value.msg = 'bar'
+      await nextTick()
+      expect(container.innerHTML).toBe(
+        `<!--teleport start--><span>bar</span><!--teleport end-->`,
+      )
+    })
+
     test('enabled teleport with null target', async () => {
       const { container } = await mountWithHydration(
         '<!--teleport start--><!--teleport end-->',

--- a/packages/runtime-vapor/__tests__/hydration.spec.ts
+++ b/packages/runtime-vapor/__tests__/hydration.spec.ts
@@ -4970,8 +4970,160 @@ describe('Vapor Mode hydration', () => {
       `)
     })
 
+    test('update async component slot content from empty v-for branch with trailing sibling after parent mount before async component resolve', async () => {
+      const data = ref({
+        items: [] as string[],
+        tail: 'tail',
+      })
+      const compCode = `<div><slot/></div>`
+      const SSRComp = compileVaporComponent(
+        compCode,
+        undefined,
+        undefined,
+        true,
+      )
+      let serverResolve: any
+      let AsyncComp = defineAsyncComponent(
+        () =>
+          new Promise(r => {
+            serverResolve = r
+          }),
+      )
+      const appCode = `<components.AsyncComp><span v-for="item in data.items" :key="item">{{item}}</span><i>{{data.tail}}</i></components.AsyncComp>`
+      const SSRApp = compileVaporComponent(appCode, data, { AsyncComp }, true)
+
+      const htmlPromise = VueServerRenderer.renderToString(
+        runtimeDom.createSSRApp(SSRApp),
+      )
+      serverResolve(SSRComp)
+      const html = await htmlPromise
+
+      let clientResolve: any
+      AsyncComp = defineVaporAsyncComponent(
+        () =>
+          new Promise(r => {
+            clientResolve = r
+          }),
+      ) as any
+
+      const Comp = compileVaporComponent(compCode)
+      const App = compileVaporComponent(appCode, data, { AsyncComp })
+
+      const container = document.createElement('div')
+      container.innerHTML = html
+      document.body.appendChild(container)
+      createVaporSSRApp(App).mount(container)
+
+      data.value.items = ['foo', 'bar']
+      await nextTick()
+
+      clientResolve(Comp)
+      await new Promise(r => setTimeout(r))
+
+      expect(`Hydration node mismatch`).toHaveBeenWarned()
+      expect(`Hydration text mismatch`).toHaveBeenWarned()
+      expect(formatHtml(container.innerHTML)).toMatchInlineSnapshot(`
+      	"<div>
+      	<!--[-->
+      	<!--[--><span>foo</span><span>bar</span><!--]-->
+      	<i>tail</i><!--]-->
+      	</div><!--async component-->"
+      `)
+    })
+
     describe('suspense', () => {
       describe('VDOM suspense', () => {
+        test('hydrate VDOM Suspense vapor async setup updates empty v-for before trailing sibling', async () => {
+          const data = ref({
+            items: [] as string[],
+            tail: 'tail',
+          })
+          const vaporChildCode = `
+            <script vapor>
+              import { onMounted } from 'vue'
+              const data = _data
+              onMounted(() => {
+                data.value.items = ['foo', 'bar']
+              })
+              await new Promise(r => setTimeout(r, 10))
+            </script>
+            <template>
+              <div>
+                <span v-for="item in data.items" :key="item">{{ item }}</span>
+                <i>{{ data.tail }}</i>
+              </div>
+            </template>
+          `
+          const appCode = `
+            <script setup>
+              import { Suspense } from 'vue'
+              const components = _components
+            </script>
+            <template>
+              <Suspense>
+                <components.VaporChild />
+              </Suspense>
+            </template>
+          `
+
+          const serverComponents: any = {}
+          const clientComponents: any = {}
+          serverComponents.VaporChild = compile(
+            vaporChildCode,
+            data,
+            serverComponents,
+            {
+              vapor: true,
+              ssr: true,
+            },
+          )
+          clientComponents.VaporChild = compile(
+            vaporChildCode,
+            data,
+            clientComponents,
+            {
+              vapor: true,
+              ssr: false,
+            },
+          )
+          const serverComp = compile(appCode, data, serverComponents, {
+            vapor: false,
+            ssr: true,
+          })
+
+          const html = await VueServerRenderer.renderToString(
+            runtimeDom.createSSRApp(serverComp),
+          )
+          expect(formatHtml(html)).toMatchInlineSnapshot(`
+          	"<div>
+          	<!--[--><!--]-->
+          	<i>tail</i></div>"
+          `)
+
+          const container = document.createElement('div')
+          document.body.appendChild(container)
+          container.innerHTML = html
+
+          const clientComp = compile(appCode, data, clientComponents, {
+            vapor: false,
+            ssr: false,
+          })
+          const app = runtimeDom.createSSRApp(clientComp)
+          app.use(runtimeVapor.vaporInteropPlugin)
+          app.mount(container)
+
+          await new Promise(r => setTimeout(r, 20))
+          await nextTick()
+
+          expect(`Hydration node mismatch`).not.toHaveBeenWarned()
+          expect(`Hydration text mismatch`).not.toHaveBeenWarned()
+          expect(formatHtml(container.innerHTML)).toMatchInlineSnapshot(`
+          	"<div>
+          	<!--[--><span>foo</span><span>bar</span><!--]-->
+          	<i>tail</i></div>"
+          `)
+        })
+
         test('hydrate VDOM Suspense vapor async setup should not enter mount hooks twice', async () => {
           const beforeMount = vi.fn()
           const data = ref({ beforeMount })

--- a/packages/runtime-vapor/__tests__/hydration.spec.ts
+++ b/packages/runtime-vapor/__tests__/hydration.spec.ts
@@ -5333,6 +5333,101 @@ describe('Vapor Mode hydration', () => {
           expect(beforeMount).toHaveBeenCalledTimes(1)
         })
 
+        test('hydrate VDOM Suspense vapor async multi-root setup should preserve SSR range before resolve', async () => {
+          let resolveClient!: () => void
+          const serverData = ref({
+            wait: Promise.resolve(),
+            msg: 'one',
+          })
+          const clientData = ref({
+            wait: new Promise<void>(r => {
+              resolveClient = r
+            }),
+            msg: 'one',
+          })
+          const vaporChildCode = `
+            <script vapor>
+              const data = _data
+              await data.value.wait
+            </script>
+            <template>
+              <span>{{ data.msg }}</span>
+              <span>two</span>
+            </template>
+          `
+          const appCode = `
+            <script setup>
+              import { Suspense } from 'vue'
+              const components = _components
+            </script>
+            <template>
+              <Suspense>
+                <div>
+                  <components.VaporChild />
+                  <i>after</i>
+                </div>
+              </Suspense>
+            </template>
+          `
+
+          const serverComponents: any = {}
+          const clientComponents: any = {}
+          serverComponents.VaporChild = compile(
+            vaporChildCode,
+            serverData,
+            serverComponents,
+            {
+              vapor: true,
+              ssr: true,
+            },
+          )
+          clientComponents.VaporChild = compile(
+            vaporChildCode,
+            clientData,
+            clientComponents,
+            {
+              vapor: true,
+              ssr: false,
+            },
+          )
+          const serverApp = compile(appCode, serverData, serverComponents, {
+            vapor: false,
+            ssr: true,
+          })
+          const html = await VueServerRenderer.renderToString(
+            runtimeDom.createSSRApp(serverApp),
+          )
+
+          const clientApp = compile(appCode, clientData, clientComponents, {
+            vapor: false,
+            ssr: false,
+          })
+          const container = document.createElement('div')
+          container.innerHTML = html
+          document.body.appendChild(container)
+
+          const app = runtimeDom.createSSRApp(clientApp)
+          app.use(runtimeVapor.vaporInteropPlugin)
+          app.mount(container)
+
+          expect(container.querySelectorAll('span')).toHaveLength(2)
+          expect(container.textContent).toBe('onetwoafter')
+          expect(`Hydration node mismatch`).not.toHaveBeenWarned()
+          expect(`Hydration children mismatch`).not.toHaveBeenWarned()
+
+          resolveClient()
+          await new Promise(r => setTimeout(r))
+          await nextTick()
+
+          expect(`Hydration node mismatch`).not.toHaveBeenWarned()
+          expect(`Hydration children mismatch`).not.toHaveBeenWarned()
+          expect(formatHtml(container.innerHTML)).toMatchInlineSnapshot(`
+            "<div>
+            <!--[--><span>one</span><span>two</span><!--]-->
+            <i>after</i></div>"
+          `)
+        })
+
         test('hydrate safely when property used by async setup changed before render', async () => {
           const data = ref({ toggle: true })
           const vaporChildCode = `

--- a/packages/runtime-vapor/src/apiCreateFor.ts
+++ b/packages/runtime-vapor/src/apiCreateFor.ts
@@ -30,6 +30,7 @@ import {
   isHydrating,
   locateHydrationNode,
   locateNextNode,
+  markHydrationAnchor,
   setCurrentHydrationNode,
 } from './dom/hydration'
 import {
@@ -118,57 +119,73 @@ export const createFor = (
 
     if (!isMounted) {
       isMounted = true
-      let nextNode
-      const hydrationStart = isHydrating ? currentHydrationNode : null
-      for (let i = 0; i < newLength; i++) {
-        if (isHydrating) nextNode = locateNextNode(currentHydrationNode!)
-        mount(source, i)
-        if (isHydrating && nextNode) setCurrentHydrationNode(nextNode)
-      }
-
       if (isHydrating) {
-        // Slot fallback can fall through an empty/invalid `v-for`. In that
-        // case SSR only rendered the parent slot range, so this `v-for` has no
-        // own `<!--]-->` to reuse. If `hydrationStart` is not the parent slot
-        // end anchor, use `hydrationStart.nextSibling` as the insertion anchor
-        // so the runtime `<!--for-->` lands immediately after that local SSR
-        // range. Otherwise insert it before the parent slot end anchor.
-        if (
-          currentEmptyFragment !== undefined &&
-          !isValidBlock(newBlocks) &&
-          currentSlotEndAnchor
-        ) {
-          const anchor =
-            // The invalid list still consumed local SSR item ranges.
-            currentHydrationNode !== hydrationStart
-              ? currentHydrationNode!
-              : // Empty source with trailing slot siblings.
-                hydrationStart !== currentSlotEndAnchor
-                ? hydrationStart!.nextSibling!
-                : currentSlotEndAnchor
-          parentAnchor = __DEV__ ? createComment('for') : createTextNode()
-          pendingHydrationAnchor = true
-          setCurrentHydrationNode(hydrationStart)
-          queuePostFlushCb(() =>
-            anchor.parentNode!.insertBefore(parentAnchor, anchor),
-          )
+        const hydrationStart = currentHydrationNode!
+        let nextNode
+        const emptyLocalRange =
+          isComment(hydrationStart, ']') &&
+          isComment(hydrationStart.previousSibling!, '[')
+
+        if (emptyLocalRange && newLength) {
+          parentAnchor = markHydrationAnchor(hydrationStart)
+          for (let i = 0; i < newLength; i++) {
+            mount(source, i)
+          }
+          setCurrentHydrationNode(parentAnchor)
         } else {
-          parentAnchor = currentHydrationNode!
-          if (
-            __DEV__ &&
-            (!parentAnchor || (parentAnchor && !isComment(parentAnchor, ']')))
-          ) {
-            throw new Error(
-              `v-for fragment anchor node was not found. this is likely a Vue internal bug.`,
-            )
+          for (let i = 0; i < newLength; i++) {
+            nextNode = locateNextNode(currentHydrationNode!)
+            mount(source, i)
+            if (nextNode) setCurrentHydrationNode(nextNode)
           }
 
-          // optimization: cache the fragment end anchor as $llc (last logical child)
-          // so that locateChildByLogicalIndex can skip the entire fragment
-          if (_insertionParent && isComment(parentAnchor, ']')) {
-            ;(parentAnchor as any as ChildItem).$idx = _insertionIndex || 0
-            _insertionParent.$llc = parentAnchor
+          // Slot fallback can fall through an empty/invalid `v-for`. In that
+          // case SSR only rendered the parent slot range, so this `v-for` has no
+          // own `<!--]-->` to reuse. If `hydrationStart` is not the parent slot
+          // end anchor, use `hydrationStart.nextSibling` as the insertion anchor
+          // so the runtime `<!--for-->` lands immediately after that local SSR
+          // range. Otherwise insert it before the parent slot end anchor.
+          if (
+            currentEmptyFragment !== undefined &&
+            !isValidBlock(newBlocks) &&
+            currentSlotEndAnchor
+          ) {
+            const anchor =
+              // The invalid list still consumed local SSR item ranges.
+              currentHydrationNode !== hydrationStart
+                ? currentHydrationNode!
+                : // Empty source with trailing slot siblings.
+                  hydrationStart !== currentSlotEndAnchor
+                  ? hydrationStart.nextSibling!
+                  : currentSlotEndAnchor
+            parentAnchor = __DEV__ ? createComment('for') : createTextNode()
+            pendingHydrationAnchor = true
+            setCurrentHydrationNode(hydrationStart)
+            queuePostFlushCb(() =>
+              anchor.parentNode!.insertBefore(parentAnchor, anchor),
+            )
+          } else {
+            parentAnchor = currentHydrationNode!
+            if (
+              __DEV__ &&
+              (!parentAnchor || (parentAnchor && !isComment(parentAnchor, ']')))
+            ) {
+              throw new Error(
+                `v-for fragment anchor node was not found. this is likely a Vue internal bug.`,
+              )
+            }
+
+            // optimization: cache the fragment end anchor as $llc (last logical child)
+            // so that locateChildByLogicalIndex can skip the entire fragment
+            if (_insertionParent && isComment(parentAnchor, ']')) {
+              ;(parentAnchor as any as ChildItem).$idx = _insertionIndex || 0
+              _insertionParent.$llc = parentAnchor
+            }
           }
+        }
+      } else {
+        for (let i = 0; i < newLength; i++) {
+          mount(source, i)
         }
       }
     } else {

--- a/packages/runtime-vapor/src/apiCreateFor.ts
+++ b/packages/runtime-vapor/src/apiCreateFor.ts
@@ -26,8 +26,10 @@ import { VaporVForFlags } from '@vue/shared'
 import {
   advanceHydrationNode,
   currentHydrationNode,
+  enterHydrationBoundary,
   isComment,
   isHydrating,
+  locateHydrationBoundaryClose,
   locateHydrationNode,
   locateNextNode,
   markHydrationAnchor,
@@ -121,67 +123,82 @@ export const createFor = (
       isMounted = true
       if (isHydrating) {
         const hydrationStart = currentHydrationNode!
+        let exitHydrationBoundary: (() => void) | undefined
         let nextNode
         const emptyLocalRange =
           isComment(hydrationStart, ']') &&
           isComment(hydrationStart.previousSibling!, '[')
+        const slotFallbackRange =
+          currentEmptyFragment !== undefined && currentSlotEndAnchor
 
-        if (emptyLocalRange && newLength) {
-          parentAnchor = markHydrationAnchor(hydrationStart)
-          for (let i = 0; i < newLength; i++) {
-            mount(source, i)
-          }
-          setCurrentHydrationNode(parentAnchor)
-        } else {
-          for (let i = 0; i < newLength; i++) {
-            nextNode = locateNextNode(currentHydrationNode!)
-            mount(source, i)
-            if (nextNode) setCurrentHydrationNode(nextNode)
-          }
-
-          // Slot fallback can fall through an empty/invalid `v-for`. In that
-          // case SSR only rendered the parent slot range, so this `v-for` has no
-          // own `<!--]-->` to reuse. If `hydrationStart` is not the parent slot
-          // end anchor, use `hydrationStart.nextSibling` as the insertion anchor
-          // so the runtime `<!--for-->` lands immediately after that local SSR
-          // range. Otherwise insert it before the parent slot end anchor.
-          if (
-            currentEmptyFragment !== undefined &&
-            !isValidBlock(newBlocks) &&
-            currentSlotEndAnchor
-          ) {
-            const anchor =
-              // The invalid list still consumed local SSR item ranges.
-              currentHydrationNode !== hydrationStart
-                ? currentHydrationNode!
-                : // Empty source with trailing slot siblings.
-                  hydrationStart !== currentSlotEndAnchor
-                  ? hydrationStart.nextSibling!
-                  : currentSlotEndAnchor
-            parentAnchor = __DEV__ ? createComment('for') : createTextNode()
-            pendingHydrationAnchor = true
-            setCurrentHydrationNode(hydrationStart)
-            queuePostFlushCb(() =>
-              anchor.parentNode!.insertBefore(parentAnchor, anchor),
-            )
+        try {
+          if (emptyLocalRange && newLength) {
+            parentAnchor = markHydrationAnchor(hydrationStart)
+            exitHydrationBoundary = enterHydrationBoundary(parentAnchor)
+            for (let i = 0; i < newLength; i++) {
+              mount(source, i)
+            }
+            setCurrentHydrationNode(parentAnchor)
           } else {
-            parentAnchor = currentHydrationNode!
-            if (
-              __DEV__ &&
-              (!parentAnchor || (parentAnchor && !isComment(parentAnchor, ']')))
-            ) {
-              throw new Error(
-                `v-for fragment anchor node was not found. this is likely a Vue internal bug.`,
-              )
+            for (let i = 0; i < newLength; i++) {
+              if (isComment(currentHydrationNode!, ']')) {
+                nextNode = markHydrationAnchor(currentHydrationNode!)
+                setCurrentHydrationNode(nextNode)
+              } else {
+                nextNode = locateNextNode(currentHydrationNode!)
+              }
+              mount(source, i)
+              if (nextNode) setCurrentHydrationNode(nextNode)
             }
 
-            // optimization: cache the fragment end anchor as $llc (last logical child)
-            // so that locateChildByLogicalIndex can skip the entire fragment
-            if (_insertionParent && isComment(parentAnchor, ']')) {
-              ;(parentAnchor as any as ChildItem).$idx = _insertionIndex || 0
-              _insertionParent.$llc = parentAnchor
+            // Slot fallback can fall through an empty/invalid `v-for`. In that
+            // case SSR only rendered the parent slot range, so this `v-for` has no
+            // own `<!--]-->` to reuse. If `hydrationStart` is not the parent slot
+            // end anchor, use `hydrationStart.nextSibling` as the insertion point
+            // so the runtime `<!--for-->` lands immediately after that local SSR
+            // range. Otherwise insert it before the parent slot end anchor.
+            if (slotFallbackRange && !isValidBlock(newBlocks)) {
+              const anchor =
+                // The invalid list still consumed local SSR item ranges.
+                currentHydrationNode !== hydrationStart
+                  ? currentHydrationNode!
+                  : // Empty source with trailing slot siblings.
+                    hydrationStart !== currentSlotEndAnchor
+                    ? hydrationStart.nextSibling!
+                    : currentSlotEndAnchor!
+              parentAnchor = markHydrationAnchor(
+                __DEV__ ? createComment('for') : createTextNode(),
+              )
+              pendingHydrationAnchor = true
+              if (
+                currentHydrationNode === hydrationStart ||
+                currentHydrationNode === currentSlotEndAnchor
+              ) {
+                setCurrentHydrationNode(hydrationStart)
+              }
+              queuePostFlushCb(() =>
+                anchor.parentNode!.insertBefore(parentAnchor, anchor),
+              )
+            } else {
+              const close = locateHydrationBoundaryClose(currentHydrationNode!)
+              parentAnchor = markHydrationAnchor(close)
+              exitHydrationBoundary = enterHydrationBoundary(parentAnchor)
+              if (__DEV__ && !isComment(parentAnchor, ']')) {
+                throw new Error(
+                  `v-for fragment anchor node was not found. this is likely a Vue internal bug.`,
+                )
+              }
+
+              // optimization: cache the fragment end anchor as $llc (last logical child)
+              // so that locateChildByLogicalIndex can skip the entire fragment
+              if (_insertionParent && isComment(parentAnchor, ']')) {
+                ;(parentAnchor as any as ChildItem).$idx = _insertionIndex || 0
+                _insertionParent.$llc = parentAnchor
+              }
             }
           }
+        } finally {
+          exitHydrationBoundary && exitHydrationBoundary()
         }
       } else {
         for (let i = 0; i < newLength; i++) {

--- a/packages/runtime-vapor/src/apiDefineAsyncComponent.ts
+++ b/packages/runtime-vapor/src/apiDefineAsyncComponent.ts
@@ -9,7 +9,6 @@ import {
   performAsyncHydrate,
   setCurrentInstance,
   useAsyncComponentState,
-  watch,
 } from '@vue/runtime-dom'
 import { defineVaporComponent } from './apiDefineComponent'
 import {
@@ -24,12 +23,10 @@ import {
   isComment,
   isHydrating,
   locateEndAnchor,
-  removeFragmentNodes,
   setCurrentHydrationNode,
 } from './dom/hydration'
-import { type TransitionOptions, insert, remove } from './block'
-import { _next, parentNode } from './dom/node'
-import { invokeArrayFns } from '@vue/shared'
+import type { TransitionOptions } from './block'
+import { _next } from './dom/node'
 
 /*@ __NO_SIDE_EFFECTS__ */
 export function defineVaporAsyncComponent<T extends VaporComponent>(
@@ -92,45 +89,10 @@ export function defineVaporAsyncComponent<T extends VaporComponent>(
         isComment(el, '[') ? locateEndAnchor(el)! : el.nextSibling,
       )
 
-      // If async component needs to be updated before hydration, hydration is no longer needed.
-      let isHydrated = false
-      watch(
-        () => instance.attrs,
-        () => {
-          // early return if already hydrated
-          if (isHydrated) return
-
-          // call the beforeUpdate hook to avoid calling hydrate in performAsyncHydrate
-          instance.bu && invokeArrayFns(instance.bu)
-
-          // mount the inner component and remove the placeholder
-          const parent = parentNode(el)!
-          load().then(() => {
-            if (instance.isUnmounted) return
-            hydrate()
-            if (isComment(el, '[')) {
-              const endAnchor = locateEndAnchor(el)!
-              removeFragmentNodes(el, endAnchor)
-              insert(instance.block, parent, endAnchor)
-            } else {
-              insert(instance.block, parent, el)
-              remove(el, parent)
-            }
-          })
-        },
-        { deep: true, once: true },
-      )
-
       performAsyncHydrate(
         el,
         instance,
-        () => {
-          hydrateNode(el, () => {
-            hydrate()
-            insert(instance.block, parentNode(el)!, el)
-            isHydrated = true
-          })
-        },
+        () => hydrateNode(el, hydrate),
         getResolvedComp,
         load,
         hydrateStrategy,

--- a/packages/runtime-vapor/src/component.ts
+++ b/packages/runtime-vapor/src/component.ts
@@ -87,6 +87,7 @@ import {
   adoptTemplate,
   advanceHydrationNode,
   currentHydrationNode,
+  isComment,
   isHydrating,
   locateHydrationNode,
   locateNextNode,
@@ -763,6 +764,23 @@ export function createComponentWithFallback(
   appContext?: GenericAppContext,
 ): HTMLElement | VaporComponentInstance {
   if (comp === NULL_DYNAMIC_COMPONENT) {
+    if (isHydrating && currentHydrationNode) {
+      if (isReusableNullComponentAnchor(currentHydrationNode)) {
+        const node = currentHydrationNode
+        if (isComment(node, '')) {
+          advanceHydrationNode(node)
+        }
+        return node as any as HTMLElement
+      }
+
+      const nextAnchor = locateNextNode(currentHydrationNode)
+      if (nextAnchor && isReusableNullComponentAnchor(nextAnchor)) {
+        // Keep the cursor on the stale SSR node before `nextAnchor` so the
+        // owning DynamicFragment can trim that range on hydrate exit and then
+        // advance past the reused null-branch anchor in one place.
+        return nextAnchor as any as HTMLElement
+      }
+    }
     return (__DEV__
       ? createComment('ndc')
       : createTextNode('')) as any as HTMLElement
@@ -780,6 +798,15 @@ export function createComponentWithFallback(
   }
 
   return createPlainElement(comp, rawProps, rawSlots, isSingleRoot, once)
+}
+
+function isReusableNullComponentAnchor(node: Node): boolean {
+  return (
+    isComment(node, '') ||
+    isComment(node, 'dynamic-component') ||
+    isComment(node, 'async component') ||
+    isComment(node, 'keyed')
+  )
 }
 
 export function createPlainElement(

--- a/packages/runtime-vapor/src/component.ts
+++ b/packages/runtime-vapor/src/component.ts
@@ -87,10 +87,13 @@ import {
   adoptTemplate,
   advanceHydrationNode,
   currentHydrationNode,
+  enterHydrationBoundary,
   isComment,
   isHydrating,
+  locateEndAnchor,
   locateHydrationNode,
   locateNextNode,
+  markHydrationAnchor,
   setCurrentHydrationNode,
 } from './dom/hydration'
 import { createComment, createElement, createTextNode } from './dom/node'
@@ -245,156 +248,174 @@ export function createComponent(
   const _insertionParent = insertionParent
   const _insertionAnchor = insertionAnchor
   const _isLastInsertion = isLastInsertion
+  let hydrationClose: Node | null = null
+  let exitHydrationBoundary: (() => void) | undefined
   if (isHydrating) {
-    locateHydrationNode(component.__multiRoot)
+    locateHydrationNode()
+    if (component.__multiRoot && isComment(currentHydrationNode!, '[')) {
+      hydrationClose = locateEndAnchor(currentHydrationNode!)
+      exitHydrationBoundary = enterHydrationBoundary(
+        hydrationClose && markHydrationAnchor(hydrationClose),
+      )
+      setCurrentHydrationNode(currentHydrationNode!.nextSibling)
+    }
   } else {
     resetInsertionState()
   }
 
-  let prevSuspense: SuspenseBoundary | null = null
-  if (__FEATURE_SUSPENSE__ && currentInstance && currentInstance.suspense) {
-    prevSuspense = setParentSuspense(currentInstance.suspense)
-  }
+  try {
+    let prevSuspense: SuspenseBoundary | null = null
+    if (__FEATURE_SUSPENSE__ && currentInstance && currentInstance.suspense) {
+      prevSuspense = setParentSuspense(currentInstance.suspense)
+    }
 
-  if (
-    (isSingleRoot ||
-      // transition has attrs fallthrough
-      (currentInstance && isVaporTransition(currentInstance!.type))) &&
-    component.inheritAttrs !== false &&
-    isVaporComponent(currentInstance) &&
-    currentInstance.hasFallthrough
-  ) {
-    // check if we are the single root of the parent
-    // if yes, inject parent attrs as dynamic props source
-    const attrs = currentInstance.attrs
-    if (rawProps && rawProps !== EMPTY_OBJ) {
-      ;((rawProps as RawProps).$ || ((rawProps as RawProps).$ = [])).push(
-        () => attrs,
+    if (
+      (isSingleRoot ||
+        // transition has attrs fallthrough
+        (currentInstance && isVaporTransition(currentInstance!.type))) &&
+      component.inheritAttrs !== false &&
+      isVaporComponent(currentInstance) &&
+      currentInstance.hasFallthrough
+    ) {
+      // check if we are the single root of the parent
+      // if yes, inject parent attrs as dynamic props source
+      const attrs = currentInstance.attrs
+      if (rawProps && rawProps !== EMPTY_OBJ) {
+        ;((rawProps as RawProps).$ || ((rawProps as RawProps).$ = [])).push(
+          () => attrs,
+        )
+      } else {
+        rawProps = { $: [() => attrs] } as RawProps
+      }
+    }
+
+    // keep-alive
+    if (
+      currentInstance &&
+      currentInstance.vapor &&
+      isKeepAlive(currentInstance)
+    ) {
+      const cached = (
+        currentInstance as KeepAliveInstance
+      ).ctx.getCachedComponent(component)
+      // @ts-expect-error
+      if (cached) return cached
+    }
+
+    // vdom interop enabled and component is not an explicit vapor component
+    if (isInteropEnabled && appContext.vapor && !component.__vapor) {
+      const frag = appContext.vapor.vdomMount(
+        component as any,
+        currentInstance as any,
+        rawProps,
+        rawSlots,
+      )
+      if (!isHydrating) {
+        if (_insertionParent) insert(frag, _insertionParent, _insertionAnchor)
+      } else {
+        frag.hydrate()
+        if (_isLastInsertion) {
+          advanceHydrationNode(_insertionParent!)
+        }
+      }
+      return frag
+    }
+
+    // teleport
+    if (isVaporTeleport(component)) {
+      const frag = component.process(rawProps!, rawSlots!)
+      if (!isHydrating) {
+        if (_insertionParent) insert(frag, _insertionParent, _insertionAnchor)
+      } else {
+        frag.hydrate()
+        if (_isLastInsertion) {
+          advanceHydrationNode(_insertionParent!)
+        }
+      }
+
+      return frag as any
+    }
+
+    const instance = new VaporComponentInstance(
+      component,
+      rawProps as RawProps,
+      rawSlots as RawSlots,
+      appContext,
+      once,
+    )
+
+    // handle currentKeepAliveCtx for component boundary isolation
+    // AsyncWrapper should NOT clear currentKeepAliveCtx so its internal
+    // DynamicFragment can capture it
+    if (currentKeepAliveCtx && !isAsyncWrapper(instance)) {
+      currentKeepAliveCtx.processShapeFlag(instance)
+      // clear currentKeepAliveCtx so child components don't associate
+      // with parent's KeepAlive
+      setCurrentKeepAliveCtx(null)
+    }
+
+    // reset currentSlotOwner to null to avoid affecting the child components
+    const prevSlotOwner = setCurrentSlotOwner(null)
+
+    // HMR
+    if (__DEV__) {
+      registerHMR(instance)
+      instance.isSingleRoot = isSingleRoot
+      instance.hmrRerender = hmrRerender.bind(null, instance)
+      instance.hmrReload = hmrReload.bind(null, instance)
+
+      pushWarningContext(instance)
+      startMeasure(instance, `init`)
+
+      // cache normalized options for dev only emit check
+      instance.propsOptions = normalizePropsOptions(component)
+      instance.emitsOptions = normalizeEmitsOptions(component)
+    }
+
+    // hydrating async component
+    if (
+      isHydrating &&
+      isAsyncWrapper(instance) &&
+      component.__asyncHydrate &&
+      !component.__asyncResolved
+    ) {
+      component.__asyncHydrate(currentHydrationNode as Element, instance, () =>
+        setupComponent(instance, component),
       )
     } else {
-      rawProps = { $: [() => attrs] } as RawProps
+      setupComponent(instance, component)
     }
-  }
 
-  // keep-alive
-  if (
-    currentInstance &&
-    currentInstance.vapor &&
-    isKeepAlive(currentInstance)
-  ) {
-    const cached = (
-      currentInstance as KeepAliveInstance
-    ).ctx.getCachedComponent(component)
-    // @ts-expect-error
-    if (cached) return cached
-  }
+    if (__DEV__) {
+      popWarningContext()
+      endMeasure(instance, 'init')
+    }
 
-  // vdom interop enabled and component is not an explicit vapor component
-  if (isInteropEnabled && appContext.vapor && !component.__vapor) {
-    const frag = appContext.vapor.vdomMount(
-      component as any,
-      currentInstance as any,
-      rawProps,
-      rawSlots,
-    )
-    if (!isHydrating) {
-      if (_insertionParent) insert(frag, _insertionParent, _insertionAnchor)
-    } else {
-      frag.hydrate()
-      if (_isLastInsertion) {
-        advanceHydrationNode(_insertionParent!)
+    if (__FEATURE_SUSPENSE__ && currentInstance && currentInstance.suspense) {
+      setParentSuspense(prevSuspense)
+    }
+
+    // restore currentSlotOwner to previous value after setupFn is called
+    setCurrentSlotOwner(prevSlotOwner)
+    onScopeDispose(() => unmountComponent(instance), true)
+
+    if (!managedMount && (_insertionParent || isHydrating)) {
+      mountComponent(instance, _insertionParent!, _insertionAnchor)
+    }
+
+    if (isHydrating && _insertionAnchor !== undefined) {
+      advanceHydrationNode(_insertionParent!)
+    }
+
+    return instance
+  } finally {
+    if (isHydrating) {
+      exitHydrationBoundary && exitHydrationBoundary()
+      if (hydrationClose && currentHydrationNode === hydrationClose) {
+        advanceHydrationNode(hydrationClose)
       }
     }
-    return frag
   }
-
-  // teleport
-  if (isVaporTeleport(component)) {
-    const frag = component.process(rawProps!, rawSlots!)
-    if (!isHydrating) {
-      if (_insertionParent) insert(frag, _insertionParent, _insertionAnchor)
-    } else {
-      frag.hydrate()
-      if (_isLastInsertion) {
-        advanceHydrationNode(_insertionParent!)
-      }
-    }
-
-    return frag as any
-  }
-
-  const instance = new VaporComponentInstance(
-    component,
-    rawProps as RawProps,
-    rawSlots as RawSlots,
-    appContext,
-    once,
-  )
-
-  // handle currentKeepAliveCtx for component boundary isolation
-  // AsyncWrapper should NOT clear currentKeepAliveCtx so its internal
-  // DynamicFragment can capture it
-  if (currentKeepAliveCtx && !isAsyncWrapper(instance)) {
-    currentKeepAliveCtx.processShapeFlag(instance)
-    // clear currentKeepAliveCtx so child components don't associate
-    // with parent's KeepAlive
-    setCurrentKeepAliveCtx(null)
-  }
-
-  // reset currentSlotOwner to null to avoid affecting the child components
-  const prevSlotOwner = setCurrentSlotOwner(null)
-
-  // HMR
-  if (__DEV__) {
-    registerHMR(instance)
-    instance.isSingleRoot = isSingleRoot
-    instance.hmrRerender = hmrRerender.bind(null, instance)
-    instance.hmrReload = hmrReload.bind(null, instance)
-
-    pushWarningContext(instance)
-    startMeasure(instance, `init`)
-
-    // cache normalized options for dev only emit check
-    instance.propsOptions = normalizePropsOptions(component)
-    instance.emitsOptions = normalizeEmitsOptions(component)
-  }
-
-  // hydrating async component
-  if (
-    isHydrating &&
-    isAsyncWrapper(instance) &&
-    component.__asyncHydrate &&
-    !component.__asyncResolved
-  ) {
-    component.__asyncHydrate(currentHydrationNode as Element, instance, () =>
-      setupComponent(instance, component),
-    )
-  } else {
-    setupComponent(instance, component)
-  }
-
-  if (__DEV__) {
-    popWarningContext()
-    endMeasure(instance, 'init')
-  }
-
-  if (__FEATURE_SUSPENSE__ && currentInstance && currentInstance.suspense) {
-    setParentSuspense(prevSuspense)
-  }
-
-  // restore currentSlotOwner to previous value after setupFn is called
-  setCurrentSlotOwner(prevSlotOwner)
-  onScopeDispose(() => unmountComponent(instance), true)
-
-  if (!managedMount && (_insertionParent || isHydrating)) {
-    mountComponent(instance, _insertionParent!, _insertionAnchor)
-  }
-
-  if (isHydrating && _insertionAnchor !== undefined) {
-    advanceHydrationNode(_insertionParent!)
-  }
-
-  return instance
 }
 
 export function setupComponent(

--- a/packages/runtime-vapor/src/component.ts
+++ b/packages/runtime-vapor/src/component.ts
@@ -38,7 +38,7 @@ import {
   warn,
   warnExtraneousAttributes,
 } from '@vue/runtime-dom'
-import { type Block, insert, isBlock, remove } from './block'
+import { type Block, findBlockNode, insert, isBlock, remove } from './block'
 import {
   type ShallowRef,
   markRaw,
@@ -250,6 +250,13 @@ export function createComponent(
   const _isLastInsertion = isLastInsertion
   let hydrationClose: Node | null = null
   let exitHydrationBoundary: (() => void) | undefined
+  let deferHydrationBoundary = false
+  const finalizeHydrationBoundary = () => {
+    exitHydrationBoundary && exitHydrationBoundary()
+    if (hydrationClose && currentHydrationNode === hydrationClose) {
+      advanceHydrationNode(hydrationClose)
+    }
+  }
   if (isHydrating) {
     locateHydrationNode()
     if (component.__multiRoot && isComment(currentHydrationNode!, '[')) {
@@ -407,13 +414,31 @@ export function createComponent(
       advanceHydrationNode(_insertionParent!)
     }
 
+    if (
+      isHydrating &&
+      hydrationClose &&
+      instance.suspense &&
+      instance.asyncDep &&
+      !instance.asyncResolved &&
+      instance.restoreAsyncContext
+    ) {
+      deferHydrationBoundary = true
+      instance.deferredHydrationBoundary = () => {
+        if (
+          instance.block &&
+          hydrationClose &&
+          findBlockNode(instance.block).nextNode === hydrationClose.nextSibling
+        ) {
+          setCurrentHydrationNode(hydrationClose)
+        }
+        finalizeHydrationBoundary()
+      }
+    }
+
     return instance
   } finally {
-    if (isHydrating) {
-      exitHydrationBoundary && exitHydrationBoundary()
-      if (hydrationClose && currentHydrationNode === hydrationClose) {
-        advanceHydrationNode(hydrationClose)
-      }
+    if (isHydrating && !deferHydrationBoundary) {
+      finalizeHydrationBoundary()
     }
   }
 }
@@ -602,6 +627,7 @@ export class VaporComponentInstance<
   asyncDep: Promise<any> | null
   asyncResolved: boolean
   restoreAsyncContext?: () => void | (() => void)
+  deferredHydrationBoundary?: () => void
 
   // for vapor custom element
   renderEffects?: RenderEffect[]
@@ -923,7 +949,14 @@ export function mountComponent(
       try {
         handleSetupResult(setupResult, component, instance)
         mountComponent(instance, parent, anchor)
+        if (isHydrating) {
+          instance.deferredHydrationBoundary &&
+            instance.deferredHydrationBoundary()
+        }
       } finally {
+        if (isHydrating) {
+          instance.deferredHydrationBoundary = undefined
+        }
         instance.restoreAsyncContext = undefined
         if (reset) reset()
       }

--- a/packages/runtime-vapor/src/components/Teleport.ts
+++ b/packages/runtime-vapor/src/components/Teleport.ts
@@ -259,6 +259,20 @@ export class TeleportFragment extends VaporFragment {
     }
   }
 
+  private clearMainViewChildren(): void {
+    if (!this.placeholder || !this.anchor) return
+
+    let node = this.placeholder.nextSibling
+    while (node && node !== this.anchor) {
+      const next = node.nextSibling
+      remove(node, parentNode(node)!)
+      node = next
+    }
+
+    this.isMounted = false
+    this.mountContainer = null
+  }
+
   private handlePropsUpdate(): void {
     // not mounted yet
     if (!this.parent || isHydrating) return
@@ -270,6 +284,17 @@ export class TeleportFragment extends VaporFragment {
     }
     // mount into target container
     else {
+      // Align with initial enabled-null-target hydration: once Teleport leaves
+      // disabled mode, its children should no longer stay mounted inline in the
+      // main view if there is no valid target to move them into.
+      if (
+        this.placeholder &&
+        this.anchor &&
+        this.placeholder.nextSibling !== this.anchor
+      ) {
+        this.clearMainViewChildren()
+      }
+
       if (
         isTeleportDeferred(this.resolvedProps!) ||
         // force defer when the parent is not connected to the DOM,

--- a/packages/runtime-vapor/src/components/Teleport.ts
+++ b/packages/runtime-vapor/src/components/Teleport.ts
@@ -39,6 +39,7 @@ import {
   isComment,
   isHydrating,
   logMismatchError,
+  markHydrationAnchor,
   runWithoutHydration,
   setCurrentHydrationNode,
 } from '../dom/hydration'
@@ -386,7 +387,7 @@ export class TeleportFragment extends VaporFragment {
         if ((targetAnchor as Comment).data === 'teleport start anchor') {
           this.targetStart = targetAnchor
         } else if ((targetAnchor as Comment).data === 'teleport anchor') {
-          this.targetAnchor = targetAnchor
+          this.targetAnchor = markHydrationAnchor(targetAnchor)
           target._lpa = this.targetAnchor.nextSibling
           break
         }
@@ -402,7 +403,9 @@ export class TeleportFragment extends VaporFragment {
     if (!isHydrating) return
     let nextNode = this.placeholder!.nextSibling!
     setCurrentHydrationNode(nextNode)
-    this.mountAnchor = this.anchor = locateTeleportEndAnchor(nextNode)!
+    this.mountAnchor = this.anchor = markHydrationAnchor(
+      locateTeleportEndAnchor(nextNode)!,
+    )
     this.mountContainer = parentNode(this.anchor)
     if (target) {
       this.hydrateTargetAnchors(target, targetNode)
@@ -417,7 +420,8 @@ export class TeleportFragment extends VaporFragment {
     if (!isHydrating) return
     target.appendChild((this.targetStart = createTextNode('')))
     target.appendChild(
-      (this.mountAnchor = this.targetAnchor = createTextNode('')),
+      (this.mountAnchor = this.targetAnchor =
+        markHydrationAnchor(createTextNode(''))),
     )
 
     if (!isMismatchAllowed(target as Element, MismatchTypes.CHILDREN)) {
@@ -451,9 +455,9 @@ export class TeleportFragment extends VaporFragment {
           targetNode,
         )
       } else {
-        this.anchor = locateTeleportEndAnchor(
-          currentHydrationNode!.nextSibling!,
-        )!
+        this.anchor = markHydrationAnchor(
+          locateTeleportEndAnchor(currentHydrationNode!.nextSibling!)!,
+        )
         this.mountContainer = target
         this.hydrateTargetAnchors(target as TeleportTargetElement, targetNode)
         this.mountAnchor = this.targetAnchor
@@ -479,7 +483,9 @@ export class TeleportFragment extends VaporFragment {
       // Align with VDOM Teleport hydration: keep main-view markers only and
       // avoid mounting children inline or eagerly initializing them when the
       // target is missing.
-      this.anchor = locateTeleportEndAnchor(currentHydrationNode!.nextSibling!)!
+      this.anchor = markHydrationAnchor(
+        locateTeleportEndAnchor(currentHydrationNode!.nextSibling!)!,
+      )
     }
 
     if (target || disabled) {

--- a/packages/runtime-vapor/src/dom/hydration.ts
+++ b/packages/runtime-vapor/src/dom/hydration.ts
@@ -155,7 +155,7 @@ function adoptTemplateImpl(node: Node, template: string): Node | null {
       node.before((node = createTextNode()))
     }
 
-    node = resolveHydrationTarget(node, template)
+    node = resolveHydrationTarget(node)
   }
 
   const type = node.nodeType
@@ -236,6 +236,31 @@ export function locateEndAnchor(
   return null
 }
 
+// Find the SSR close marker for the current owner.
+export function locateHydrationBoundaryClose(
+  node: Node,
+  closeHint: Node | null = null,
+): Node {
+  let close = closeHint
+  if (!close || !isComment(close, ']')) {
+    if (isComment(node, ']')) {
+      close = node
+    } else {
+      let candidate = locateNextNode(node)
+      while (candidate && !isComment(candidate, ']')) {
+        candidate = locateNextNode(candidate)
+      }
+      close = candidate
+    }
+  }
+
+  if (!close) {
+    return node
+  }
+
+  return close
+}
+
 function handleMismatch(node: Node, template: string): Node {
   if (!isMismatchAllowed(node.parentElement!, MismatchTypes.CHILDREN)) {
     ;(__DEV__ || __FEATURE_PROD_HYDRATION_MISMATCH_DETAILS__) &&
@@ -295,15 +320,52 @@ export const logMismatchError = (): void => {
 }
 
 export function removeFragmentNodes(node: Node, endAnchor?: Node): void {
+  const parent = parentNode(node)
+  if (!parent) {
+    return
+  }
   const end = endAnchor || locateEndAnchor(node as Anchor)
   while (true) {
     const next = _next(node)
     if (next && next !== end) {
-      remove(next, parentNode(node)!)
+      remove(next, parent)
     } else {
       break
     }
   }
+}
+
+function removeHydrationNode(node: Node, close: Node | null = null): void {
+  const parent = parentNode(node)
+  if (!parent) {
+    return
+  }
+
+  if (isComment(node, '[')) {
+    const end = locateEndAnchor(node)
+    removeFragmentNodes(node, end || undefined)
+    const endParent = end && parentNode(end)
+    if (end && end !== close && endParent) {
+      remove(end, endParent)
+    }
+  } else if (isComment(node, 'teleport start')) {
+    const end = locateEndAnchor(node, 'teleport start', 'teleport end')
+    removeFragmentNodes(node, end || undefined)
+    const endParent = end && parentNode(end)
+    if (end && end !== close && endParent) {
+      remove(end, endParent)
+    }
+  }
+
+  remove(node, parent)
+}
+
+export function cleanupHydrationTail(node: Node): void {
+  const container = node.parentElement
+  if (container) {
+    warnHydrationChildrenMismatch(container)
+  }
+  removeHydrationNode(node)
 }
 
 export function markHydrationAnchor<T extends Node>(node: T): T {
@@ -315,14 +377,9 @@ export function isHydrationAnchor(node: Node | null | undefined): boolean {
   return !!node && (node as Anchor).$vha === 1
 }
 
-function resolveHydrationTarget(node: Node, template: string): Node {
+function resolveHydrationTarget(node: Node): Node {
   while (true) {
     if (isHydrationAnchor(node)) {
-      const next = node.nextSibling
-      if (next && canUseAsHydrationTarget(next, template)) {
-        node = next
-        continue
-      }
       return node
     }
 
@@ -343,17 +400,60 @@ function resolveHydrationTarget(node: Node, template: string): Node {
   }
 }
 
-function canUseAsHydrationTarget(node: Node, template: string): boolean {
-  if (template[0] !== '<') {
-    return node.nodeType === 3
+function finalizeHydrationBoundary(close: Node | null): void {
+  let node = currentHydrationNode
+
+  // Once the hydration cursor has already reached `close`, this scope has no
+  // unclaimed SSR nodes left to trim. Single-root paths commonly end up here,
+  // so there is no children-count mismatch to report for this boundary.
+  if (!close || !node || node === close) {
+    return
   }
 
-  if (template.startsWith('<!')) {
-    return node.nodeType === 8
+  // This boundary only owns cleanup while the current cursor is still inside
+  // its SSR range. If nested hydration has already advanced past `close`, stop
+  // here so we don't delete sibling or parent-owned SSR nodes by mistake.
+  let cur: Node | null = node
+  let hasRemovableNode = false
+  while (cur && cur !== close) {
+    if (!isHydrationAnchor(cur)) {
+      hasRemovableNode = true
+    }
+    cur = locateNextNode(cur)
+  }
+  if (!cur) return
+  if (!hasRemovableNode) {
+    setCurrentHydrationNode(close)
+    return
   }
 
-  return (
-    node.nodeType === 1 &&
-    template.startsWith(`<${(node as Element).tagName.toLowerCase()}`)
-  )
+  warnHydrationChildrenMismatch((close as Node).parentElement)
+
+  while (node && node !== close) {
+    const next = locateNextNode(node)
+    if (!isHydrationAnchor(node)) {
+      removeHydrationNode(node, close)
+    }
+    node = next!
+  }
+
+  setCurrentHydrationNode(close)
+}
+
+function warnHydrationChildrenMismatch(container: Element | null): void {
+  if (container && !isMismatchAllowed(container, MismatchTypes.CHILDREN)) {
+    ;(__DEV__ || __FEATURE_PROD_HYDRATION_MISMATCH_DETAILS__) &&
+      warn(
+        `Hydration children mismatch on`,
+        container,
+        `\nServer rendered element contains more child nodes than client nodes.`,
+      )
+    logMismatchError()
+  }
+}
+
+export function enterHydrationBoundary(close: Node | null): () => void {
+  return () => {
+    finalizeHydrationBoundary(close)
+  }
 }

--- a/packages/runtime-vapor/src/dom/hydration.ts
+++ b/packages/runtime-vapor/src/dom/hydration.ts
@@ -112,16 +112,19 @@ export function enterHydration(node: Node): () => void {
 export let adoptTemplate: (node: Node, template: string) => Node | null
 export let locateHydrationNode: (consumeFragmentStart?: boolean) => void
 
-type Anchor = Comment & {
-  // reused hydration anchors must stay in place during mismatch recovery
+type Anchor = Node & {
+  // Runtime-created or reused hydration anchor that mismatch recovery and
+  // boundary cleanup must keep in place.
   $vha?: 1
 
-  // cached matching fragment end to avoid repeated traversal
-  // on nested fragments
+  // cached matching fragment end to avoid repeated traversal on nested
+  // comment fragments.
   $fe?: Anchor
 }
 
-export const isComment = (node: Node, data: string): node is Anchor =>
+type CommentAnchor = Comment & Anchor
+
+export const isComment = (node: Node, data: string): node is CommentAnchor =>
   node.nodeType === 8 && (node as Comment).data === data
 
 export function setCurrentHydrationNode(node: Node | null): void {
@@ -211,7 +214,7 @@ function locateHydrationNodeImpl(consumeFragmentStart = false) {
 }
 
 export function locateEndAnchor(
-  node: Anchor,
+  node: CommentAnchor,
   open = '[',
   close = ']',
 ): Node | null {
@@ -220,8 +223,8 @@ export function locateEndAnchor(
     return node.$fe
   }
 
-  const stack: Anchor[] = [node]
-  while ((node = _next(node) as Anchor) && stack.length > 0) {
+  const stack: CommentAnchor[] = [node]
+  while ((node = _next(node) as CommentAnchor) && stack.length > 0) {
     if (node.nodeType === 8) {
       if (node.data === open) {
         stack.push(node)
@@ -283,8 +286,11 @@ function handleMismatch(node: Node, template: string): Node {
     removeFragmentNodes(node)
   }
 
-  const container = parentNode(node)!
+  // Reused hydration anchors are structural boundaries, not replaceable
+  // content. Mismatch recovery inserts the new node before the anchor and
+  // keeps the anchor in place.
   const shouldPreserveAnchor = isHydrationAnchor(node)
+  const container = parentNode(node)!
   const next = shouldPreserveAnchor ? node : _next(node)
   if (!shouldPreserveAnchor) {
     remove(node, container)
@@ -299,6 +305,8 @@ function handleMismatch(node: Node, template: string): Node {
   const t = createElement('template') as HTMLTemplateElement
   t.innerHTML = template
   const newNode = _child(t.content).cloneNode(true) as Element
+  // only carry over existing children/attrs when the original node is itself
+  // an element (the legacy element-vs-element mismatch case).
   if (node.nodeType === 1) {
     newNode.innerHTML = (node as Element).innerHTML
     Array.from((node as Element).attributes).forEach(attr => {
@@ -324,7 +332,7 @@ export function removeFragmentNodes(node: Node, endAnchor?: Node): void {
   if (!parent) {
     return
   }
-  const end = endAnchor || locateEndAnchor(node as Anchor)
+  const end = endAnchor || locateEndAnchor(node as CommentAnchor)
   while (true) {
     const next = _next(node)
     if (next && next !== end) {
@@ -369,7 +377,7 @@ export function cleanupHydrationTail(node: Node): void {
 }
 
 export function markHydrationAnchor<T extends Node>(node: T): T {
-  ;(node as any).$vha = 1
+  ;(node as Anchor).$vha = 1
   return node
 }
 

--- a/packages/runtime-vapor/src/dom/hydration.ts
+++ b/packages/runtime-vapor/src/dom/hydration.ts
@@ -61,6 +61,7 @@ function performHydration<T>(
     ;(Comment.prototype as any).$fe = undefined
     ;(Node.prototype as any).$idx = undefined
     ;(Node.prototype as any).$llc = undefined
+    ;(Node.prototype as any).$vha = undefined
 
     isOptimized = true
   }
@@ -112,6 +113,9 @@ export let adoptTemplate: (node: Node, template: string) => Node | null
 export let locateHydrationNode: (consumeFragmentStart?: boolean) => void
 
 type Anchor = Comment & {
+  // reused hydration anchors must stay in place during mismatch recovery
+  $vha?: 1
+
   // cached matching fragment end to avoid repeated traversal
   // on nested fragments
   $fe?: Anchor
@@ -151,9 +155,7 @@ function adoptTemplateImpl(node: Node, template: string): Node | null {
       node.before((node = createTextNode()))
     }
 
-    while (node.nodeType === 8) {
-      node = node.nextSibling!
-    }
+    node = resolveHydrationTarget(node)
   }
 
   const type = node.nodeType
@@ -256,9 +258,12 @@ function handleMismatch(node: Node, template: string): Node {
     removeFragmentNodes(node)
   }
 
-  const next = _next(node)
   const container = parentNode(node)!
-  remove(node, container)
+  const shouldPreserveAnchor = isHydrationAnchor(node)
+  const next = shouldPreserveAnchor ? node : _next(node)
+  if (!shouldPreserveAnchor) {
+    remove(node, container)
+  }
 
   // fast path for text nodes
   if (template[0] !== '<') {
@@ -269,10 +274,12 @@ function handleMismatch(node: Node, template: string): Node {
   const t = createElement('template') as HTMLTemplateElement
   t.innerHTML = template
   const newNode = _child(t.content).cloneNode(true) as Element
-  newNode.innerHTML = (node as Element).innerHTML
-  Array.from((node as Element).attributes).forEach(attr => {
-    newNode.setAttribute(attr.name, attr.value)
-  })
+  if (node.nodeType === 1) {
+    newNode.innerHTML = (node as Element).innerHTML
+    Array.from((node as Element).attributes).forEach(attr => {
+      newNode.setAttribute(attr.name, attr.value)
+    })
+  }
   container.insertBefore(newNode, next)
   return newNode
 }
@@ -296,5 +303,33 @@ export function removeFragmentNodes(node: Node, endAnchor?: Node): void {
     } else {
       break
     }
+  }
+}
+
+export function markHydrationAnchor<T extends Node>(node: T): T {
+  ;(node as T & { $vha?: 1 }).$vha = 1
+  return node
+}
+
+function isHydrationAnchor(node: Node | null | undefined): boolean {
+  return !!node && (node as Node & { $vha?: 1 }).$vha === 1
+}
+
+function resolveHydrationTarget(node: Node): Node {
+  while (true) {
+    if (isHydrationAnchor(node)) {
+      return node
+    }
+
+    if (node.nodeType === 8) {
+      const next = node.nextSibling
+      if (!next) {
+        return node
+      }
+      node = next
+      continue
+    }
+
+    return node
   }
 }

--- a/packages/runtime-vapor/src/dom/hydration.ts
+++ b/packages/runtime-vapor/src/dom/hydration.ts
@@ -155,7 +155,7 @@ function adoptTemplateImpl(node: Node, template: string): Node | null {
       node.before((node = createTextNode()))
     }
 
-    node = resolveHydrationTarget(node)
+    node = resolveHydrationTarget(node, template)
   }
 
   const type = node.nodeType
@@ -307,29 +307,53 @@ export function removeFragmentNodes(node: Node, endAnchor?: Node): void {
 }
 
 export function markHydrationAnchor<T extends Node>(node: T): T {
-  ;(node as T & { $vha?: 1 }).$vha = 1
+  ;(node as any).$vha = 1
   return node
 }
 
-function isHydrationAnchor(node: Node | null | undefined): boolean {
-  return !!node && (node as Node & { $vha?: 1 }).$vha === 1
+export function isHydrationAnchor(node: Node | null | undefined): boolean {
+  return !!node && (node as Anchor).$vha === 1
 }
 
-function resolveHydrationTarget(node: Node): Node {
+function resolveHydrationTarget(node: Node, template: string): Node {
   while (true) {
     if (isHydrationAnchor(node)) {
+      const next = node.nextSibling
+      if (next && canUseAsHydrationTarget(next, template)) {
+        node = next
+        continue
+      }
       return node
     }
 
-    if (node.nodeType === 8) {
+    if (
+      node.nodeType === 8 &&
+      ((node as Comment).data === '[' ||
+        (node as Comment).data === ']' ||
+        (node as Comment).data === 'teleport start' ||
+        (node as Comment).data === 'teleport end')
+    ) {
       const next = node.nextSibling
-      if (!next) {
-        return node
-      }
+      if (!next) return node
       node = next
       continue
     }
 
     return node
   }
+}
+
+function canUseAsHydrationTarget(node: Node, template: string): boolean {
+  if (template[0] !== '<') {
+    return node.nodeType === 3
+  }
+
+  if (template.startsWith('<!')) {
+    return node.nodeType === 8
+  }
+
+  return (
+    node.nodeType === 1 &&
+    template.startsWith(`<${(node as Element).tagName.toLowerCase()}`)
+  )
 }

--- a/packages/runtime-vapor/src/dom/prop.ts
+++ b/packages/runtime-vapor/src/dom/prop.ts
@@ -346,14 +346,17 @@ export function setText(el: Text & { $txt?: string }, value: string): void {
       return
     }
 
-    ;(__DEV__ || __FEATURE_PROD_HYDRATION_MISMATCH_DETAILS__) &&
-      warn(
-        `Hydration text mismatch in`,
-        el.parentNode,
-        `\n  - rendered on server: ${JSON.stringify((el as Text).data)}` +
-          `\n  - expected on client: ${JSON.stringify(value)}`,
-      )
-    logMismatchError()
+    const parent = el.parentElement
+    if (parent && !isMismatchAllowed(parent, MismatchTypes.TEXT)) {
+      ;(__DEV__ || __FEATURE_PROD_HYDRATION_MISMATCH_DETAILS__) &&
+        warn(
+          `Hydration text mismatch in`,
+          el.parentNode,
+          `\n  - rendered on server: ${JSON.stringify((el as Text).data)}` +
+            `\n  - expected on client: ${JSON.stringify(value)}`,
+        )
+      logMismatchError()
+    }
   }
 
   if (el.$txt !== value) {

--- a/packages/runtime-vapor/src/fragment.ts
+++ b/packages/runtime-vapor/src/fragment.ts
@@ -499,8 +499,11 @@ export class DynamicFragment extends VaporFragment {
       let parentNode: Node | null
       let nextNode: Node | null
       if (forwardedSlot) {
-        parentNode = slotAnchor!.parentNode
-        nextNode = slotAnchor!.nextSibling
+        // Keep the forwarded slot close marker structural for parent cleanup,
+        // even though this fragment uses a runtime anchor after it.
+        const anchor = markHydrationAnchor(slotAnchor!)
+        parentNode = anchor.parentNode
+        nextNode = anchor.nextSibling
       } else {
         const node = findBlockNode(this.nodes)
         parentNode = node.parentNode
@@ -511,11 +514,13 @@ export class DynamicFragment extends VaporFragment {
       // Otherwise detached anchors could be observed too early by traversal
       // logic such as `findLastChild()`.
       queuePostFlushCb(() => {
+        const anchor =
+          nextNode && nextNode.parentNode === parentNode ? nextNode : null
         parentNode!.insertBefore(
           (this.anchor = markHydrationAnchor(
             __DEV__ ? createComment(this.anchorLabel!) : createTextNode(),
           )),
-          nextNode,
+          anchor,
         )
       })
     } finally {
@@ -566,6 +571,7 @@ export let currentEmptyFragment: DynamicFragment | null | undefined
 
 export class SlotFragment extends DynamicFragment {
   forwarded = false
+  deferredHydrationBoundary?: () => void
 
   constructor() {
     super(isHydrating || __DEV__ ? 'slot' : undefined, false, false)
@@ -579,6 +585,7 @@ export class SlotFragment extends DynamicFragment {
     let prevEndAnchor: Node | null = null
     let pushedEndAnchor = false
     let exitHydrationBoundary: (() => void) | undefined
+    let deferHydrationBoundary = false
     if (isHydrating) {
       locateHydrationNode()
       if (isComment(currentHydrationNode!, '[')) {
@@ -624,12 +631,24 @@ export class SlotFragment extends DynamicFragment {
       // once against the final block.
       if (isHydrating) {
         this.hydrate(render == null, true)
+        // Empty slots rendered while resolving an outer slot fallback can be
+        // filled by that fallback immediately after render() returns.
+        deferHydrationBoundary =
+          !!exitHydrationBoundary &&
+          currentEmptyFragment !== undefined &&
+          !isValidBlock(this.nodes)
       }
     } finally {
-      if (isHydrating && pushedEndAnchor) {
-        setCurrentSlotEndAnchor(prevEndAnchor)
+      if (isHydrating) {
+        if (pushedEndAnchor) {
+          setCurrentSlotEndAnchor(prevEndAnchor)
+        }
+        if (deferHydrationBoundary) {
+          this.deferredHydrationBoundary = exitHydrationBoundary
+        } else {
+          exitHydrationBoundary && exitHydrationBoundary()
+        }
       }
-      exitHydrationBoundary && exitHydrationBoundary()
     }
   }
 }
@@ -657,6 +676,15 @@ export function renderSlotFallback(
       frag.nodes[0] = [fallback() || []] as Block[]
     } else if (frag instanceof DynamicFragment) {
       frag.update(fallback)
+      if (isHydrating && frag instanceof SlotFragment) {
+        const deferredHydrationBoundary = frag.deferredHydrationBoundary
+        if (deferredHydrationBoundary) {
+          frag.deferredHydrationBoundary = undefined
+          // The fallback has now had a chance to hydrate the SSR nodes that
+          // originally belonged to the empty forwarded slot.
+          deferredHydrationBoundary()
+        }
+      }
     }
     return block
   }

--- a/packages/runtime-vapor/src/fragment.ts
+++ b/packages/runtime-vapor/src/fragment.ts
@@ -374,6 +374,22 @@ export class DynamicFragment extends VaporFragment {
       }
     }
 
+    // Reuse an attached SSR comment anchor for empty dynamic-component /
+    // async-component / keyed-fragment branches. Otherwise hydration would
+    // fall back to creating a detached runtime anchor and lose the sibling
+    // position needed for later same-tick inserts.
+    if (
+      this.anchorLabel &&
+      !isValidBlock(this.nodes) &&
+      currentHydrationNode &&
+      isReusableDynamicFragmentAnchor(currentHydrationNode, this.anchorLabel)
+    ) {
+      this.anchor = markHydrationAnchor(currentHydrationNode)
+      this.nodes = []
+      advanceHydrationNode(this.anchor)
+      return
+    }
+
     // Slot fallback can fall through an inner `v-if`. When the `if` resolves
     // to an invalid block and the fallback is selected, the `if` still needs
     // its own runtime anchor instead of reusing the parent slot's end anchor.
@@ -455,6 +471,19 @@ function setCurrentSlotEndAnchor(end: Node | null): Node | null {
   } finally {
     currentSlotEndAnchor = end
   }
+}
+
+function isReusableDynamicFragmentAnchor(
+  node: Node,
+  anchorLabel: string,
+): boolean {
+  return (
+    isComment(node, anchorLabel) ||
+    (isComment(node, '') &&
+      (anchorLabel === 'dynamic-component' ||
+        anchorLabel === 'async component' ||
+        anchorLabel === 'keyed'))
+  )
 }
 
 // Tracks slot fallback hydration that falls through an inner empty fragment,

--- a/packages/runtime-vapor/src/fragment.ts
+++ b/packages/runtime-vapor/src/fragment.ts
@@ -1,5 +1,9 @@
 import { EffectScope, type ShallowRef, setActiveSub } from '@vue/reactivity'
-import { createComment, createTextNode } from './dom/node'
+import {
+  createComment,
+  createTextNode,
+  parentNode as getParentNode,
+} from './dom/node'
 import {
   type Block,
   type BlockFn,
@@ -12,14 +16,11 @@ import {
 } from './block'
 import {
   type GenericComponentInstance,
-  MismatchTypes,
   type TransitionHooks,
   type VNode,
   currentInstance,
-  isMismatchAllowed,
   queuePostFlushCb,
   setCurrentInstance,
-  warn,
   warnExtraneousAttributes,
 } from '@vue/runtime-dom'
 import {
@@ -30,13 +31,15 @@ import {
 import type { NodeRef } from './apiTemplateRef'
 import {
   advanceHydrationNode,
+  cleanupHydrationTail,
   currentHydrationNode,
+  enterHydrationBoundary,
   isComment,
   isHydrating,
   locateEndAnchor,
+  locateHydrationBoundaryClose,
   locateHydrationNode,
   locateNextNode,
-  logMismatchError,
   markHydrationAnchor,
   setCurrentHydrationNode,
 } from './dom/hydration'
@@ -369,126 +372,158 @@ export class DynamicFragment extends VaporFragment {
     // re-enter `hydrate()` after its empty branch has already hydrated once.
     if (this.isAnchorPending) return
 
-    // reuse `<!---->` as anchor
-    // `<div v-if="false"></div>` -> `<!---->`
-    if (isEmpty) {
-      if (isComment(currentHydrationNode!, '')) {
-        this.anchor = markHydrationAnchor(currentHydrationNode!)
-        advanceHydrationNode(currentHydrationNode)
+    let advanceAfterRestore: Node | null = null
+    let exitHydrationBoundary: (() => void) | undefined
+
+    try {
+      // reuse `<!---->` as anchor
+      // `<div v-if="false"></div>` -> `<!---->`
+      if (isEmpty) {
+        if (isComment(currentHydrationNode!, '')) {
+          this.anchor = markHydrationAnchor(currentHydrationNode!)
+          advanceHydrationNode(currentHydrationNode)
+          return
+        }
+      }
+
+      // Reuse an existing SSR comment anchor for empty dynamic-component /
+      // async-component / keyed-fragment branches. Without this, hydration can
+      // end up creating a detached runtime anchor and lose the parent/sibling
+      // position needed for same-hydration branch flips.
+      if (
+        this.anchorLabel &&
+        !isValidBlock(this.nodes) &&
+        this.nodes instanceof Comment &&
+        isReusableDynamicFragmentAnchor(this.nodes, this.anchorLabel) &&
+        getParentNode(this.nodes)
+      ) {
+        this.anchor = markHydrationAnchor(this.nodes)
+        this.nodes = []
+        const needsCleanup = currentHydrationNode !== this.anchor
+        if (needsCleanup) {
+          exitHydrationBoundary = enterHydrationBoundary(this.anchor)
+          advanceAfterRestore = this.anchor
+        } else {
+          advanceHydrationNode(this.anchor)
+        }
         return
       }
-    }
 
-    if (
-      this.anchorLabel &&
-      !isValidBlock(this.nodes) &&
-      this.nodes instanceof Comment &&
-      this.nodes.parentNode &&
-      isReusableDynamicFragmentAnchor(this.nodes, this.anchorLabel)
-    ) {
-      this.anchor = markHydrationAnchor(this.nodes)
-      this.nodes = []
+      // Empty dynamic fragments can also start from a detached runtime comment
+      // (for example client null against non-empty SSR content). In that case
+      // derive the insertion point from the current hydration cursor rather
+      // than from the detached block node, and let boundary cleanup trim the
+      // SSR range before the next logical sibling.
       if (
-        currentHydrationNode &&
-        shouldCleanupHydrationNodesBeforeAnchor(
-          currentHydrationNode,
-          this.anchor,
-        )
+        this.anchorLabel &&
+        !isValidBlock(this.nodes) &&
+        this.nodes instanceof Comment &&
+        !getParentNode(this.nodes) &&
+        currentHydrationNode
       ) {
-        cleanupHydrationNodesBeforeAnchor(this.anchor)
+        const parentNode = getParentNode(currentHydrationNode)
+        const nextNode = locateNextNode(currentHydrationNode)
+        if (parentNode) {
+          this.nodes = []
+          if (nextNode) {
+            exitHydrationBoundary = enterHydrationBoundary(nextNode)
+          } else {
+            cleanupHydrationTail(currentHydrationNode)
+            setCurrentHydrationNode(null)
+          }
+          queuePostFlushCb(() => {
+            parentNode.insertBefore(
+              (this.anchor = markHydrationAnchor(
+                __DEV__ ? createComment(this.anchorLabel!) : createTextNode(),
+              )),
+              nextNode,
+            )
+          })
+          return
+        }
+      }
+
+      // Slot fallback can fall through an inner `v-if`. When the `if` resolves
+      // to an invalid block and the fallback is selected, the `if` still needs
+      // its own runtime anchor instead of reusing the parent slot's end anchor.
+      if (this.anchorLabel === 'if' && currentSlotEndAnchor) {
+        if (
+          currentEmptyFragment !== undefined &&
+          (!isValidBlock(this.nodes) || currentEmptyFragment === this)
+        ) {
+          const endAnchor = currentSlotEndAnchor
+          this.isAnchorPending = true
+          queuePostFlushCb(() =>
+            endAnchor.parentNode!.insertBefore(
+              (this.anchor = markHydrationAnchor(
+                __DEV__ ? createComment(this.anchorLabel!) : createTextNode(),
+              )),
+              endAnchor,
+            ),
+          )
+          return
+        }
+      }
+
+      const forwardedSlot = (this as any as SlotFragment).forwarded
+      const slotAnchor = isSlot ? currentSlotEndAnchor : null
+      // Reuse SSR `<!--]-->` as anchor.
+      // SSR wraps slots and multi-root `v-if` branches with `<!--[-->...<!--]-->`.
+      // Non-forwarded slots always own the closing `<!--]-->`, even when empty.
+      // Forwarded slots only own it when they rendered valid content.
+      if (
+        (isSlot && (!forwardedSlot || isValidBlock(this.nodes))) ||
+        (this.anchorLabel === 'if' &&
+          isArray(this.nodes) &&
+          this.nodes.length > 1)
+      ) {
+        const anchor = locateHydrationBoundaryClose(
+          slotAnchor || currentHydrationNode!,
+          slotAnchor || null,
+        )
+        if (isComment(anchor!, ']')) {
+          this.anchor = markHydrationAnchor(anchor)
+          exitHydrationBoundary = enterHydrationBoundary(anchor)
+          advanceHydrationNode(anchor)
+          return
+        } else if (__DEV__) {
+          throw new Error(
+            `Failed to locate ${this.anchorLabel} fragment anchor. this is likely a Vue internal bug.`,
+          )
+        }
+      }
+
+      // Otherwise, create a new anchor.
+      // This covers: empty forwarded slots, dynamic-component,
+      // async component, keyed fragment.
+      let parentNode: Node | null
+      let nextNode: Node | null
+      if (forwardedSlot) {
+        parentNode = slotAnchor!.parentNode
+        nextNode = slotAnchor!.nextSibling
       } else {
-        advanceHydrationNode(this.anchor)
+        const node = findBlockNode(this.nodes)
+        parentNode = node.parentNode
+        nextNode = node.nextNode
       }
-      return
-    }
 
-    // Reuse an attached SSR comment anchor for empty dynamic-component /
-    // async-component / keyed-fragment branches. Otherwise hydration would
-    // fall back to creating a detached runtime anchor and lose the sibling
-    // position needed for later same-tick inserts.
-    if (
-      this.anchorLabel &&
-      !isValidBlock(this.nodes) &&
-      currentHydrationNode &&
-      isReusableDynamicFragmentAnchor(currentHydrationNode, this.anchorLabel)
-    ) {
-      this.anchor = markHydrationAnchor(currentHydrationNode)
-      this.nodes = []
-      advanceHydrationNode(this.anchor)
-      return
-    }
-
-    // Slot fallback can fall through an inner `v-if`. When the `if` resolves
-    // to an invalid block and the fallback is selected, the `if` still needs
-    // its own runtime anchor instead of reusing the parent slot's end anchor.
-    if (this.anchorLabel === 'if' && currentSlotEndAnchor) {
-      if (
-        currentEmptyFragment !== undefined &&
-        (!isValidBlock(this.nodes) || currentEmptyFragment === this)
-      ) {
-        const endAnchor = currentSlotEndAnchor
-        this.isAnchorPending = true
-        queuePostFlushCb(() =>
-          endAnchor.parentNode!.insertBefore(
-            (this.anchor = markHydrationAnchor(
-              __DEV__ ? createComment(this.anchorLabel!) : createTextNode(),
-            )),
-            endAnchor,
-          ),
+      // Assign `this.anchor` only after the anchor is inserted.
+      // Otherwise detached anchors could be observed too early by traversal
+      // logic such as `findLastChild()`.
+      queuePostFlushCb(() => {
+        parentNode!.insertBefore(
+          (this.anchor = markHydrationAnchor(
+            __DEV__ ? createComment(this.anchorLabel!) : createTextNode(),
+          )),
+          nextNode,
         )
-        return
+      })
+    } finally {
+      exitHydrationBoundary && exitHydrationBoundary()
+      if (advanceAfterRestore && currentHydrationNode === advanceAfterRestore) {
+        advanceHydrationNode(advanceAfterRestore)
       }
     }
-
-    const forwardedSlot = (this as any as SlotFragment).forwarded
-    const slotAnchor = isSlot ? currentSlotEndAnchor : null
-    // Reuse SSR `<!--]-->` as anchor.
-    // SSR wraps slots and multi-root `v-if` branches with `<!--[-->...<!--]-->`.
-    // Non-forwarded slots always own the closing `<!--]-->`, even when empty.
-    // Forwarded slots only own it when they rendered valid content.
-    if (
-      (isSlot && (!forwardedSlot || isValidBlock(this.nodes))) ||
-      (this.anchorLabel === 'if' &&
-        isArray(this.nodes) &&
-        this.nodes.length > 1)
-    ) {
-      const anchor = slotAnchor || currentHydrationNode
-      if (isComment(anchor!, ']')) {
-        this.anchor = markHydrationAnchor(anchor)
-        advanceHydrationNode(anchor)
-        return
-      } else if (__DEV__) {
-        throw new Error(
-          `Failed to locate ${this.anchorLabel} fragment anchor. this is likely a Vue internal bug.`,
-        )
-      }
-    }
-
-    // Otherwise, create a new anchor.
-    // This covers: empty forwarded slots, dynamic-component,
-    // async component, keyed fragment.
-    let parentNode: Node | null
-    let nextNode: Node | null
-    if (forwardedSlot) {
-      parentNode = slotAnchor!.parentNode
-      nextNode = slotAnchor!.nextSibling
-    } else {
-      const node = findBlockNode(this.nodes)
-      parentNode = node.parentNode
-      nextNode = node.nextNode
-    }
-
-    // Assign `this.anchor` only after the anchor is inserted.
-    // Otherwise detached anchors could be observed too early by traversal
-    // logic such as `findLastChild()`.
-    queuePostFlushCb(() => {
-      parentNode!.insertBefore(
-        (this.anchor = markHydrationAnchor(
-          __DEV__ ? createComment(this.anchorLabel!) : createTextNode(),
-        )),
-        nextNode,
-      )
-    })
   }
 }
 
@@ -502,7 +537,7 @@ function setCurrentSlotEndAnchor(end: Node | null): Node | null {
 }
 
 function isReusableDynamicFragmentAnchor(
-  node: Node,
+  node: Comment,
   anchorLabel: string,
 ): boolean {
   return (
@@ -511,43 +546,6 @@ function isReusableDynamicFragmentAnchor(
       (anchorLabel === 'dynamic-component' ||
         anchorLabel === 'async component' ||
         anchorLabel === 'keyed'))
-  )
-}
-
-function cleanupHydrationNodesBeforeAnchor(anchor: Node): void {
-  let node = currentHydrationNode
-  const container = anchor.parentElement
-  if (container && !isMismatchAllowed(container, MismatchTypes.CHILDREN)) {
-    if (__DEV__ || __FEATURE_PROD_HYDRATION_MISMATCH_DETAILS__) {
-      warn(
-        `Hydration children mismatch on`,
-        container,
-        `\nServer rendered element contains more child nodes than client nodes.`,
-      )
-    }
-    logMismatchError()
-  }
-
-  while (node && node !== anchor) {
-    const next = locateNextNode(node)
-    const parent = node.parentNode
-    if (parent) {
-      remove(node, parent)
-    }
-    node = next
-  }
-
-  setCurrentHydrationNode(anchor)
-  advanceHydrationNode(anchor)
-}
-
-function shouldCleanupHydrationNodesBeforeAnchor(
-  node: Node,
-  anchor: Node,
-): boolean {
-  return !!(
-    node !== anchor &&
-    node.compareDocumentPosition(anchor) & Node.DOCUMENT_POSITION_FOLLOWING
   )
 }
 

--- a/packages/runtime-vapor/src/fragment.ts
+++ b/packages/runtime-vapor/src/fragment.ts
@@ -32,6 +32,7 @@ import {
   isHydrating,
   locateEndAnchor,
   locateHydrationNode,
+  markHydrationAnchor,
   setCurrentHydrationNode,
 } from './dom/hydration'
 import { isArray } from '@vue/shared'
@@ -239,6 +240,27 @@ export class DynamicFragment extends VaporFragment {
       }
     }
 
+    // A non-slot fragment can render empty first during hydration, then flip
+    // to a real branch before hydration exits (for example inside an async
+    // component slot). Re-point the cursor at the fragment-owned insertion
+    // anchor so the late branch inserts before that anchor instead of
+    // consuming trailing hydrated siblings or the enclosing slot boundary.
+    if (
+      isHydrating &&
+      render &&
+      this.anchorLabel !== 'slot' &&
+      !isValidBlock(this.nodes)
+    ) {
+      const anchor =
+        this.anchor ||
+        (currentHydrationNode === currentSlotEndAnchor
+          ? currentSlotEndAnchor
+          : null)
+      if (anchor) {
+        setCurrentHydrationNode(markHydrationAnchor(anchor))
+      }
+    }
+
     this.renderBranch(render, transition, parent, key)
     setActiveSub(prevSub)
 
@@ -346,7 +368,7 @@ export class DynamicFragment extends VaporFragment {
     // `<div v-if="false"></div>` -> `<!---->`
     if (isEmpty) {
       if (isComment(currentHydrationNode!, '')) {
-        this.anchor = currentHydrationNode
+        this.anchor = markHydrationAnchor(currentHydrationNode!)
         advanceHydrationNode(currentHydrationNode)
         return
       }
@@ -364,9 +386,9 @@ export class DynamicFragment extends VaporFragment {
         this.isAnchorPending = true
         queuePostFlushCb(() =>
           endAnchor.parentNode!.insertBefore(
-            (this.anchor = __DEV__
-              ? createComment(this.anchorLabel!)
-              : createTextNode()),
+            (this.anchor = markHydrationAnchor(
+              __DEV__ ? createComment(this.anchorLabel!) : createTextNode(),
+            )),
             endAnchor,
           ),
         )
@@ -388,7 +410,7 @@ export class DynamicFragment extends VaporFragment {
     ) {
       const anchor = slotAnchor || currentHydrationNode
       if (isComment(anchor!, ']')) {
-        this.anchor = anchor
+        this.anchor = markHydrationAnchor(anchor)
         advanceHydrationNode(anchor)
         return
       } else if (__DEV__) {
@@ -417,9 +439,9 @@ export class DynamicFragment extends VaporFragment {
     // logic such as `findLastChild()`.
     queuePostFlushCb(() => {
       parentNode!.insertBefore(
-        (this.anchor = __DEV__
-          ? createComment(this.anchorLabel!)
-          : createTextNode()),
+        (this.anchor = markHydrationAnchor(
+          __DEV__ ? createComment(this.anchorLabel!) : createTextNode(),
+        )),
         nextNode,
       )
     })

--- a/packages/runtime-vapor/src/fragment.ts
+++ b/packages/runtime-vapor/src/fragment.ts
@@ -12,11 +12,14 @@ import {
 } from './block'
 import {
   type GenericComponentInstance,
+  MismatchTypes,
   type TransitionHooks,
   type VNode,
   currentInstance,
+  isMismatchAllowed,
   queuePostFlushCb,
   setCurrentInstance,
+  warn,
   warnExtraneousAttributes,
 } from '@vue/runtime-dom'
 import {
@@ -32,6 +35,8 @@ import {
   isHydrating,
   locateEndAnchor,
   locateHydrationNode,
+  locateNextNode,
+  logMismatchError,
   markHydrationAnchor,
   setCurrentHydrationNode,
 } from './dom/hydration'
@@ -374,6 +379,29 @@ export class DynamicFragment extends VaporFragment {
       }
     }
 
+    if (
+      this.anchorLabel &&
+      !isValidBlock(this.nodes) &&
+      this.nodes instanceof Comment &&
+      this.nodes.parentNode &&
+      isReusableDynamicFragmentAnchor(this.nodes, this.anchorLabel)
+    ) {
+      this.anchor = markHydrationAnchor(this.nodes)
+      this.nodes = []
+      if (
+        currentHydrationNode &&
+        shouldCleanupHydrationNodesBeforeAnchor(
+          currentHydrationNode,
+          this.anchor,
+        )
+      ) {
+        cleanupHydrationNodesBeforeAnchor(this.anchor)
+      } else {
+        advanceHydrationNode(this.anchor)
+      }
+      return
+    }
+
     // Reuse an attached SSR comment anchor for empty dynamic-component /
     // async-component / keyed-fragment branches. Otherwise hydration would
     // fall back to creating a detached runtime anchor and lose the sibling
@@ -483,6 +511,43 @@ function isReusableDynamicFragmentAnchor(
       (anchorLabel === 'dynamic-component' ||
         anchorLabel === 'async component' ||
         anchorLabel === 'keyed'))
+  )
+}
+
+function cleanupHydrationNodesBeforeAnchor(anchor: Node): void {
+  let node = currentHydrationNode
+  const container = anchor.parentElement
+  if (container && !isMismatchAllowed(container, MismatchTypes.CHILDREN)) {
+    if (__DEV__ || __FEATURE_PROD_HYDRATION_MISMATCH_DETAILS__) {
+      warn(
+        `Hydration children mismatch on`,
+        container,
+        `\nServer rendered element contains more child nodes than client nodes.`,
+      )
+    }
+    logMismatchError()
+  }
+
+  while (node && node !== anchor) {
+    const next = locateNextNode(node)
+    const parent = node.parentNode
+    if (parent) {
+      remove(node, parent)
+    }
+    node = next
+  }
+
+  setCurrentHydrationNode(anchor)
+  advanceHydrationNode(anchor)
+}
+
+function shouldCleanupHydrationNodesBeforeAnchor(
+  node: Node,
+  anchor: Node,
+): boolean {
+  return !!(
+    node !== anchor &&
+    node.compareDocumentPosition(anchor) & Node.DOCUMENT_POSITION_FOLLOWING
   )
 }
 

--- a/packages/runtime-vapor/src/fragment.ts
+++ b/packages/runtime-vapor/src/fragment.ts
@@ -527,15 +527,6 @@ export class DynamicFragment extends VaporFragment {
   }
 }
 
-export let currentSlotEndAnchor: Node | null = null
-function setCurrentSlotEndAnchor(end: Node | null): Node | null {
-  try {
-    return currentSlotEndAnchor
-  } finally {
-    currentSlotEndAnchor = end
-  }
-}
-
 function isReusableDynamicFragmentAnchor(
   node: Comment,
   anchorLabel: string,
@@ -547,6 +538,15 @@ function isReusableDynamicFragmentAnchor(
         anchorLabel === 'async component' ||
         anchorLabel === 'keyed'))
   )
+}
+
+export let currentSlotEndAnchor: Node | null = null
+function setCurrentSlotEndAnchor(end: Node | null): Node | null {
+  try {
+    return currentSlotEndAnchor
+  } finally {
+    currentSlotEndAnchor = end
+  }
 }
 
 // Tracks slot fallback hydration that falls through an inner empty fragment,
@@ -578,6 +578,7 @@ export class SlotFragment extends DynamicFragment {
   ): void {
     let prevEndAnchor: Node | null = null
     let pushedEndAnchor = false
+    let exitHydrationBoundary: (() => void) | undefined
     if (isHydrating) {
       locateHydrationNode()
       if (isComment(currentHydrationNode!, '[')) {
@@ -585,6 +586,7 @@ export class SlotFragment extends DynamicFragment {
         setCurrentHydrationNode(currentHydrationNode.nextSibling)
         prevEndAnchor = setCurrentSlotEndAnchor(endAnchor)
         pushedEndAnchor = true
+        exitHydrationBoundary = enterHydrationBoundary(endAnchor)
       }
     }
 
@@ -627,6 +629,7 @@ export class SlotFragment extends DynamicFragment {
       if (isHydrating && pushedEndAnchor) {
         setCurrentSlotEndAnchor(prevEndAnchor)
       }
+      exitHydrationBoundary && exitHydrationBoundary()
     }
   }
 }

--- a/packages/vue/__tests__/e2e/hydrationStrategies.spec.ts
+++ b/packages/vue/__tests__/e2e/hydrationStrategies.spec.ts
@@ -114,18 +114,34 @@ describe('async component hydration strategies', () => {
       // patch
       await page().evaluate(() => (window.show.value = false))
       await click('button')
-      expect(await text('button')).toBe('1')
+      if (!vapor) {
+        expect(await text('button')).toBe('1')
+      } else {
+        // Vapor lazy hydration does not run the async component's setup until
+        // hydration actually starts, so there is no pre-hydration patch here.
+        expect(await text('button')).toBe('0')
+      }
 
       // resize
       await page().setViewport({ width: 400, height: 600 })
       await page().waitForFunction(() => window.isHydrated)
-      await assertHydrationSuccess('2')
+      if (!vapor) {
+        await assertHydrationSuccess('2')
+      } else {
+        await assertHydrationSuccess('1')
+      }
 
       expect(spy).toBeCalledTimes(0)
       currentPage.off('pageerror', spy)
-      expect(
-        warn.some(w => w.includes('Skipping lazy hydration for component')),
-      ).toBe(true)
+
+      // Vapor still enters lazy hydration after the strategy triggers, so it
+      // corrects the drift through mismatch recovery instead of taking the
+      // shared "Skipping lazy hydration..." short-circuit path.
+      if (!vapor) {
+        expect(
+          warn.some(w => w.includes('Skipping lazy hydration for component')),
+        ).toBe(true)
+      }
     })
 
     test('interaction', async () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server-side rendering hydration stability for v-for, Teleport, dynamic, and async components
  * Enhanced handling of edge cases during client-side hydration including empty targets and component state transitions
  * Fixed text mismatch detection during hydration

* **Tests**
  * Expanded hydration test coverage for complex component scenarios and edge cases
  * Updated test expectations for hydration behavior across framework modes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->