### PR TITLE
fix(compiler-sfc): resolve :deep inside :is/:where at start position

### DIFF
--- a/packages/compiler-sfc/__tests__/compileStyle.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileStyle.spec.ts
@@ -151,6 +151,22 @@ color: red
       ":where(.foo[data-v-test] .bar) { color: red;
       }"
     `)
+    // #14724 - :deep at the start of :is/:where
+    expect(compileScoped(`:is(:deep(.foo)) { color: red; }`))
+      .toMatchInlineSnapshot(`
+      ":is([data-v-test] .foo) { color: red;
+      }"
+    `)
+    expect(compileScoped(`:where(:deep(.foo)) { color: red; }`))
+      .toMatchInlineSnapshot(`
+      ":where([data-v-test] .foo) { color: red;
+      }"
+    `)
+    expect(compileScoped(`:is(:deep(.foo)) .bar { color: red; }`))
+      .toMatchInlineSnapshot(`
+      ":is([data-v-test] .foo) .bar { color: red;
+      }"
+    `)
     expect(compileScoped(`:deep(.foo) { color: red; .bar { color: red; } }`))
       .toMatchInlineSnapshot(`
       "[data-v-test] .foo { color: red;

--- a/packages/compiler-sfc/src/style/pluginScoped.ts
+++ b/packages/compiler-sfc/src/style/pluginScoped.ts
@@ -246,6 +246,26 @@ function rewriteSelector(
       ;(node as selectorParser.Pseudo).nodes.forEach(value =>
         rewriteSelector(id, rule, value, selectorRoot, deep, slotted),
       )
+      // If __deep was set inside :is/:where, we need to inject [id] at the start
+      // of the inner selector (before the first node), not after.
+      // :is(:deep(.foo)) should become :is([data-v-xxx] .foo)
+      if ((rule as any).__deep && (node as selectorParser.Pseudo).nodes.length) {
+        selector.insertBefore(
+          (node as selectorParser.Pseudo).nodes[0],
+          selectorParser.attribute({
+            attribute: slotted ? id + '-s' : id,
+            value: slotted ? id + '-s' : id,
+            raws: {},
+            quoteMark: `"`,
+          }),
+        )
+        selector.insertBefore(
+          (node as selectorParser.Pseudo).nodes[0],
+          selectorParser.combinator({
+            value: ' ',
+          }),
+        )
+      }
       shouldInject = false
     }
   }


### PR DESCRIPTION
## Description

Fix issue #14724 where `:deep` at the start of `:is`/`:where` selector was not being properly resolved.

### Before
```css
:is(:deep(.foo)) .bar { color: red; }
```
Was compiled to:
```css
:is(:deep(.foo)) .bar { color: red; } /* :deep not resolved! */
```

### After
```css
:is(:deep(.foo)) .bar { color: red; }
```
Is compiled to:
```css
:is([data-v-xxx] .foo) .bar { color: red; }
```

## Test cases added

- `:is(:deep(.foo))`
- `:where(:deep(.foo))`
- `:is(:deep(.foo)) .bar`

Fixes #14724

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed scoped CSS attribute injection when `:deep()` is used within `:is()` and `:where()` pseudo-classes, ensuring proper selector rewriting.

* **Tests**
  * Added test coverage for scoped CSS compilation of `:deep()` in `:is()` and `:where()` pseudo-selectors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->