### PR TITLE
fix(package.json): set `homepage` to vuejs.org

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -93,7 +93,7 @@
   "bugs": {
     "url": "https://github.com/vuejs/core/issues"
   },
-  "homepage": "https://github.com/vuejs/core/tree/main/packages/vue#readme",
+  "homepage": "https://vuejs.org/",
   "dependencies": {
     "@vue/shared": "workspace:*",
     "@vue/compiler-dom": "workspace:*",


### PR DESCRIPTION
`repository.url` and `bugs.url` already point to the repo, as they should. But since Vue has a homepage (https://vuejs.org), point `homepage` to it.

Honestly, this is because I'm building a package likes leaderboard on https://npmx.dev and it's really sad that I can't pull the favicon from vue's published `package.json#homepage`, as this approach works for every other top-ten package 😁:

<img width="777" height="1108" alt="Screenshot 2026-04-10 at 18 41 48" src="https://github.com/user-attachments/assets/a0ffa486-e9d5-4512-8eb8-31afc956b9bd" />

(If vue were to make it onto the top-three podium, we wouldn't be able to render its `package.json#homepage` OG image either 😢.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated homepage link in package metadata to point to the official Vue website.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->